### PR TITLE
fix(table): 修复使用firstFullRow和lastFullRow属性无效的问题。

### DIFF
--- a/src/table/base-table/index.tsx
+++ b/src/table/base-table/index.tsx
@@ -172,6 +172,7 @@ export default mixins(getConfigReceiverMixins<Vue, TableConfig>('table')).extend
           selectedRowKeys: this.selectedRowKeys,
           rowspanAndColspan: this.rowspanAndColspan,
           firstFullRow: this.firstFullRow,
+          lastFullRow: this.lastFullRow,
         },
         scopedSlots,
         on: {

--- a/src/table/base-table/table-body.tsx
+++ b/src/table/base-table/table-body.tsx
@@ -18,6 +18,7 @@ export default Vue.extend({
     rowKey: baseTableProps.rowKey,
     rowspanAndColspan: baseTableProps.rowspanAndColspan,
     firstFullRow: baseTableProps.firstFullRow,
+    lastFullRow: baseTableProps.lastFullRow,
     onRowHover: baseTableProps.onRowHover,
     onRowMouseup: baseTableProps.onRowMouseup,
     onRowMousedown: baseTableProps.onRowMousedown,

--- a/src/table/primary-table/index.tsx
+++ b/src/table/primary-table/index.tsx
@@ -91,7 +91,7 @@ export default mixins(expand, select, sort, rowDraggable, filter, showColumns, a
           dragging: this.dragging,
         },
         // this.hasFilterCondition is from mixins/filter.tsx
-        firstFullRow: this.hasFilterCondition ? this.renderFirstFilterRow : undefined,
+        firstFullRow: this.hasFilterCondition ? this.renderFirstFilterRow : this.firstFullRow,
         empty: this.empty,
       },
       scopedSlots,


### PR DESCRIPTION
修复使用firstFullRow和lastFullRow属性无效的问题。这两个属性在组件传递过程中丢失了，导致最终使用这两个属性的渲染函数拿到的是null

fix #113

- Table: 修复使用firstFullRow和lastFullRow属性无效的问题，[pr#124](https://github.com/Tencent/tdesign-vue/pull/124)，[@xiecz123](https://github.com/xiecz123)
