### PR TITLE
fix(select):修复visible-change关闭后不触发问题。#274

### DIFF
--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -381,6 +381,7 @@ export default mixins(getConfigReceiverMixins<Vue, SelectConfig>('select')).exte
     },
     hideMenu() {
       this.visible = false;
+      emitEvent<Parameters<TdSelectProps['onVisibleChange']>>(this, 'visible-change', false);
     },
     clearSelect(e: MouseEvent) {
       e.stopPropagation();


### PR DESCRIPTION
- 组件名称：select下拉选择框：修复visible-change关闭下拉框之后不触发问题，[issue#274 ](https://github.com/Tencent/tdesign-vue/issues/274)，[pr#281](https://github.com/Tencent/tdesign-vue/pull/281)，[xiewenxia](https://github.com/xiewenxia)
