### PR TITLE
feat: style import in lib

### DIFF
--- a/script/rollup.config.js
+++ b/script/rollup.config.js
@@ -28,7 +28,7 @@ const banner = `/**
  */
 `;
 
-const input = 'src/index.ts';
+const input = 'src/index-lib.ts';
 const inputList = ['src/**/*.ts', 'src/**/*.tsx', '!src/**/demos', '!src/**/*.d.ts', '!src/**/__tests__'];
 
 const getPlugins = ({

--- a/script/rollup.config.js
+++ b/script/rollup.config.js
@@ -139,12 +139,7 @@ const esConfig = {
   // 为了保留 style/css.js
   treeshake: false,
   external: externalDeps.concat(externalPeerDeps),
-  plugins: [
-    multiInput(),
-    postcss({
-      extensions: ['.sass', '.scss', '.css', '.less'],
-    }),
-  ].concat(getPlugins({ extractMultiCss: true })),
+  plugins: [multiInput()].concat(getPlugins({ extractMultiCss: true })),
   output: {
     banner,
     dir: 'es/',
@@ -160,12 +155,7 @@ const esmConfig = {
   // 为了保留 style/index.js
   treeshake: false,
   external: externalDeps.concat(externalPeerDeps),
-  plugins: [
-    multiInput(),
-    postcss({
-      extensions: ['.sass', '.scss', '.css', '.less'],
-    }),
-  ].concat(getPlugins({ ignoreLess: false })),
+  plugins: [multiInput()].concat(getPlugins({ ignoreLess: false })),
   output: {
     banner,
     dir: 'esm/',

--- a/src/index-lib.ts
+++ b/src/index-lib.ts
@@ -1,3 +1,4 @@
+import './style';
 import tdesign from './index';
 
 const ENV = process.env.NODE_ENV;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { VueConstructor } from 'vue';
-import './style/index.js';
 import * as components from './components';
 
 function install(Vue: VueConstructor, config?: object) {


### PR DESCRIPTION
https://github.com/Tencent/tdesign-vue/pull/271 中没有考虑 es/esm 产物入口文件中 postcss 也处理了引入的 style 的问题，本 pr 里修改引入样式入口到 index-lib 中，避免不必要的样式构建

--------

**brefore**
![image](https://user-images.githubusercontent.com/7600149/150119974-00b29523-2ca7-4be8-90ec-455525cfaf87.png)

.....


**after**

![image](https://user-images.githubusercontent.com/7600149/150120086-6f8e0f45-2e10-42e2-a50e-fdd653b1aac7.png)

......
