### PR TITLE
chore: upgrade icon package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dayjs": "^1.9.7",
     "lodash": "^4.17.21",
     "raf": "^3.4.1",
-    "tdesign-icons-vue": "0.0.6",
+    "tdesign-icons-vue": "~0.0.7",
     "validator": "^13.5.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
升级icon包 0.0.6到0.0.7没什么变动 只是支持了一下es-check到es5
改为~ 针对一些bug fix可以平滑升级