### PR TITLE
fix: 修复input-number中value为null时的错误

### DIFF
--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -178,7 +178,8 @@ export default Vue.extend({
       if (this.inputing && this.userInput !== null) {
         return this.filterValue;
       }
-      if (this.value === undefined) return '';
+
+      if (this.value === undefined || this.value === null) return '';
       // end input
       return this.format && !this.inputing ? this.format(this.value) : this.value.toFixed(this.digitsNum);
     },


### PR DESCRIPTION
fix #345


- input-number：解决value为null时报错，[#345](https://github.com/Tencent/tdesign-vue/issues/345)，[novlan1](https://github.com/novlan1)

