### PR TITLE
fix: 兼容IE9，修复input-number 在IE下 enter事件无效问题

### DIFF
--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -258,7 +258,7 @@ export default Vue.extend({
       emitEvent<Parameters<TdInputNumberProps['onFocus']>>(this, 'focus', this.value, { e });
     },
     handleKeydownEnter(e: KeyboardEvent) {
-      if (!['Enter', 'NumpadEnter'].includes(e.code)) return;
+      if (!['Enter', 'NumpadEnter'].includes(e.code || e.key)) return;
       emitEvent<Parameters<TdInputNumberProps['onEnter']>>(this, 'enter', this.value, { e });
     },
     handleKeydown(e: KeyboardEvent) {
@@ -272,8 +272,9 @@ export default Vue.extend({
         Enter: this.handleKeydownEnter,
         NumpadEnter: this.handleKeydownEnter,
       };
-      if (keyEvent[e.code] !== undefined) {
-        keyEvent[e.code](e);
+      const code = e.code || e.key;
+      if (keyEvent[code] !== undefined) {
+        keyEvent[code](e);
       }
     },
     handleKeyup(e: KeyboardEvent) {


### PR DESCRIPTION
- 组件名称：修复input-number组件回车事件在IE浏览器下失效的问题，[smile33](https://github.com/smile33)

--------

**brefore**
IE下 code为undefined，无法识别enter事件，会导致触发keydown事件。需改为key字段
![image](https://user-images.githubusercontent.com/11691667/150757504-fc8d679d-cb89-4b4a-b643-258bec155eb3.png)

.....


**after**
可以识别enter事件

......
