### PR TITLE
Fix table filter can not show empty data element

### DIFF
--- a/examples/drawer/demos/no-mask.vue
+++ b/examples/drawer/demos/no-mask.vue
@@ -1,6 +1,13 @@
 <template>
   <div>
-    <t-drawer :visible="visible" @close="handleClose" :showOverlay="false" :onConfirm="handleClose" header="抽屉标题">
+    <t-drawer
+      :visible="visible"
+      :showOverlay="false"
+      :onConfirm="handleClose"
+      :preventScrollThrough="false"
+      header="抽屉标题"
+      @close="handleClose"
+    >
       <p>抽屉的内容</p>
     </t-drawer>
 

--- a/examples/table/demos/async-loading.vue
+++ b/examples/table/demos/async-loading.vue
@@ -81,14 +81,12 @@ export default {
   },
   computed: {
     loadingNode() {
-      return this.asyncLoading === 'loading-custom'
-        ? this.customLoadingNode
-        : this.asyncLoading;
+      return this.asyncLoading === 'loading-custom' ? this.customLoadingNode : this.asyncLoading;
     },
   },
   methods: {
     customLoadingNode() {
-      return <div class='t-table--loading-async'>这是自定义加载状态和内容</div>;
+      return <div class="t-table__async-loading">这是自定义加载状态和内容</div>;
     },
     onAsyncLoadingClick({ status }) {
       if (status === 'load-more') {

--- a/examples/table/table.md
+++ b/examples/table/table.md
@@ -10,7 +10,6 @@ columns | Array | [] | 列配置，泛型 T 指表格数据类型。TS 类型：
 data | Array | [] | 数据源，泛型 T 指表格数据类型。TS 类型：`Array<T>` | N
 disableDataSort | Boolean | false | 是否禁用本地数据排序。当 `data` 数据长度超过分页大小时，会自动进行本地数据排序。如果 `disabledDataSort` 设置为 true，则无论何时，都不会进行本地排序 | N
 empty | String / Slot / Function | '' | 空表格呈现样式。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
-expandedRow | String / Slot / Function | - | 展开行内容，可自定义，泛型 T 指表格数据类型。TS 类型：`string | TNode<{ row: T; index: number }>`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 firstFullRow | String / Slot / Function | - | 首行内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 height | String / Number | 'auto' | 表格高度，超出后会出现滚动条。示例：100,  '30%',  '300px'。值为数字类型，会自动加上单位 px | N
 hover | Boolean | false | 是否显示鼠标悬浮状态 | N
@@ -75,7 +74,7 @@ width | String / Number | - | 列宽 | N
 -- | -- | -- | -- | --
 asyncLoading | String / Slot / Function | - | 异步加载状态。值为 `loading` 显示默认文字 “正在加载中，请稍后”，值为 `loading-more` 显示“点击加载更多”，值为其他，表示完全自定义异步加载区域内容。TS 类型：`'loading' | 'load-more' | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 columns | Array | [] | 列配置，泛型 T 指表格数据类型。TS 类型：`Array<PrimaryTableCol<T>>` | N
-dragSort | Boolean | false |【开发中】是否开始拖拽排序，会显示拖拽图标 | N
+dragSort | Boolean | false | 是否开始拖拽排序，会显示拖拽图标 | N
 expandedRow | String / Slot / Function | - | 展开行内容，泛型 T 指表格数据类型。TS 类型：`TNode<{ row: T; index: number }>`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 expandedRowKeys | Array | [] | 展开行。支持语法糖。TS 类型：`Array<string | number>` | N
 defaultExpandedRowKeys | Array | [] | 展开行。非受控属性。TS 类型：`Array<string | number>` | N
@@ -89,7 +88,7 @@ multipleSort | Boolean | false | 是否支持多列排序 | N
 selectedRowKeys | Array | - | 选中的行，控制属性。支持语法糖。TS 类型：`Array<string | number>` | N
 defaultSelectedRowKeys | Array | - | 选中的行，控制属性。非受控属性。TS 类型：`Array<string | number>` | N
 showColumnController | Boolean | false | 【开发中】是否显示 自定义显示列控制器 | N
-showDragCol | Boolean | false | 【开发中】是否显示为通过拖拽图标进行排序 | N
+showDragCol | Boolean | false | 【讨论中-待定】是否显示为通过拖拽图标进行排序 | N
 sort | Object / Array | - | 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序。当 `data` 数据长度超过分页大小时，会自动对本地数据 `data` 进行排序，如果不希望对于 `data` 进行排序，可以设置 `disableDatasort = true`。支持语法糖。TS 类型：`TableSort`。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 defaultSort | Object / Array | - | 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序。当 `data` 数据长度超过分页大小时，会自动对本地数据 `data` 进行排序，如果不希望对于 `data` 进行排序，可以设置 `disableDatasort = true`。非受控属性。TS 类型：`TableSort`。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 sortOnRowDraggable | Boolean | false | 允许表格行拖拽时排序 | N
@@ -129,7 +128,7 @@ render | Function | - | 自定义表头或单元格，泛型 T 指表格数据�
 sorter | Boolean / Function | false | 该列是否支持排序。值为 true 表示该列支持排序；值类型为函数，表示对本地数据 `data` 进行排序。泛型 T 指表格数据类型。TS 类型：`boolean | SorterFun<T>`。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 sortType | String | all | 当前列支持排序的方式，desc 表示当前列只能进行降序排列；asc 表示当前列只能进行升序排列；all 表示当前列既可升序排列，又可以降序排列。可选项：desc/asc/all。TS 类型：`SortType`。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 title | String / Function | - | 自定义表头渲染。值类型为 Function 表示以函数形式渲染表头。值类型为 string 表示使用插槽渲染，插槽名称为 title 的值。优先级高于 render。TS 类型：`string | TNode<{ col: PrimaryTableCol; colIndex: number }>`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
-type | String | single | 行选中有两种模式：单选和多选。可选项：single/multiple | N
+type | String | single | 行选中有两种模式：单选和多选。`colKey` 值为 `row-select` 时，表示当前列选中项， `type=single/multiple` 有效。可选项：single/multiple | N
 `Omit<BaseTableCol, 'cell' | 'title' | 'render'>` | - | - | 继承 `Omit<BaseTableCol, 'cell' | 'title' | 'render'>` 中的全部 API | N
 
 ### EnhancedTable Props

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -87,12 +87,8 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DrawerConfig>('d
       immediate: true,
     },
     visible: {
-      handler(value) {
-        if (value && !this.showInAttachedElement) {
-          this.preventScrollThrough && addClass(document.body, lockClass);
-        } else {
-          this.preventScrollThrough && removeClass(document.body, lockClass);
-        }
+      handler(val) {
+        this.handleScrollThrough(val);
       },
       immediate: true,
     },
@@ -100,6 +96,10 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DrawerConfig>('d
 
   updated() {
     this.updatePushMode();
+  },
+
+  mounted() {
+    this.handleScrollThrough(this.visible);
   },
 
   render() {
@@ -132,6 +132,14 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DrawerConfig>('d
   },
 
   methods: {
+    handleScrollThrough(visible: boolean) {
+      if (!document || !document.body) return;
+      if (visible && !this.showInAttachedElement) {
+        this.preventScrollThrough && addClass(document.body, lockClass);
+      } else {
+        this.preventScrollThrough && removeClass(document.body, lockClass);
+      }
+    },
     handlePushMode() {
       if (this.mode !== 'push') return;
       this.$nextTick(() => {

--- a/src/drawer/drawer.tsx
+++ b/src/drawer/drawer.tsx
@@ -90,7 +90,6 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DrawerConfig>('d
       handler(val) {
         this.handleScrollThrough(val);
       },
-      immediate: true,
     },
   },
 
@@ -133,7 +132,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DrawerConfig>('d
 
   methods: {
     handleScrollThrough(visible: boolean) {
-      if (!document || !document.body) return;
+      if (!document || !document.body || !this.preventScrollThrough) return;
       if (visible && !this.showInAttachedElement) {
         this.preventScrollThrough && addClass(document.body, lockClass);
       } else {

--- a/src/table/base-table-props.ts
+++ b/src/table/base-table-props.ts
@@ -2,7 +2,7 @@
 
 /**
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
- * updated at 2021-12-25 11:57:19
+ * updated at 2022-01-10 09:31:10
  * */
 
 import { TdBaseTableProps } from '../table/type';
@@ -27,10 +27,6 @@ export default {
   empty: {
     type: [String, Function] as PropType<TdBaseTableProps['empty']>,
     default: '',
-  },
-  /** 展开行内容，可自定义，泛型 T 指表格数据类型 */
-  expandedRow: {
-    type: [String, Function] as PropType<TdBaseTableProps['expandedRow']>,
   },
   /** 首行内容 */
   firstFullRow: {

--- a/src/table/base-table/index.tsx
+++ b/src/table/base-table/index.tsx
@@ -36,9 +36,7 @@ export default mixins(getConfigReceiverMixins<Vue, TableConfig>('table')).extend
     provider: {
       type: Object,
       default() {
-        return {
-          renderRows(): void {},
-        };
+        return {};
       },
     },
   },

--- a/src/table/base-table/table-body.tsx
+++ b/src/table/base-table/table-body.tsx
@@ -130,12 +130,12 @@ export default Vue.extend({
     },
 
     renderFullRow(type: 'firstFullRow' | 'lastFullRow') {
-      const firstFullRowNode = renderTNodeJSX(this, type);
-      if (firstFullRowNode) {
+      const fullRowNode = renderTNodeJSX(this, type);
+      if (fullRowNode) {
         return (
           <tr>
             <td colspan={this.columns.length} class={`${prefix}-table__row--full`}>
-              {firstFullRowNode}
+              {fullRowNode}
             </td>
           </tr>
         );

--- a/src/table/base-table/table-body.tsx
+++ b/src/table/base-table/table-body.tsx
@@ -209,6 +209,9 @@ export default Vue.extend({
         rowVnode = <TableRow rowKey={this.rowKey} {...props} />;
         // 按行渲染
         body.push(rowVnode);
+        // 渲染展开行
+        const expandedRow = this.provider.renderExpandedRow?.({ row, index });
+        expandedRow && (body = body.concat(expandedRow));
       });
       const firstRow = this.renderFullRow('first-full-row');
       if (firstRow) {
@@ -224,7 +227,7 @@ export default Vue.extend({
 
   render() {
     if (this.provider.sortOnRowDraggable) {
-      const className = `${prefix}-table__body ${this.provider.dragging ? 'dragging' : ''}`;
+      const className = `${prefix}-table__body ${this.provider.dragging ? `${prefix}-table__body--dragging` : ''}`;
       return (
         <transition-group class={className} tag="tbody">
           {this.renderBody()}

--- a/src/table/base-table/table-body.tsx
+++ b/src/table/base-table/table-body.tsx
@@ -1,5 +1,6 @@
 import Vue, { VNode } from 'vue';
 import get from 'lodash/get';
+import camelCase from 'lodash/camelCase';
 import { emitEvent } from '../../utils/event';
 import { prefix } from '../../config';
 import baseTableProps from '../base-table-props';
@@ -28,9 +29,7 @@ export default Vue.extend({
     provider: {
       type: Object,
       default() {
-        return {
-          renderRows(): void {},
-        };
+        return {};
       },
     },
     current: {
@@ -129,12 +128,12 @@ export default Vue.extend({
       return props;
     },
 
-    renderFullRow(type: 'firstFullRow' | 'lastFullRow') {
-      const fullRowNode = renderTNodeJSX(this, type);
+    renderFullRow(type: 'first-full-row' | 'last-full-row') {
+      const fullRowNode = renderTNodeJSX(this, camelCase(type));
       if (fullRowNode) {
         return (
           <tr>
-            <td colspan={this.columns.length} class={`${prefix}-table__row--full`}>
+            <td colspan={this.columns.length} class={`${prefix}-table__row--full ${prefix}-table__row-${type}`}>
               {fullRowNode}
             </td>
           </tr>
@@ -148,7 +147,6 @@ export default Vue.extend({
         data,
         rowClassName,
         rowKey,
-        provider,
         $scopedSlots: scopedSlots,
         rowspanAndColspan,
         selectedRowKeys,
@@ -211,19 +209,12 @@ export default Vue.extend({
         rowVnode = <TableRow rowKey={this.rowKey} {...props} />;
         // 按行渲染
         body.push(rowVnode);
-
-        provider.renderRows({
-          rows: body,
-          row,
-          rowIndex: index,
-          columns: this.columns,
-        });
       });
-      const firstRow = this.renderFullRow('firstFullRow');
+      const firstRow = this.renderFullRow('first-full-row');
       if (firstRow) {
         body = [firstRow].concat(body);
       }
-      const lastRow = this.renderFullRow('lastFullRow');
+      const lastRow = this.renderFullRow('last-full-row');
       if (lastRow) {
         body = body.concat(lastRow);
       }

--- a/src/table/enhanced-table-props.ts
+++ b/src/table/enhanced-table-props.ts
@@ -2,7 +2,7 @@
 
 /**
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
- * updated at 2021-12-23 13:19:48
+ * updated at 2022-01-10 09:31:10
  * */
 
 import { TdEnhancedTableProps } from '../table/type';

--- a/src/table/primary-table-props.ts
+++ b/src/table/primary-table-props.ts
@@ -2,7 +2,7 @@
 
 /**
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
- * updated at 2021-12-25 11:57:19
+ * updated at 2022-01-10 09:31:10
  * */
 
 import { TdPrimaryTableProps } from '../table/type';
@@ -69,7 +69,7 @@ export default {
   },
   /** 【开发中】是否显示 自定义显示列控制器 */
   showColumnController: Boolean,
-  /** 【开发中】是否显示为通过拖拽图标进行排序 */
+  /** 【讨论中-待定】是否显示为通过拖拽图标进行排序 */
   showDragCol: Boolean,
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序。当 `data` 数据长度超过分页大小时，会自动对本地数据 `data` 进行排序，如果不希望对于 `data` 进行排序，可以设置 `disableDatasort = true` */
   sort: {

--- a/src/table/primary-table/index.tsx
+++ b/src/table/primary-table/index.tsx
@@ -97,10 +97,6 @@ export default mixins(expand, select, sort, rowDraggable, filter, showColumns, a
       scopedSlots,
       on,
     };
-    // 存在过滤条件，查询结果为空时，不显示空数据节点，有过滤结果行即可
-    if (this.hasFilterCondition) {
-      baseTableProps.props.empty = null;
-    }
     // TODO: 可使用插槽 `topContent` 自定义显示列
     return <BaseTable {...baseTableProps} />;
   },

--- a/src/table/primary-table/index.tsx
+++ b/src/table/primary-table/index.tsx
@@ -85,9 +85,9 @@ export default mixins(expand, select, sort, rowDraggable, filter, showColumns, a
     const baseTableProps = {
       props: {
         ...$props,
-        data: this.data,
         columns: rehandleColumns,
         provider: {
+          renderExpandedRow: this.expandedRow ?? this.$scopedSlots.expandedRow ? this.renderExpandedRow : undefined,
           sortOnRowDraggable: this.sortOnRowDraggable,
           dragging: this.dragging,
         },

--- a/src/table/primary-table/index.tsx
+++ b/src/table/primary-table/index.tsx
@@ -13,9 +13,9 @@ import rowDraggable from './mixins/row-draggable';
 import filter from './mixins/filter';
 import showColumns from './mixins/show-columns';
 import asyncLoadingMixin from './mixins/async-loading';
-import { RenderExpandRow } from '../util/interface';
 import { PageInfo } from '../../pagination/type';
 import { emitEvent } from '../../utils/event';
+import { renderTNodeJSX } from '../../utils/render-tnode';
 
 type PageChangeContext = Parameters<TdBaseTableProps['onPageChange']>;
 type ChangeContext = Parameters<TdPrimaryTableProps['onChange']>;
@@ -27,9 +27,6 @@ export default mixins(expand, select, sort, rowDraggable, filter, showColumns, a
     ...primaryTableProps,
   },
   computed: {
-    rehandleData(): Array<DataType> {
-      return this.asyncLoadingHandler([...this.data]);
-    },
     rehandleColumns(): Array<PrimaryTableCol> {
       let columns = this.columns.map((col) => ({ ...col }));
       columns = this.getShowColumns([...this.columns]);
@@ -46,14 +43,19 @@ export default mixins(expand, select, sort, rowDraggable, filter, showColumns, a
     }
   },
   methods: {
-    // 提供给 BaseTable 添加渲染 Rows 方法
-    renderRows(params: RenderExpandRow): void {
-      const { row, rowIndex, rows } = params;
-      if (row.colKey === 'async-loading-row') {
-        rows.splice(rowIndex, 1, this.renderAsyncLoadingRow());
-        return;
-      }
-      this.renderExpandedRow(params);
+    // 最后一行，通行数据，可能是异步加载状态，可能是其他
+    renderLastFullRow() {
+      const lastFullRow = renderTNodeJSX(this, 'lastFullRow');
+      const asyncLoadingNode = this.renderAsyncLoadingRow();
+      const nodes = [lastFullRow, asyncLoadingNode].filter((v) => ![undefined, null, false].includes(v));
+      if (nodes.length === 0) return null;
+      if (nodes.length === 1) return nodes[0];
+      return (
+        <div>
+          {nodes[0]}
+          {nodes[1]}
+        </div>
+      );
     },
   },
   render() {
@@ -83,15 +85,15 @@ export default mixins(expand, select, sort, rowDraggable, filter, showColumns, a
     const baseTableProps = {
       props: {
         ...$props,
-        data: this.rehandleData,
+        data: this.data,
         columns: rehandleColumns,
         provider: {
-          renderRows: this.renderRows,
           sortOnRowDraggable: this.sortOnRowDraggable,
           dragging: this.dragging,
         },
         // this.hasFilterCondition is from mixins/filter.tsx
         firstFullRow: this.hasFilterCondition ? this.renderFirstFilterRow : this.firstFullRow,
+        lastFullRow: this.renderLastFullRow,
         empty: this.empty,
       },
       scopedSlots,

--- a/src/table/primary-table/mixins/async-loading.tsx
+++ b/src/table/primary-table/mixins/async-loading.tsx
@@ -1,14 +1,13 @@
 import Vue, { VNode } from 'vue';
-import { CreateElement } from 'vue/types/umd';
+import isString from 'lodash/isString';
 import primaryTableProps from '../../primary-table-props';
-import TableRow from '../../base-table/table-row';
 import Loading from '../../../loading';
 import { prefix } from '../../../config';
 import { STATUS_CLASSNAMES } from '../../../utils/classnames';
-// import GradientIcon from '../../../loading/icon/gradient';
 import { emitEvent } from '../../../utils/event';
 import { TdPrimaryTableProps } from '../../type';
 import { ClassName } from '../../../common';
+import { renderTNodeJSX } from '../../../utils/render-tnode';
 
 type AsyncLoadingClickParams = Parameters<TdPrimaryTableProps['onAsyncLoadingClick']>;
 
@@ -18,7 +17,6 @@ export default Vue.extend({
   name: `${prefix}-primary-table-async-loading`,
 
   props: {
-    columns: primaryTableProps.columns,
     asyncLoading: primaryTableProps.asyncLoading,
   },
 
@@ -41,46 +39,32 @@ export default Vue.extend({
   },
 
   methods: {
-    // 异步加载 pullDownLoading 新增一条数据
-    asyncLoadingHandler(data: TdPrimaryTableProps['data']): TdPrimaryTableProps['data'] {
-      if (this.asyncLoading || typeof this.$scopedSlots.asyncLoading === 'function') {
-        return data.concat({ colKey: ASYNC_LOADING_ROW });
-      }
-      return data;
-    },
     onLoadClick() {
       if (typeof this.asyncLoading !== 'string') return;
       emitEvent<AsyncLoadingClickParams>(this, 'async-loading-click', { status: this.asyncLoading });
     },
     renderAsyncLoadingRow(): VNode {
-      const { asyncLoading } = this;
-      const columns = [
-        {
-          colKey: ASYNC_LOADING_ROW,
-          attrs: { colSpan: this.columns.length },
-          render: (h: CreateElement) => {
-            if (typeof asyncLoading === 'function') {
-              return asyncLoading(h);
-            }
-            if (typeof this.$scopedSlots.asyncLoading === 'function') {
-              return this.$scopedSlots.asyncLoading(h);
-            }
-            const loadingText = {
-              'load-more': '点击加载更多',
-              loading: '正在加载中，请稍后',
-            }[String(asyncLoading)];
-            if (!loadingText) {
-              return '';
-            }
-            return (
-              <div class={this.classes} onClick={this.onLoadClick}>
-                {<Loading loading={asyncLoading === 'loading'} text={loadingText} />}
-              </div>
-            );
-          },
-        },
-      ];
-      return <TableRow rowKey={ASYNC_LOADING_ROW} columns={columns}></TableRow>;
+      const asyncLoadingNode = renderTNodeJSX(this, 'asyncLoading');
+      if (isString(asyncLoadingNode)) {
+        const { asyncLoading } = this;
+        const loadingText = {
+          'load-more': '点击加载更多',
+          loading: '正在加载中，请稍后',
+        }[String(asyncLoading)];
+        return (
+          <div class={this.classes} onClick={this.onLoadClick}>
+            {<Loading loading={asyncLoading === 'loading'} text={loadingText} />}
+          </div>
+        );
+      }
+      if (![null, false, undefined].includes(asyncLoadingNode)) {
+        return (
+          <div class={this.classes} onClick={this.onLoadClick}>
+            {asyncLoadingNode}
+          </div>
+        );
+      }
+      return null;
     },
   },
 });

--- a/src/table/primary-table/mixins/expand.tsx
+++ b/src/table/primary-table/mixins/expand.tsx
@@ -36,7 +36,6 @@ export default Vue.extend({
       return [
         {
           colKey: expandedColKey,
-          align: 'center',
           width: 48,
           attrs: {
             class: [`${prefix}-table__expandable-icon-cell`],

--- a/src/table/primary-table/mixins/expand.tsx
+++ b/src/table/primary-table/mixins/expand.tsx
@@ -3,9 +3,8 @@ import get from 'lodash/get';
 import { TdPrimaryTableProps } from '../../type';
 import baseTableProps from '../../base-table-props';
 import ExpandBox from '../expand-box';
-import TableRow from '../../base-table/table-row';
-import { ExpandProps, RenderExpandRow } from '../../util/interface';
-import { filterDataByIds, getRecord } from '../../util/common';
+import { ExpandProps } from '../../util/interface';
+import { filterDataByIds } from '../../util/common';
 import { prefix } from '../../../config';
 import { emitEvent } from '../../../utils/event';
 import { renderTNodeJSX } from '../../../utils/render-tnode';
@@ -17,6 +16,7 @@ export default Vue.extend({
   name: `${prefix}-primary-table-expand`,
   props: {
     data: baseTableProps.data,
+    columns: baseTableProps.columns,
     rowKey: baseTableProps.rowKey,
     ...ExpandProps,
   },
@@ -36,6 +36,7 @@ export default Vue.extend({
       return [
         {
           colKey: expandedColKey,
+          align: 'center',
           width: 48,
           attrs: {
             class: [`${prefix}-table__expandable-icon-cell`],
@@ -66,40 +67,21 @@ export default Vue.extend({
         />
       );
     },
-    // 渲染被展开的TableRow内容
-    renderExpandedRow({
-      rows, row, columns: defaultColumns, rowIndex,
-    }: RenderExpandRow): VNode {
-      const columnCounts = defaultColumns.length;
-      const expandRowHandler = this.getExpandRowHandler();
-      if (!expandRowHandler) return; // 若无展开渲染函数，则无需处理行数据
 
-      const { expandedRowKeys } = this;
-      const id = get(row, this.reRowKey);
-      const isShowExpanded = expandedRowKeys.includes(id);
-      const params = {
-        record: getRecord(row),
-        row,
-        index: rowIndex,
-      };
-      const columns = [
-        {
-          colKey: 'expanded-row',
-          attrs: {
-            colspan: columnCounts,
-            class: [`${prefix}-table__expanded-cell`],
-          },
-          render: (h: CreateElement): VNode => expandRowHandler(h, params) as VNode,
-        },
-      ];
-      rows.push(
-        <TableRow
-          key={`ExpandTableRowBox${rowIndex}`}
-          rowKey={this.rowKey}
-          style={{ ...(!isShowExpanded ? { display: 'none' } : {}) }}
-          columns={columns}
-        />,
-      );
+    // 渲染被展开行
+    renderExpandedRow(
+      params: Parameters<TdPrimaryTableProps['expandedRow']>[1],
+    ): ReturnType<TdPrimaryTableProps['expandedRow']> {
+      const id = get(params.row, this.reRowKey);
+      const isShowExpanded = this.expandedRowKeys.includes(id);
+      if (isShowExpanded) {
+        return (
+          <tr>
+            <td colspan={this.columns.length}>{renderTNodeJSX(this, 'expandedRow', { params })}</td>
+          </tr>
+        );
+      }
+      return null;
     },
 
     // handle

--- a/src/table/primary-table/mixins/filter.tsx
+++ b/src/table/primary-table/mixins/filter.tsx
@@ -82,7 +82,8 @@ export default Vue.extend({
 
   methods: {
     updateTableWidth() {
-      const tbody = this.$el.querySelector(`.${prefix}-table__body`);
+      if (!this.$el) return;
+      const tbody = this.$el?.querySelector(`.${prefix}-table__body`);
       if (tbody) {
         this.tableWidth = tbody.clientWidth;
       } else {

--- a/src/table/primary-table/mixins/select.tsx
+++ b/src/table/primary-table/mixins/select.tsx
@@ -62,7 +62,7 @@ export default Vue.extend({
               }),
             }
             : {}),
-          ...(isSelection ? ({ title }) : {}),
+          ...(isSelection ? { title } : {}),
         };
       });
     },
@@ -73,7 +73,8 @@ export default Vue.extend({
           indeterminate={this.isSelectedSome}
           disabled={!this.canSelectedRows.length}
           {...{ on: { change: this.handleSelectAll } }}
-        />);
+        />
+      );
     },
 
     // render
@@ -83,16 +84,15 @@ export default Vue.extend({
           checked: this.selectedRowKeys.includes(get(row, this.reRowKey)),
           ...column,
           type: column.type,
-          checkProps: typeof column.checkProps === 'function'
-            ? column.checkProps({ row, rowIndex })
-            : column.checkProps,
+          checkProps:
+            typeof column.checkProps === 'function' ? column.checkProps({ row, rowIndex }) : column.checkProps,
           disabled: typeof column.disabled === 'function' ? column.disabled({ row, rowIndex }) : column.disabled,
           rowIndex,
         },
         on: {
           click: (e: MouseEvent) => {
             // 选中行功能中，点击 checkbo/radio 需阻止事件冒泡，避免触发不必要的 onRowClick
-            e.stopPropagation();
+            e?.stopPropagation();
           },
           // radio 单选框可再点击一次关闭选择，input / change 事件无法监听
           change: (): void => this.handleSelectChange(row),
@@ -127,9 +127,9 @@ export default Vue.extend({
       const { selectedRowKeys, canSelectedRows, reRowKey } = this;
       const canSelectedRowKeys = canSelectedRows.map((record) => get(record, reRowKey));
       const disabledSelectedRowKeys = selectedRowKeys.filter((id) => !canSelectedRowKeys.includes(id));
-      const allIds = (this.isSelectedAll
+      const allIds = this.isSelectedAll
         ? [...disabledSelectedRowKeys]
-        : [...disabledSelectedRowKeys, ...canSelectedRowKeys]);
+        : [...disabledSelectedRowKeys, ...canSelectedRowKeys];
       emitEvent<SelectChangeParams>(this, 'select-change', allIds, {
         selectedRowData: filterDataByIds(this.data, allIds, reRowKey),
         type: this.isSelectedAll ? 'uncheck' : 'check',

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -2,7 +2,7 @@
 
 /**
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
- * updated at 2021-12-25 11:57:19
+ * updated at 2022-01-10 09:31:10
  * */
 
 import { PaginationProps, PageInfo } from '../pagination';
@@ -37,10 +37,6 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
    * @default ''
    */
   empty?: string | TNode;
-  /**
-   * 展开行内容，可自定义，泛型 T 指表格数据类型
-   */
-  expandedRow?: string | TNode<{ row: T; index: number }>;
   /**
    * 首行内容
    */
@@ -280,7 +276,7 @@ export interface TdPrimaryTableProps<T extends TableRowData = TableRowData>
    */
   showColumnController?: boolean;
   /**
-   * 【开发中】是否显示为通过拖拽图标进行排序
+   * 【讨论中-待定】是否显示为通过拖拽图标进行排序
    * @default false
    */
   showDragCol?: boolean;
@@ -373,7 +369,7 @@ export interface PrimaryTableCol<T extends TableRowData = TableRowData>
    */
   title?: string | TNode<{ col: PrimaryTableCol; colIndex: number }>;
   /**
-   * 行选中有两种模式：单选和多选
+   * 行选中有两种模式：单选和多选。`colKey` 值为 `row-select` 时，表示当前列选中项， `type=single/multiple` 有效
    * @default single
    */
   type?: 'single' | 'multiple';

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -3334,32 +3334,17 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/table.vue co
               <td class="" key="platform" length="4">Vue(PC)</td>
               <td class="" key="property" length="4">A</td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="4" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>This is expanded row info</div>
-              </td>
-            </tr>
             <tr rowKey="property" class="" key="B">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="4" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right"><path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="" key="type" length="4">String</td>
               <td class="" key="platform" length="4">React(PC)</td>
               <td class="" key="property" length="4">B</td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="4" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>This is expanded row info</div>
-              </td>
-            </tr>
             <tr rowKey="property" class="" key="C">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="4" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right"><path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="" key="type" length="4">Object</td>
               <td class="" key="platform" length="4">Miniprogram</td>
               <td class="" key="property" length="4">C</td>
-            </tr>
-            <tr style="display:none;">
-              <td colspan="4" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>This is expanded row info</div>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -10207,7 +10192,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/async-loading.vue corr
               <td class="" key="email" length="3" style="overflow:hidden;">zcroson5@virginia.edu</td>
             </tr>
             <tr>
-              <td colSpan="3" class="" key="async-loading-row" length="1">
+              <td colspan="3" class="t-table__row--full t-table__row-last-full-row">
                 <div class="t-table__async-loading t-is-loading">
                   <div class="t-loading--center t-size-m t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="medium" class="t-loading__gradient t-icon-loading">
                       <foreignObject x="1" y="1" width="12" height="12">
@@ -10663,18 +10648,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/expandable.vue correct
               <td class="" key="description" length="6">隐藏展开图标</td>
               <td class="" key="op" length="6" style="overflow:hidden;"><a class="link">管理</a> <a class="link">删除</a></td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div class="more-detail">
-                  <p class="title"><b>集群名称:</b></p>
-                  <p class="content">集群测试1</p><br>
-                  <p class="title"><b>管理员:</b></p>
-                  <p class="content">jenny;peter</p><br>
-                  <p class="title"><b>描述:</b></p>
-                  <p class="content">隐藏展开图标</p>
-                </div>
-              </td>
-            </tr>
             <tr rowKey="id" class="" key="2">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="6" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;transform:rotate(90deg);"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right-circle"><path fill="currentColor" d="M6.2 5.2L9 8l-2.8 2.8.71.7 3.5-3.5-3.5-3.5-.7.7z" fill-opacity="0.9"></path><path fill="currentColor" d="M8 15A7 7 0 118 1a7 7 0 010 14zm0-1A6 6 0 108 2a6 6 0 000 12z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="" key="instance" length="6" style="overflow:hidden;">集群测试2</td>
@@ -10687,7 +10660,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/expandable.vue correct
               <td class="" key="op" length="6" style="overflow:hidden;"><a class="link">管理</a> <a class="link">删除</a></td>
             </tr>
             <tr>
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
+              <td colspan="5">
                 <div class="more-detail">
                   <p class="title"><b>集群名称:</b></p>
                   <p class="content">集群测试2</p><br>
@@ -10709,18 +10682,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/expandable.vue correct
               <td class="" key="description" length="6">自定义图标</td>
               <td class="" key="op" length="6" style="overflow:hidden;"><a class="link">管理</a> <a class="link">删除</a></td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div class="more-detail">
-                  <p class="title"><b>集群名称:</b></p>
-                  <p class="content">集群测试3</p><br>
-                  <p class="title"><b>管理员:</b></p>
-                  <p class="content">jenny</p><br>
-                  <p class="title"><b>描述:</b></p>
-                  <p class="content">自定义图标</p>
-                </div>
-              </td>
-            </tr>
             <tr rowKey="id" class="" key="4">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="6" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right-circle"><path fill="currentColor" d="M6.2 5.2L9 8l-2.8 2.8.71.7 3.5-3.5-3.5-3.5-.7.7z" fill-opacity="0.9"></path><path fill="currentColor" d="M8 15A7 7 0 118 1a7 7 0 010 14zm0-1A6 6 0 108 2a6 6 0 000 12z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="" key="instance" length="6" style="overflow:hidden;">集群测试4</td>
@@ -10731,18 +10692,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/expandable.vue correct
               <td class="" key="owner" length="6">peter</td>
               <td class="" key="description" length="6">test</td>
               <td class="" key="op" length="6" style="overflow:hidden;"><a class="link">管理</a> <a class="link">删除</a></td>
-            </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div class="more-detail">
-                  <p class="title"><b>集群名称:</b></p>
-                  <p class="content">集群测试4</p><br>
-                  <p class="title"><b>管理员:</b></p>
-                  <p class="content">peter</p><br>
-                  <p class="title"><b>描述:</b></p>
-                  <p class="content">test</p>
-                </div>
-              </td>
             </tr>
           </tbody>
         </table>
@@ -12471,11 +12420,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree-select.vue correc
               <td class="" key="owner" length="6">jenny</td>
               <td class="" key="description" length="6">important.</td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>这是展开项数据，我是 0 号</div>
-              </td>
-            </tr>
             <tr rowKey="key" class="" key="1">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="6" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right-circle"><path fill="currentColor" d="M6.2 5.2L9 8l-2.8 2.8.71.7 3.5-3.5-3.5-3.5-.7.7z" fill-opacity="0.9"></path><path fill="currentColor" d="M8 15A7 7 0 118 1a7 7 0 010 14zm0-1A6 6 0 108 2a6 6 0 000 12z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="t-table__cell--selectable" key="row-select" length="6" style="overflow:hidden;"><label class="t-checkbox t-is-disabled"><input type="checkbox" disabled="disabled" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
@@ -12490,11 +12434,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree-select.vue correc
               </td>
               <td class="" key="owner" length="6">peter</td>
               <td class="" key="description" length="6">important.</td>
-            </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>这是展开项数据，我是 1 号</div>
-              </td>
             </tr>
             <tr rowKey="key" class="" key="2">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="6" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right-circle"><path fill="currentColor" d="M6.2 5.2L9 8l-2.8 2.8.71.7 3.5-3.5-3.5-3.5-.7.7z" fill-opacity="0.9"></path><path fill="currentColor" d="M8 15A7 7 0 118 1a7 7 0 010 14zm0-1A6 6 0 108 2a6 6 0 000 12z" fill-opacity="0.9"></path></svg></span></span></td>
@@ -12511,11 +12450,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree-select.vue correc
               <td class="" key="owner" length="6">jenny</td>
               <td class="" key="description" length="6">important.</td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>这是展开项数据，我是 2 号</div>
-              </td>
-            </tr>
             <tr rowKey="key" class="" key="3">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="6" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right-circle"><path fill="currentColor" d="M6.2 5.2L9 8l-2.8 2.8.71.7 3.5-3.5-3.5-3.5-.7.7z" fill-opacity="0.9"></path><path fill="currentColor" d="M8 15A7 7 0 118 1a7 7 0 010 14zm0-1A6 6 0 108 2a6 6 0 000 12z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="t-table__cell--selectable" key="row-select" length="6" style="overflow:hidden;"><label class="t-checkbox t-is-disabled"><input type="checkbox" disabled="disabled" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
@@ -12531,11 +12465,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree-select.vue correc
               <td class="" key="owner" length="6">peter</td>
               <td class="" key="description" length="6">important.</td>
             </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>这是展开项数据，我是 3 号</div>
-              </td>
-            </tr>
             <tr rowKey="key" class="" key="4">
               <td class="t-table__expandable-icon-cell" key="expanded-icon-cell" length="6" style="overflow:hidden;"><span class="t-table__expand-box"><span style="transition:all .2s;display:flex;align-items:center;"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right-circle"><path fill="currentColor" d="M6.2 5.2L9 8l-2.8 2.8.71.7 3.5-3.5-3.5-3.5-.7.7z" fill-opacity="0.9"></path><path fill="currentColor" d="M8 15A7 7 0 118 1a7 7 0 010 14zm0-1A6 6 0 108 2a6 6 0 000 12z" fill-opacity="0.9"></path></svg></span></span></td>
               <td class="t-table__cell--selectable" key="row-select" length="6" style="overflow:hidden;"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
@@ -12550,11 +12479,6 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree-select.vue correc
               </td>
               <td class="" key="owner" length="6">jenny</td>
               <td class="" key="description" length="6">important.</td>
-            </tr>
-            <tr style="display:none;">
-              <td colspan="6" class="t-table__expanded-cell" key="expanded-row" length="1">
-                <div>这是展开项数据，我是 4 号</div>
-              </td>
             </tr>
           </tbody>
         </table>

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -1468,59 +1468,6 @@ exports[`Table expandable demo works fine 1`] = `
               </td>
             </tr>
             <tr
-              style="display: none;"
-            >
-              <td
-                class="t-table__expanded-cell"
-                colspan="6"
-                key="expanded-row"
-                length="1"
-              >
-                <div
-                  class="more-detail"
-                >
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      集群名称:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    集群测试1
-                  </p>
-                  <br />
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      管理员:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    jenny;peter
-                  </p>
-                  <br />
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      描述:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    隐藏展开图标
-                  </p>
-                </div>
-              </td>
-            </tr>
-            <tr
               class=""
               key="2"
               rowkey="id"
@@ -1615,10 +1562,7 @@ exports[`Table expandable demo works fine 1`] = `
             </tr>
             <tr>
               <td
-                class="t-table__expanded-cell"
-                colspan="6"
-                key="expanded-row"
-                length="1"
+                colspan="5"
               >
                 <div
                   class="more-detail"
@@ -1758,59 +1702,6 @@ exports[`Table expandable demo works fine 1`] = `
               </td>
             </tr>
             <tr
-              style="display: none;"
-            >
-              <td
-                class="t-table__expanded-cell"
-                colspan="6"
-                key="expanded-row"
-                length="1"
-              >
-                <div
-                  class="more-detail"
-                >
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      集群名称:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    集群测试3
-                  </p>
-                  <br />
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      管理员:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    jenny
-                  </p>
-                  <br />
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      描述:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    自定义图标
-                  </p>
-                </div>
-              </td>
-            </tr>
-            <tr
               class=""
               key="4"
               rowkey="id"
@@ -1901,59 +1792,6 @@ exports[`Table expandable demo works fine 1`] = `
                 >
                   删除
                 </a>
-              </td>
-            </tr>
-            <tr
-              style="display: none;"
-            >
-              <td
-                class="t-table__expanded-cell"
-                colspan="6"
-                key="expanded-row"
-                length="1"
-              >
-                <div
-                  class="more-detail"
-                >
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      集群名称:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    集群测试4
-                  </p>
-                  <br />
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      管理员:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    peter
-                  </p>
-                  <br />
-                  <p
-                    class="title"
-                  >
-                    <b>
-                      描述:
-                    </b>
-                  </p>
-                  <p
-                    class="content"
-                  >
-                    test
-                  </p>
-                </div>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
子仓库变更：https://github.com/Tencent/tdesign-common/pull/112

- Table：修复过滤功能不显示空数据元素问题，[pr#197](https://github.com/Tencent/tdesign-vue/pull/197)，[issue#178](https://github.com/Tencent/tdesign-vue/issues/178)，[commit](https://github.com/Tencent/tdesign-vue/pull/197/commits/72fd400ab395986b496b087ea03fa3eb2290326e)，[@chaishi](https://github.com/chaishi)
- Table：为了保证每次展开的数据最新，展开行不再进行预渲染，如果有预渲染需求，后期再新增，[pr#197](https://github.com/Tencent/tdesign-vue/pull/197)，[issue#199](https://github.com/Tencent/tdesign-vue/issues/199)，[@chaishi](https://github.com/chaishi)
- Drawer：支持 SSR，[pr#197](https://github.com/Tencent/tdesign-vue/pull/197)，[@chaishi](https://github.com/chaishi)
- Table: 异步加载功能重构，之前使用 Provider 渲染，现更为使用 `lastFullRow` 渲染，[commit](https://github.com/Tencent/tdesign-vue/pull/197/commits/656802f77183e41f72c300a1cf454b6b4ebad8b8)

因 Drawer 出现 ssr 测试失败，因此修复一下，以保证 CI 正常通过

