### PR TITLE
fix(timepicker): missing render under HH:mm:ss A format

### DIFF
--- a/src/time-picker/panel/index.tsx
+++ b/src/time-picker/panel/index.tsx
@@ -41,7 +41,7 @@ export default mixins(getConfigReceiverMixins<TimePickerPanelInstance, TimePicke
       return this.colValues.length > 1;
     },
     formatField() {
-      const match = this.format.match(/(a\s+|A\s+)?(h+|H+)?:?(m+)?:?(s+)?(\s+a|A)?/);
+      const match = this.format.match(/(a\s+|A\s+)?(h+|H+)?:?(m+)?:?(s+)?(\s+a|\s+A)?/);
       const [, startAChart, hour, minute, second, endAChart] = match;
       return {
         startAChart,


### PR DESCRIPTION
current status
![image](https://user-images.githubusercontent.com/26377630/146542802-4d4fb263-66bc-4c85-bfd5-07f127e003e9.png)

correct status
<img width="355" alt="WeChatWorkScreenshot_c94b401c-5fa1-482c-a96a-3549ed77392d" src="https://user-images.githubusercontent.com/26377630/146542721-0e0cccbf-4cba-414a-bcb8-678f233cda27.png">
