### PR TITLE
fix(site): changeVersion behavior

### DIFF
--- a/site/src/components/page.vue
+++ b/site/src/components/page.vue
@@ -4,13 +4,12 @@
       <td-doc-search slot="search" ref="tdDocSearch"></td-doc-search>
     </td-header>
     <td-doc-aside ref="tdDocAside" title="Vue for Web">
-      <t-select slot="extra" v-model="version" :popupProps="{ zIndex: 500 }" @change="changeVersion">
+      <t-select slot="extra" :value="version" :popupProps="{ zIndex: 500 }" @change="changeVersion">
         <t-option v-for="(item, index) in options" :value="item.value" :label="item.label" :key="index">
           {{ item.label }}
         </t-option>
       </t-select>
     </td-doc-aside>
-
     <router-view :style="contentStyle" @loaded="contentLoaded" />
   </td-doc-layout>
 </template>


### PR DESCRIPTION
fix #238

before:
切换版本会打开新的tab页，会导致当前的tab页的版本显示错误

after
切换版本仍然会打开新的tab页，但当前tab页版本不变(参考了tdesign-react)
