### PR TITLE
perf(affix.tsx): 获取当前可视的高度containerHeight用三目运算符

### DIFF
--- a/src/affix/affix.tsx
+++ b/src/affix/affix.tsx
@@ -60,12 +60,8 @@ export default (Vue as VueConstructor<Affix>).extend({
     },
     calcInitValue() {
       const { scrollContainer } = this;
-      let containerHeight = 0; // 获取当前可视的高度
-      if (scrollContainer instanceof Window) {
-        containerHeight = scrollContainer.innerHeight;
-      } else {
-        containerHeight = scrollContainer.clientHeight;
-      }
+      // 获取当前可视的高度
+      const containerHeight = scrollContainer[scrollContainer instanceof Window ? 'innerHeight' : 'clientHeight'];
       // 需要减掉当前节点的高度，对比的高度应该从 border-top 比对开始
       this.containerHeight = containerHeight - this.$el.clientHeight;
       // 被包裹的子节点宽高


### PR DESCRIPTION

- Affix：calcInitValue方法中获取当前可视的高度逻辑冗余 处理问题或特性描述 [@kenny](https://github.com/868618)

--------

**brefore**

  let containerHeight = 0; // 获取当前可视的高度
  if (scrollContainer instanceof Window) {
    containerHeight = scrollContainer.innerHeight;
  } else {
    containerHeight = scrollContainer.clientHeight;
  }


**after**

  const containerHeight = scrollContainer[scrollContainer instanceof Window ? 'innerHeight' : 'clientHeight'];
