### PR TITLE
fix(ie-slider): 去掉slider-button的disabled属性，以兼容ie9下事件触发

### DIFF
--- a/src/slider/slider-button.tsx
+++ b/src/slider/slider-button.tsx
@@ -276,7 +276,7 @@ export default (Vue as VueConstructor<SliderInstanceType>).extend({
     return (
       <div
         ref="button"
-        class={[{ hover: this.hovering, dragging: this.dragging }, 't-slider__button-wrapper']}
+        class={[{ hover: this.hovering, dragging: this.dragging }, `${prefix}-slider__button-wrapper`]}
         style={this.wrapperStyle}
         tabindex="0"
         show-tooltip={this.showTooltip}

--- a/src/slider/slider-button.tsx
+++ b/src/slider/slider-button.tsx
@@ -3,6 +3,7 @@ import { Styles } from '@src/common';
 import { prefix } from '../config';
 import Slider from './slider';
 import Popup from '../popup/popup';
+import { getIEVersion } from '../utils/helper';
 import { TdSliderProps } from './type';
 
 const name = `${prefix}-slider-button`;
@@ -38,9 +39,7 @@ export default (Vue as VueConstructor<SliderInstanceType>).extend({
   computed: {
     placement(): string {
       if (this.tooltipProps instanceof Object) {
-        const {
-          placement,
-        } = this.tooltipProps;
+        const { placement } = this.tooltipProps;
         if (placement) return placement;
       }
 
@@ -107,12 +106,7 @@ export default (Vue as VueConstructor<SliderInstanceType>).extend({
     setTooltipProps() {
       if (this.tooltipProps instanceof Object) {
         const {
-          trigger,
-          destroyOnClose,
-          showArrow,
-          overlayStyle,
-          overlayClassName,
-          attach,
+          trigger, destroyOnClose, showArrow, overlayStyle, overlayClassName, attach,
         } = this.tooltipProps;
         if (!this.empty(trigger)) {
           this.trigger = trigger;
@@ -279,36 +273,38 @@ export default (Vue as VueConstructor<SliderInstanceType>).extend({
     },
   },
   render(): VNode {
-    return <div
-      ref="button"
-      class={[{ hover: this.hovering, dragging: this.dragging }, 't-slider__button-wrapper']}
-      style={this.wrapperStyle}
-      tabindex="0"
-      show-tooltip={this.showTooltip}
-      disabled={this.disabled}
-      onmouseenter={this.handleMouseEnter}
-      onmouseleave={this.handleMouseLeave}
-      onmousedown={this.onButtonDown}
-      ontouchstart={this.onButtonDown}
-      onfocus={this.handleMouseEnter}
-      onblur={this.handleMouseLeave}
-      onKeydown={this.onNativeKeyDown}
-    >
-      <t-popup
-        ref="popup"
-        popper-class={this.popupClass}
-        disabled={!this.showTooltip}
-        content={String(this.formatValue)}
-        placement={this.placement}
-        trigger={this.trigger}
-        showArrow={this.showArrow}
-        overlayStyle={this.overlayStyle}
-        overlayClassName={this.overlayClassName}
-        attach={this.attach}
-        visible={this.visible}
+    return (
+      <div
+        ref="button"
+        class={[{ hover: this.hovering, dragging: this.dragging }, 't-slider__button-wrapper']}
+        style={this.wrapperStyle}
+        tabindex="0"
+        show-tooltip={this.showTooltip}
+        disabled={getIEVersion() > 11 ? this.disabled : undefined}
+        onmouseenter={this.handleMouseEnter}
+        onmouseleave={this.handleMouseLeave}
+        onmousedown={this.onButtonDown}
+        ontouchstart={this.onButtonDown}
+        onfocus={this.handleMouseEnter}
+        onblur={this.handleMouseLeave}
+        onKeydown={this.onNativeKeyDown}
       >
-        <div class={['t-slider__button', { hover: this.hovering, dragging: this.dragging }]} />
-      </t-popup>
-    </div>;
+        <t-popup
+          ref="popup"
+          popper-class={this.popupClass}
+          disabled={!this.showTooltip}
+          content={String(this.formatValue)}
+          placement={this.placement}
+          trigger={this.trigger}
+          showArrow={this.showArrow}
+          overlayStyle={this.overlayStyle}
+          overlayClassName={this.overlayClassName}
+          attach={this.attach}
+          visible={this.visible}
+        >
+          <div class={['t-slider__button', { hover: this.hovering, dragging: this.dragging }]} />
+        </t-popup>
+      </div>
+    );
   },
 });


### PR DESCRIPTION
- slider: 移除 slider-button的 disabled 属性，以兼容 slider disabled 状态时，ie9下鼠标移入button无法显示tooltip的问题。[pr#280](https://github.com/Tencent/tdesign-vue/pull/280)  [wwervin72](https://github.com/wwervin72)