### PR TITLE
fix(input): focus after clear value

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -193,6 +193,8 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     emitClear(e: MouseEvent) {
       emitEvent<Parameters<TdInputProps['onClear']>>(this, 'clear', { e });
       emitEvent<Parameters<TdInputProps['onChange']>>(this, 'change', '', { e });
+      this.focus();
+      this.emitFocus(e);
     },
     emitFocus(e: FocusEvent) {
       if (this.disabled) return;


### PR DESCRIPTION
resolved #90 

本地已经跑过lint和test了

- Input: 修复清除数据后没有聚焦的问题，[pr#91](https://github.com/Tencent/tdesign-vue/pull/91)，[issue#90](https://github.com/Tencent/tdesign-vue/issues/90)，[@clark-cui](https://github.com/clark-cui)