### PR TITLE
fix(table): 空表格高度与API height 保持一致 #194

### DIFF
--- a/src/table/base-table/index.tsx
+++ b/src/table/base-table/index.tsx
@@ -186,8 +186,15 @@ export default mixins(getConfigReceiverMixins<Vue, TableConfig>('table')).extend
     renderEmptyTable(): VNode {
       if (this.empty === null) return null;
       const useLocale = !this.empty && !this.$scopedSlots.empty;
+      const { height } = this;
+      const wrapperStyle: { height?: string | number } = {};
+      if (height !== 'auto') {
+        wrapperStyle.height = isNaN(Number(height)) ? height : `${height}px`;
+      }
       return (
-        <div class={`${prefix}-table__empty`}>{useLocale ? this.global.empty : renderTNodeJSX(this, 'empty')}</div>
+        <div style={wrapperStyle} class={`${prefix}-table__empty`}>
+          {useLocale ? this.global.empty : renderTNodeJSX(this, 'empty')}
+        </div>
       );
     },
     renderPagination(): VNode {


### PR DESCRIPTION
- Table：空表格高度与 API `height` 保持一致，[pr#200](https://github.com/Tencent/tdesign-vue/pull/200)，[issue#194](https://github.com/Tencent/tdesign-vue/issues/194)[@realyuyanan](https://github.com/realyuyanan)

--------

**brefore**

![image](https://user-images.githubusercontent.com/22365107/148715987-e1977ddc-26f1-4cc2-bfeb-853c7b80a45b.png)

**after**

![image](https://user-images.githubusercontent.com/22365107/148716005-e28b11e0-4606-405f-b10c-d11ccd2e6e04.png)
