### PR TITLE
fix: 兼容IE，构建后的组件列表存在__proto__属性，Object.keys在IE浏览器下会将__proto__属性也输出，从而导致代码在IE浏览器下报错

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@ import * as components from './components';
 
 function install(Vue: VueConstructor, config?: object) {
   Object.keys(components).forEach((key) => {
-    /plugin/i.test(key)
-      ? Vue.use(components[key])
-      : Vue.use(components[key], config);
+    if (components[key]) {
+      /plugin/i.test(key) ? Vue.use(components[key]) : Vue.use(components[key], config);
+    }
   });
 }
 


### PR DESCRIPTION
兼容IE，打包构建后的组件列表存在__proto__属性且为null(es/index.js)，Object.keys在IE浏览器下会将__proto__属性也输出，从而导致代码在IE浏览器下报错

![IE浏览器下报错](https://user-images.githubusercontent.com/11691667/147728415-e2977f85-e6e3-40c2-a0df-0bb1e2b7fe41.png)

![对象在IE浏览器下输出__proto__属性](https://user-images.githubusercontent.com/11691667/147728401-aa19ff62-a1e0-4254-840c-c82889e867c3.png)
