### PR TITLE
fix(calendar): fix: 修复日历组件monthChange事件在年只通过月份下拉框触发的问题

### DIFF
--- a/examples/calendar/demos/events.vue
+++ b/examples/calendar/demos/events.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="tdesign-demo-block-column-large">
     <t-calendar
-      :value="value"
       @cell-click="cellClick"
       @cell-double-click="cellDoubleClick"
       @cell-right-click="cellRightClick"
@@ -13,11 +12,6 @@
 
 <script>
 export default {
-  data() {
-    return {
-      value: null,
-    };
-  },
   methods: {
     cellClick(options) {
       console.log(`鼠标左键单击单元格 ${options.cell.formattedDate}`);

--- a/src/calendar/calendar.tsx
+++ b/src/calendar/calendar.tsx
@@ -324,6 +324,19 @@ export default mixins(getConfigReceiverMixins<Vue, CalendarConfig>('calendar')).
       const p = this.curSelectedMode === 'month' ? 'currentDayButtonProps' : 'currentMonthButtonProps';
       return this.checkControllerDisabled('current', p);
     },
+
+    filterYearStr(): string {
+      return `${this.controllerOptions.filterDate.getFullYear()}`;
+    },
+    filterMonthStr(): string {
+      return `${this.controllerOptions.filterDate.getMonth() + 1}`;
+    },
+    filterYearMonth(): { month: string; year: string } {
+      return {
+        year: this.filterYearStr,
+        month: this.filterMonthStr,
+      };
+    },
   },
   watch: {
     value: {
@@ -343,6 +356,12 @@ export default mixins(getConfigReceiverMixins<Vue, CalendarConfig>('calendar')).
         this.isShowWeekend = v;
       },
       immediate: true,
+    },
+    filterYearMonth: {
+      handler(v: { month: string; year: string }) {
+        emitEvent<Parameters<TdCalendarProps['onMonthChange']>>(this, 'month-change', v);
+        this.controllerChange();
+      },
     },
   },
   methods: {
@@ -389,15 +408,6 @@ export default mixins(getConfigReceiverMixins<Vue, CalendarConfig>('calendar')).
     controllerChange(): void {
       const options = this.controllerOptions;
       emitEvent<Parameters<TdCalendarProps['onControllerChange']>>(this, 'controller-change', options);
-    },
-    // 月份切换响应事件（包括年和月下拉框变化）
-    monthChange(): void {
-      const options = {
-        year: `${this.controllerOptions.filterDate.getFullYear()}`,
-        month: `${this.controllerOptions.filterDate.getMonth() + 1}`,
-      };
-      emitEvent<Parameters<TdCalendarProps['onMonthChange']>>(this, 'month-change', options);
-      this.controllerChange();
     },
     onWeekendToggleClick(): void {
       this.isShowWeekend = !this.isShowWeekend;
@@ -467,7 +477,6 @@ export default mixins(getConfigReceiverMixins<Vue, CalendarConfig>('calendar')).
                   size={this.controlSize}
                   disabled={this.isYearDisabled}
                   props={{ ...this.controllerConfigData.year.selecteProps }}
-                  onChange={this.monthChange}
                 >
                   {this.yearSelectOptionList.map((item) => (
                     <t-option key={item.value} value={item.value} label={item.label} disabled={item.disabled}>
@@ -484,7 +493,6 @@ export default mixins(getConfigReceiverMixins<Vue, CalendarConfig>('calendar')).
                   size={this.controlSize}
                   disabled={this.isMonthDisabled}
                   props={{ ...this.controllerConfigData.month.selecteProps }}
-                  onChange={this.monthChange}
                 >
                   {this.monthSelectOptionList.map((item) => (
                     <t-option key={item.value} value={item.value} label={item.label} disabled={item.disabled}>


### PR DESCRIPTION
目前日历组件monthChange事件只通过右上角的年月份下拉框触发，实际上点击“今天”、“本月”，或者通过代码给value属性赋值等操作也可能触发月份变化
ps：commit message 中事件名写错了··· 是monthChange