### PR TITLE
feat: import common css in index.js

### DIFF
--- a/script/rollup.config.js
+++ b/script/rollup.config.js
@@ -19,10 +19,7 @@ import ignoreImport from 'rollup-plugin-ignore-import';
 import pkg from '../package.json';
 
 const name = 'tdesign';
-const externalDeps = Object.keys(pkg.dependencies || {}).concat([
-  /lodash/,
-  /@babel\/runtime/,
-]);
+const externalDeps = Object.keys(pkg.dependencies || {}).concat([/lodash/, /@babel\/runtime/]);
 const externalPeerDeps = Object.keys(pkg.peerDependencies || {});
 const banner = `/**
  * ${name} v${pkg.version}
@@ -32,13 +29,7 @@ const banner = `/**
 `;
 
 const input = 'src/index.ts';
-const inputList = [
-  'src/**/*.ts',
-  'src/**/*.tsx',
-  '!src/**/demos',
-  '!src/**/*.d.ts',
-  '!src/**/__tests__',
-];
+const inputList = ['src/**/*.ts', 'src/**/*.tsx', '!src/**/demos', '!src/**/*.d.ts', '!src/**/__tests__'];
 
 const getPlugins = ({
   env,
@@ -73,18 +64,18 @@ const getPlugins = ({
 
   // css
   if (extractOneCss) {
-    plugins.push(postcss({
-      extract: `${isProd ? `${name}.min` : name}.css`,
-      minimize: isProd,
-      sourceMap: true,
-      extensions: ['.sass', '.scss', '.css', '.less'],
-    }));
+    plugins.push(
+      postcss({
+        extract: `${isProd ? `${name}.min` : name}.css`,
+        minimize: isProd,
+        sourceMap: true,
+        extensions: ['.sass', '.scss', '.css', '.less'],
+      }),
+    );
   } else if (extractMultiCss) {
     plugins.push(
       staticImport({
-        include: [
-          'src/**/style/css.js',
-        ],
+        include: ['src/**/style/css.js'],
       }),
       ignoreImport({
         include: ['src/*/style/*'],
@@ -96,10 +87,7 @@ const getPlugins = ({
   } else {
     plugins.push(
       staticImport({
-        include: [
-          'src/**/style/index.js',
-          'src/_common/style/web/**/*.less',
-        ],
+        include: ['src/**/style/index.js', 'src/_common/style/web/**/*.less'],
       }),
       ignoreImport({
         include: ['src/*/style/*'],
@@ -109,22 +97,26 @@ const getPlugins = ({
   }
 
   if (env) {
-    plugins.push(replace({
-      preventAssignment: true,
-      values: {
-        'process.env.NODE_ENV': JSON.stringify(env),
-      },
-    }));
+    plugins.push(
+      replace({
+        preventAssignment: true,
+        values: {
+          'process.env.NODE_ENV': JSON.stringify(env),
+        },
+      }),
+    );
   }
 
   if (isProd) {
-    plugins.push(terser({
-      output: {
-        /* eslint-disable */
-        ascii_only: true,
-        /* eslint-enable */
-      },
-    }));
+    plugins.push(
+      terser({
+        output: {
+          /* eslint-disable */
+          ascii_only: true,
+          /* eslint-enable */
+        },
+      }),
+    );
   }
 
   return plugins;
@@ -133,10 +125,7 @@ const getPlugins = ({
 /** @type {import('rollup').RollupOptions} */
 const cssConfig = {
   input: ['src/**/style/index.js'],
-  plugins: [
-    multiInput(),
-    styles({ mode: 'extract' }),
-  ],
+  plugins: [multiInput(), styles({ mode: 'extract' })],
   output: {
     banner,
     dir: 'es/',
@@ -150,7 +139,12 @@ const esConfig = {
   // 为了保留 style/css.js
   treeshake: false,
   external: externalDeps.concat(externalPeerDeps),
-  plugins: [multiInput()].concat(getPlugins({ extractMultiCss: true })),
+  plugins: [
+    multiInput(),
+    postcss({
+      extensions: ['.sass', '.scss', '.css', '.less'],
+    }),
+  ].concat(getPlugins({ extractMultiCss: true })),
   output: {
     banner,
     dir: 'es/',
@@ -166,7 +160,12 @@ const esmConfig = {
   // 为了保留 style/index.js
   treeshake: false,
   external: externalDeps.concat(externalPeerDeps),
-  plugins: [multiInput()].concat(getPlugins({ ignoreLess: false })),
+  plugins: [
+    multiInput(),
+    postcss({
+      extensions: ['.sass', '.scss', '.css', '.less'],
+    }),
+  ].concat(getPlugins({ ignoreLess: false })),
   output: {
     banner,
     dir: 'esm/',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { VueConstructor } from 'vue';
+import './style/index.js';
 import * as components from './components';
 
 function install(Vue: VueConstructor, config?: object) {


### PR DESCRIPTION
common pr: https://github.com/Tencent/tdesign-common/pull/141

修复 umd 产物 tdesign.css 中没有 theme/_index.less 中声明的 css variables 的问题 fix issue #222 。

--------

**brefore**
## 问题 1：tdesign.css 中没有 reset 和 theme 相关内容


## 问题2：重复引入 global 中全局样式
每个组件样式都引入了 base.less，如 https://github.com/Tencent/tdesign-common/blob/develop/style/web/components/button/_index.less#L1

base.less 中有引入 global.less
![image](https://user-images.githubusercontent.com/7600149/149926547-8ad26720-f77a-4b5b-b0d5-5a7039e311fe.png)

按需引入组件时，引入了几个就会重复引入几次 global 中全局样式，需要用户自己在项目中 shanking 掉
.....

**after**
在 src/index.js 中显示引入  `src/style/index.js`，保持跟 es/esm 中引入方式一样，后续新增样式文件只在 src/style/index.js 中维护即可。

构建产物：
![image](https://user-images.githubusercontent.com/7600149/149929434-b40e807e-e7e7-402c-afde-49ecfd35a9ba.png)

......
