### PR TITLE
fix(comment): resolve margin disappearing because of textarea changes

### DIFF
--- a/examples/comment/demos/reply-form.vue
+++ b/examples/comment/demos/reply-form.vue
@@ -8,7 +8,7 @@
           placeholder="请输入内容"
           v-model="replyData"
         />
-        <t-button @click="submitReply">回复</t-button>
+        <t-button class="form-submit" @click="submitReply">回复</t-button>
       </div>
     </template>
   </t-comment>
@@ -42,5 +42,9 @@ export default {
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+
+    .form-submit {
+      margin-top: 8px;
+    }
   }
 </style>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -2830,7 +2830,7 @@ exports[`ssr snapshot test renders ./examples/comment/demos/reply-form.vue corre
     <div class="t-comment__content">
       <div class="t-comment__detail">
         <div class="form-container">
-          <div class="t-textarea"><textarea placeholder="请输入内容" class="t-textarea__inner"></textarea></div> <button type="button" class="t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">回复</span></button>
+          <div class="t-textarea"><textarea placeholder="请输入内容" class="t-textarea__inner"></textarea></div> <button type="button" class="form-submit t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">回复</span></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- comment：解决因textarea样式变更导致comment中reply-form示例回复按钮间距消失的问题，[@dreamsqin ](https://github.com/dreamsqin)

--------

**brefore**
<img width="945" alt="wecom-temp-54a9a51c8ff3428d23f513eb7f6337db" src="https://user-images.githubusercontent.com/15522703/150677410-0509fd92-4b8d-41c7-a901-ab682f6a7a9a.png">


**after**
![image](https://user-images.githubusercontent.com/15522703/150677417-0e841e67-702d-4986-bf41-a820a7ae4910.png)

