### PR TITLE
fix(progress): 修复环形进度条不可更改未完成轨道颜色问题

### DIFF
--- a/src/progress/progress.tsx
+++ b/src/progress/progress.tsx
@@ -53,6 +53,11 @@ export default Vue.extend({
         borderRadius: height,
       };
     },
+    circleStrokeStyle(): Styles {
+      return {
+        stroke: this.trackColor,
+      };
+    },
     barStyle(): Styles {
       return {
         width: `${this.percentage}%`,
@@ -203,6 +208,7 @@ export default Vue.extend({
                 stroke={this.trackColor}
                 fill="none"
                 class={`${name}__circle-outer`}
+                style={this.circleStrokeStyle}
               />
               <circle
                 cx={this.rPoints}

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -7964,7 +7964,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--undefined" style="width:112px;height:112px;font-size:20px;">
           <div class="t-progress__info">30%</div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="94.2477796076938  219.9114857512855" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -7975,7 +7975,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--success" style="width:112px;height:112px;font-size:20px;">
           <div class="t-progress__info"></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="314.1592653589793  0" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -7986,7 +7986,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--success" style="width:112px;height:112px;font-size:20px;">
           <div class="t-progress__info">75day</div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="157.07963267948966  157.07963267948966" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8001,7 +8001,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
           <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check t-progress__icon">
               <path fill="currentColor" d="M6.43 9.92l6.23-6.22.92.92-7.15 7.14L1.97 7.3l.92-.92 3.54 3.54z" fill-opacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="314.1592653589793  0" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8014,7 +8014,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
           <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon">
               <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="235.61944901923448  78.53981633974483" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8027,7 +8027,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
           <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon">
               <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fill-opacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="157.07963267948966  157.07963267948966" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8041,7 +8041,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--undefined" style="width:72px;height:72px;font-size:14px;">
           <div class="t-progress__info">30%</div><svg width="72" height="72" viewBox="0 0 72 72">
-            <circle cx="36" cy="36" r="34" stroke-width="4" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="36" cy="36" r="34" stroke-width="4" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="36" cy="36" r="34" stroke-width="4" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,72)" stroke-dasharray="60.31857894892403  140.74335088082273" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8052,7 +8052,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--undefined" style="width:112px;height:112px;font-size:20px;">
           <div class="t-progress__info">30%</div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="94.2477796076938  219.9114857512855" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8063,7 +8063,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/circle.vue correctl
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--undefined" style="width:160px;height:160px;font-size:36px;">
           <div class="t-progress__info">75%</div><svg width="160" height="160" viewBox="0 0 160 160">
-            <circle cx="80" cy="80" r="77" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="80" cy="80" r="77" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="80" cy="80" r="77" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,160)" stroke-dasharray="348.71678454846705  116.23892818282235" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8080,7 +8080,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/custom.vue correctl
     <div class="t-progress">
       <div class="t-progress--circle t-progress--status--undefined" style="width:112px;height:112px;font-size:20px;">
         <div class="t-progress__info"></div><svg width="112" height="112" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="263.89378290154264  50.265482457436704" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8108,7 +8108,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/custom.vue correctl
     <div class="t-progress">
       <div class="t-progress--circle t-progress--status--undefined" style="width:200px;height:200px;font-size:45px;">
         <div class="t-progress__info">30%</div><svg width="200" height="200" viewBox="0 0 200 200">
-          <circle cx="100" cy="100" r="90" stroke-width="20" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="100" cy="100" r="90" stroke-width="20" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="100" cy="100" r="90" stroke-width="20" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,200)" stroke-dasharray="150.79644737231007  351.85837720205683" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8126,7 +8126,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/custom.vue correctl
     <div class="t-progress">
       <div class="t-progress--circle t-progress--status--undefined" style="width:112px;height:112px;font-size:20px;">
         <div class="t-progress__info">44%</div><svg width="112" height="112" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="#aaa" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="#aaa" fill="none" class="t-progress__circle-outer" style="stroke:#aaa;"></circle>
           <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="138.2300767579509  175.92918860102844" class="t-progress__circle-inner" style="stroke:#52CC8D;"></circle>
         </svg>
       </div>
@@ -8145,7 +8145,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/custom.vue correctl
     <div class="t-progress">
       <div class="t-progress--circle t-progress--status--undefined" style="width:112px;height:112px;font-size:20px;">
         <div class="t-progress__info">&lt;div&gt;45days&lt;/div&gt;</div><svg width="112" height="112" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="138.2300767579509  175.92918860102844" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8314,7 +8314,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
       <div class="t-progress">
         <div class="t-progress--circle t-progress--status--undefined" style="width:112px;height:112px;font-size:20px;">
           <div class="t-progress__info">30%</div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="94.2477796076938  219.9114857512855" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8326,7 +8326,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
           <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon">
               <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="235.61944901923448  78.53981633974483" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8338,7 +8338,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
           <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon">
               <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fill-opacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="157.07963267948966  157.07963267948966" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8350,7 +8350,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
           <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-check t-progress__icon">
               <path fill="currentColor" d="M6.43 9.92l6.23-6.22.92.92-7.15 7.14L1.97 7.3l.92-.92 3.54 3.54z" fill-opacity="0.9"></path>
             </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+            <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
             <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="314.1592653589793  0" class="t-progress__circle-inner" style="stroke:;"></circle>
           </svg>
         </div>
@@ -8363,7 +8363,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
     <div class="t-progress">
       <div class="t-progress--circle t-progress--status--undefined" style="width:72px;height:72px;font-size:14px;">
         <div class="t-progress__info">30%</div><svg width="72" height="72" viewBox="0 0 72 72">
-          <circle cx="36" cy="36" r="34" stroke-width="4" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="36" cy="36" r="34" stroke-width="4" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="36" cy="36" r="34" stroke-width="4" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,72)" stroke-dasharray="60.31857894892403  140.74335088082273" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8372,7 +8372,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/size.vue correctly 
     <div class="t-progress">
       <div class="t-progress--circle t-progress--status--undefined" style="width:160px;height:160px;font-size:36px;">
         <div class="t-progress__info">75%</div><svg width="160" height="160" viewBox="0 0 160 160">
