### PR TITLE
fix(ie-tpopup): 兼容 @popperjs/core ie9下不支持 transform 的问题

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { createPopper } from '@popperjs/core';
+import { createPopper, Options } from '@popperjs/core';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import { prefix } from '../config';
 import CLASSNAMES from '../utils/classnames';
@@ -8,10 +8,12 @@ import {
 } from '../utils/dom';
 import props from './props';
 import { renderTNodeJSX, renderContent } from '../utils/render-tnode';
+import { getIEVersion } from '../utils/helper';
 import { PopupVisibleChangeContext } from './type';
 import { Styles, ClassName } from '../common';
 import setStyle from '../utils/set-style';
 
+type popperOptionsType = Options & any;
 const stop = (e: MouseEvent) => e.stopPropagation();
 const name = `${prefix}-popup`;
 const placementMap = {
@@ -221,13 +223,26 @@ export default Vue.extend({
         }
         popperElm.style.display = 'none';
       }
-
-      this.popper = createPopper(this.referenceElm, popperElm, {
+      const popperOptions = {
         placement,
         onFirstUpdate: () => {
           this.$nextTick(this.updatePopper);
         },
-      });
+      } as popperOptionsType;
+      if (getIEVersion() <= 9) {
+        popperOptions.modifiers = [
+          {
+            name: 'computeStyles',
+            options: {
+              // 默认为 true，即使用 transform 定位，开启 gpu 加速
+              // ie9 不支持 transform，需要添加 -ms- 前缀，@popperjs/core 没有添加这个样式，
+              // 在 ie9 下则去掉 gpu 优化加速，使用 top, right, bottom, left 定位
+              gpuAcceleration: false,
+            },
+          },
+        ];
+      }
+      this.popper = createPopper(this.referenceElm, popperElm, popperOptions);
       popperElm.addEventListener('click', stop);
       // 监听trigger元素尺寸变化
       this.resizeSensor = new ResizeSensor(this.referenceElm, () => {

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -13,7 +13,6 @@ import { PopupVisibleChangeContext } from './type';
 import { Styles, ClassName } from '../common';
 import setStyle from '../utils/set-style';
 
-type popperOptionsType = Options & any;
 const stop = (e: MouseEvent) => e.stopPropagation();
 const name = `${prefix}-popup`;
 const placementMap = {
@@ -223,12 +222,14 @@ export default Vue.extend({
         }
         popperElm.style.display = 'none';
       }
-      const popperOptions = {
+      const popperOptions: Options = {
         placement,
         onFirstUpdate: () => {
           this.$nextTick(this.updatePopper);
         },
-      } as popperOptionsType;
+        modifiers: [],
+        strategy: 'absolute',
+      };
       if (getIEVersion() <= 9) {
         popperOptions.modifiers = [
           {

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -66,6 +66,31 @@ export function getPropsApiByEvent(eventName: string) {
 }
 
 /**
+ *
+ * @returns 获取 ie 浏览器版本
+ */
+export function getIEVersion() {
+  const { userAgent } = navigator;
+  // 判断是否IE<11浏览器
+  const isIE = userAgent.indexOf('compatible') > -1 && userAgent.indexOf('MSIE') > -1;
+  // 判断是否IE11浏览器
+  const isIE11 = userAgent.indexOf('Trident') > -1 && userAgent.indexOf('rv:11.0') > -1;
+  if (isIE) {
+    const reIE = new RegExp('MSIE (\\d+\\.\\d+);');
+    const match = userAgent.match(reIE);
+    if (!match) return -1;
+    const fIEVersion = parseFloat(match[1]);
+    return fIEVersion < 7 ? 6 : fIEVersion;
+  }
+  if (isIE11) {
+    // IE11
+    return 11;
+  }
+  // 不是ie浏览器
+  return Number.MAX_SAFE_INTEGER;
+}
+
+/**
  * 计算字符串字符的长度并可以截取字符串。
  * @param str 传入字符串
  * @param maxCharacter 规定最大字符串长度
@@ -112,6 +137,6 @@ export function getCharacterLength(str: string, maxCharacter?: number) {
  * @param param number或string类型的可用于样式上的值
  * @returns 可使用的样式值。
  */
-export function pxCompat(param: string|number) {
+export function pxCompat(param: string | number) {
   return typeof param === 'number' ? `${param}px` : param;
 }


### PR DESCRIPTION
- tpopup: 兼容 tpopup 组件使用的 @popperjs/core 库在 ie9 下不兼容 transform 导致弹出框错位的问题，修改为 ie9 浏览器下使用 top,right,bottom,left 定位。[pr#210](https://github.com/Tencent/tdesign-vue/pull/210)  [wwervin72](https://github.com/wwervin72)