### PR TITLE
fix: codesandbox icon render error

### DIFF
--- a/site/src/App.vue
+++ b/site/src/App.vue
@@ -1,3 +1,24 @@
 <template>
   <router-view />
 </template>
+
+<style lang="less">
+.action-online {
+  width: 32px;
+  height: 32px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  transition: all 0.2s linear;
+  cursor: pointer;
+  border-radius: 3px;
+  color: var(--text-secondary);
+
+  &:hover {
+    color: var(--text-primary);
+    background-color: var(--bg-color-demo-hover, rgb(243, 243, 243));
+  }
+}
+</style>

--- a/site/src/components/codesandbox/index.vue
+++ b/site/src/components/codesandbox/index.vue
@@ -93,24 +93,3 @@ export default {
   },
 };
 </script>
-
-<style lang="less">
-.action-online {
-  width: 32px;
-  height: 32px;
-  box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px;
-  transition: all 0.2s linear;
-  cursor: pointer;
-  border-radius: 3px;
-  color: var(--text-secondary);
-
-  &:hover {
-    color: var(--text-primary);
-    background-color: var(--bg-color-demo-hover, rgb(243, 243, 243));
-  }
-}
-</style>


### PR DESCRIPTION
`vite-plugin-vue2` v1.9.0 compile sfc error when use `Vue.component()` 