### PR TITLE
fix(select): 修复 select 组件带 filterable 属性时点两下才能关闭的问题

### DIFF
--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -5,7 +5,7 @@ import get from 'lodash/get';
 import set from 'lodash/set';
 import { ChevronDownIcon as TIconChevronDown, CloseCircleFilledIcon as TIconClose } from 'tdesign-icons-vue';
 import TLoading from '../loading';
-import Popup, { PopupProps } from '../popup';
+import Popup, { PopupProps, PopupVisibleChangeContext } from '../popup';
 import mixins from '../utils/mixins';
 import getConfigReceiverMixins, { SelectConfig } from '../config-provider/config-receiver';
 import { renderTNodeJSX } from '../utils/render-tnode';
@@ -318,9 +318,9 @@ export default mixins(getConfigReceiverMixins<Vue, SelectConfig>('select')).exte
       }
       return false;
     },
-    visibleChange(val: boolean) {
+    visibleChange(val: boolean, context: PopupVisibleChangeContext) {
       emitEvent<Parameters<TdSelectProps['onVisibleChange']>>(this, 'visible-change', val);
-      if (this.focusing && !val) {
+      if (this.focusing && !val && context.trigger !== 'document') {
         this.visible = true;
         return;
       }


### PR DESCRIPTION

Select 组件：Fixes #128 ，[palmcivet](https://github.com/palmcivet)

--------

**brefore**

`Select` 组件展开选项列表后，点击 选项 和 输入框的空白部分 应保持展开状态，点击 已输入部分 和 外部区域 应收起，而实际是在点击外部区域时，先触发 `visible-change` 再触发 `blur`，在判断时 `focusing` 仍为 `true`，导致点两次才关闭

**after**

通过 `Popup` 的 `visible-change` 事件拿到 `trigger`，来判断触发对象，是 `document` 则直接关闭选项列表
