### PR TITLE
fix: 修复select-dvalne初始化node为null ie 下报错问题

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -327,6 +327,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
         // 数据源非空
         if (!isEmpty(this.data)) {
           const node = (tree as any).getItem(nodeValue);
+          if (!node) return;
           this.nodeInfo = { label: node.data[this.realLabel], value: node.data[this.realValue] };
         } else {
           this.nodeInfo = { label: nodeValue, value: nodeValue };
@@ -337,6 +338,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
           // 数据源非空
           if (!isEmpty(this.data)) {
             const node = (tree as any).getItem(nodeValue);
+            if (!node) return;
             return { label: node.data[this.realLabel], value: node.data[this.realValue] };
           }
           return { label: nodeValue, value: nodeValue };


### PR DESCRIPTION
- TreeSelect：
- IE9 ERROR: Unhandled promise rejection TypeError: 无法获取未定义或 null 引用的属性“data”
![image](https://user-images.githubusercontent.com/766999/150898852-45ef19ed-8db7-4353-8789-290563707690.png)
- [brianzhang](https://github.com/brianzhang)
fix code:
```js
const node = (tree as any).getItem(nodeValue);
if (!node) return;
```
