### PR TITLE
fix(tree/util.ts): fix: ie getAttribute null

### DIFF
--- a/src/tree/util.ts
+++ b/src/tree/util.ts
@@ -2,11 +2,7 @@ import { VNode } from 'vue';
 import TreeStore from '../_common/js/tree/tree-store';
 import TreeNode from '../_common/js/tree/tree-node';
 import {
-  TypeMark,
-  TypeLineModel,
-  TypeTNodeProp,
-  TypeGetTNodeOption,
-  TypeTargetNode,
+  TypeMark, TypeLineModel, TypeTNodeProp, TypeGetTNodeOption, TypeTargetNode,
 } from './interface';
 
 export { emitEvent } from '../utils/event';
@@ -26,16 +22,16 @@ export function getParentsToRoot(element?: HTMLElement, root?: HTMLElement): HTM
 
 export function getParentMarks(name: string, element?: HTMLElement, root?: HTMLElement): TypeMark[] {
   const list = getParentsToRoot(element, root);
-  return (
-    list.map((el) => {
+  return list
+    .map((el) => {
       const mark: TypeMark = {
         name,
-        value: el.getAttribute(name) || '',
+        value: el?.getAttribute(name) || '',
         el,
       };
       return mark;
-    }).filter((mark) => mark.value)
-  );
+    })
+    .filter((mark) => mark.value);
 }
 
 export function getMark(name: string, element?: HTMLElement, root?: HTMLElement): TypeMark {
@@ -97,7 +93,7 @@ export function getLineModel(nodes: TreeNode[], node: TreeNode, index: number): 
 }
 
 export function isTreeNodeValue(item: unknown): boolean {
-  return (typeof item === 'string' || typeof item === 'number');
+  return typeof item === 'string' || typeof item === 'number';
 }
 
 export function getNode(store: TreeStore, item: TypeTargetNode): TreeNode {


### PR DESCRIPTION
- Tree：IE 下第一次点击icon出现`Error in v-on handler: "TypeError: 对象不支持“getAttribute”属性或方法"` 问题修复处理，[#311](https://github.com/Tencent/tdesign-vue/issues/311)，[brianzhang](https://github.com/brianzhang)
