### PR TITLE
feat: remove workspaces to aviod npm version restrictions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "eslint-plugin-vue": "^8.1.1",
     "fs-extra": "^8.1.0",
     "glob": "^7.2.0",
+    "gray-matter": "^4.0.3",
     "husky": "^7.0.4",
     "hyphenate": "^0.2.4",
     "jest": "^26.0.0",
@@ -140,6 +141,7 @@
     "lint-staged": "^10.5.4",
     "mockdate": "^3.0.2",
     "postcss": "^8.3.11",
+    "prismjs": "^1.25.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.53.2",
     "rollup-plugin-analyzer": "^3.3.0",
@@ -153,11 +155,16 @@
     "rollup-plugin-vue": "^5.1.9",
     "tdesign-icons-view": "0.0.1",
     "tdesign-publish-cli": "^0.0.8",
+    "tdesign-site-components": "^0.5.26",
     "ts-jest": "^26.0.0",
     "typescript": "^4.4.4",
+    "vite": "^2.7.6",
+    "vite-plugin-tdoc": "^2.0.2",
+    "vite-plugin-vue2": "^1.9.0",
     "vue": "^2.6.14",
     "vue-class-component": "^7.2.3",
     "vue-jest": "^3.0.5",
+    "vue-router": "^3.5.3",
     "vue-server-renderer": "^2.6.14",
     "vue-template-compiler": "^2.6.14"
   },
@@ -181,9 +188,5 @@
   },
   "workspaces": [
     "site"
-  ],
-  "engines": {
-    "node": ">=16.0.0",
-    "npm": ">=8.0.0"
-  }
+  ]
 }

--- a/site/package.json
+++ b/site/package.json
@@ -5,5 +5,16 @@
     "build": "vite build",
     "preview": "vite preview",
     "build:preview": "vite build --mode preview"
+  },
+  "dependencies": {
+    "prismjs": "^1.25.0",
+    "tdesign-site-components": "~0.5.20",
+    "vue-router": "^3.5.3"
+  },
+  "devDependencies": {
+    "gray-matter": "^4.0.3",
+    "vite": "^2.7.0",
+    "vite-plugin-tdoc": "^2.0.1",
+    "vite-plugin-vue2": "^1.9.0"
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -5,16 +5,5 @@
     "build": "vite build",
     "preview": "vite preview",
     "build:preview": "vite build --mode preview"
-  },
-  "dependencies": {
-    "prismjs": "^1.25.0",
-    "tdesign-site-components": "~0.5.20",
-    "vue-router": "^3.5.3"
-  },
-  "devDependencies": {
-    "gray-matter": "^4.0.3",
-    "vite": "^2.7.0",
-    "vite-plugin-tdoc": "^2.0.1",
-    "vite-plugin-vue2": "^1.9.0"
   }
 }


### PR DESCRIPTION
本地开发工具由 `webpack` 改为 `vite` [commit](https://github.com/Tencent/tdesign-vue/commit/0a3a97f4099271ea3f96562ece23892f61d5d06e) 时，引入了 [npm worksapce](https://docs.npmjs.com/cli/v7/using-npm/workspaces) 特性依赖，要求开发环境为 npm >= 7.x，存在以下问题：
 - 对开发者不友好，需要升级本地 nodejs 版本到 16.x LTS 以上，或 `npm i -g npm` 全局升级 npm 包版本才能参与开发
 - 有可能影响到业务使用：有可能业务项目中启用了 [engine-strict](https://docs.npmjs.com/cli/v8/using-npm/config#engine-strict) 严格模式，导致在 `nodejs < 16.x LTS | npm < 7.x` 时安装包失败

为了保证体验，本次 pr 去掉 npm worksapce 特性依赖。


