### PR TITLE
feat: Select & TimePicker 小优化

### DIFF
--- a/src/time-picker/panel/index.tsx
+++ b/src/time-picker/panel/index.tsx
@@ -72,19 +72,20 @@ export default mixins(getConfigReceiverMixins<TimePickerPanelInstance, TimePicke
     },
   },
   watch: {
-    isShowPanel(val: boolean) {
-      if (val) {
-        this.panelColUpdate();
-      }
+    isShowPanel: {
+      handler(val: boolean) {
+        if (val) {
+          this.panelColUpdate();
+        }
+      },
+      immediate: true,
     },
   },
   methods: {
     panelColUpdate() {
-      const panelCol0 = this.$refs.panelCol_0 as TimePickerPanelColInstance;
-      const panelCol1 = this.$refs.panelCol_1 as TimePickerPanelColInstance;
       this.$nextTick(() => {
-        panelCol0 && panelCol0.updateTimeScrollPos();
-        panelCol1 && panelCol1.updateTimeScrollPos();
+        (this.$refs.panelCol_0 as TimePickerPanelColInstance)?.updateTimeScrollPos();
+        (this.$refs.panelCol_1 as TimePickerPanelColInstance)?.updateTimeScrollPos();
       });
     },
     scrollToTime(colIndex: number, col: EPickerCols, time: number | string, behavior: ScrollBehavior) {


### PR DESCRIPTION
- Select：优化 options 的初始化解析，[pr 344](https://github.com/Tencent/tdesign-vue/pull/344)，[@ikeq](https://github.com/ikeq)
- TimePicker：优化 panel 定位时机，[pr 344](https://github.com/Tencent/tdesign-vue/pull/344)，[@ikeq](https://github.com/ikeq)

--------

**brefore**
select: options 提取完全依赖 children 挂载 

**after**
- select: 在 children 挂载前做一次 options 的提取
- time-picker：提升一点健壮性

**PS**: 此 PR 应不会对组件目前的行为产生任何影响，是配合 Popup 组件做改动