-          <circle cx="80" cy="80" r="77" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="80" cy="80" r="77" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="80" cy="80" r="77" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,160)" stroke-dasharray="348.71678454846705  116.23892818282235" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8407,7 +8407,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon">
             <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fill-opacity="0.9"></path>
           </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="251.32741228718348  62.83185307179585" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8437,7 +8437,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-progress__icon">
             <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
           </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="251.32741228718348  62.83185307179585" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>
@@ -8477,7 +8477,7 @@ exports[`ssr snapshot test renders ./examples/progress/demos/status.vue correctl
         <div class="t-progress__info"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-error t-progress__icon">
             <path fill="currentColor" d="M8.5 2h-1v9h1V2zm.1 10.8H7.4V14h1.2v-1.2z" fill-opacity="0.9"></path>
           </svg></div><svg width="112" height="112" viewBox="0 0 112 112">
-          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer"></circle>
+          <circle cx="56" cy="56" r="53" stroke-width="6" stroke="" fill="none" class="t-progress__circle-outer" style="stroke:;"></circle>
           <circle cx="56" cy="56" r="53" stroke-width="6" fill="none" stroke-linecap="round" transform="matrix(0,-1,1,0,0,112)" stroke-dasharray="251.32741228718348  62.83185307179585" class="t-progress__circle-inner" style="stroke:;"></circle>
         </svg>
       </div>

--- a/test/unit/progress/__snapshots__/demo.test.js.snap
+++ b/test/unit/progress/__snapshots__/demo.test.js.snap
@@ -714,6 +714,7 @@ exports[`Progress custom demo works fine 1`] = `
             r="53"
             stroke="#aaa"
             stroke-width="6"
+            style="stroke: #aaa;"
           />
           <circle
             class="t-progress__circle-inner"


### PR DESCRIPTION
fix #368

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？
日常 bug 修复

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/368
### 💡 需求背景和解决方案
https://github.com/Tencent/tdesign-vue/issues/368

### 📝 更新日志

fix(progress): 修复环形进度条不可更改未完成轨道颜色问题