### PR TITLE
feat: 用于支持 Uploader 批量合并上传功能

### DIFF
--- a/examples/upload/demos/file-flow-list-batch-upload.vue
+++ b/examples/upload/demos/file-flow-list-batch-upload.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="t-upload__file-flow-demo">
+    <t-upload
+      v-model="files"
+      action="https://service-bv448zsw-1257786608.gz.apigw.tencentcs.com/api/upload-demo"
+      placeholder="批量合并上传，会通过一个接口上传所有的文件"
+      theme="file-flow"
+      multiple
+      batchUpload
+      uploadAllFilesInOneRequest
+      :auto-upload="false"
+      :max="10"
+      @success="handleUploadSuccess"
+    ></t-upload>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TUploadFileFlow',
+
+  data() {
+    return {
+      files: [],
+    };
+  },
+
+  methods: {
+    handleUploadSuccess(e) {
+      console.log('batch upload', e);
+    },
+  },
+};
+</script>

--- a/examples/upload/upload.md
+++ b/examples/upload/upload.md
@@ -26,6 +26,8 @@ headers | Object | - | 设置上传的请求头部。TS 类型：`{[key: string]
 max | Number | 0 | 用于控制文件上传数量，值为 0 则不限制 | N
 method | String | POST | HTTP 请求类型。可选项：POST/GET/PUT/OPTION | N
 multiple | Boolean | false | 是否支持多选文件 | N
+uploadAllFilesInOneRequest | Boolean | false | 上传时是否只使用一个接口上传所有的文件，需配合 multiple 使用。 | N
+batchUpload | Boolean | false | 是否为合并上传模式，配合 multiple 与 uploadAllFilesInOneRequest 一起使用。当处于合并上传模式时，每次选择上传文件都会清空已上传的文件列表，等待再次合并上传。  | N
 name | String | 'file' | 文件上传时的名称 | N
 placeholder | String | - | 占位符 | N
 requestMethod | Function | - | 自定义上传方法。返回值 status 表示上传成功或失败，error 表示上传失败的原因，response 表示请求上传成功后的返回数据，response.url 表示上传成功后的图片地址。示例一：`{ status: 'fail', error: '上传失败', response }`。示例二：`{ status: 'success', response: { url: 'https://tdesign.gtimg.com/site/avatar.jpg' } }`。TS 类型：`(files: UploadFile) => Promise<RequestMethodResponse>` `interface RequestMethodResponse { status: 'success' | 'fail'; error?: string; response: { url?: string; [key: string]: any } }`。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/upload/type.ts) | N

--- a/src/upload/flow-list.tsx
+++ b/src/upload/flow-list.tsx
@@ -194,38 +194,58 @@ export default Vue.extend({
             </tr>
           )}
           {this.listFiles.map((file, index) => {
-            // 只有合并上传模式下，当前已上传文件列表有数据且当前为第一行的时候，才需要进行单元格合并
-            const isBatchFirstRow = this.batchUpload && this.files.length > 0 && index === 0;
-            const showRowAction = !this.batchUpload || isBatchFirstRow || (this.batchUpload && this.toUploadFiles.length > 0);
+            // 合并操作出现条件为：当前为合并上传模式且列表内没有待上传文件
+            const showBatchUploadAction = this.batchUpload && this.toUploadFiles.length === 0;
             return (
               <tr>
                 <td>{abridgeName(file.name, 7, 10)}</td>
                 <td>{returnFileSize(file.size)}</td>
                 <td>{this.renderStatus(file)}</td>
-                {showRowAction ? (
-                  <td
-                    rowspan={isBatchFirstRow ? this.listFiles.length : ''}
-                    class={isBatchFirstRow ? `${UPLOAD_NAME}__flow-table__batch-row` : ''}
-                  >
-                    <span
-                      class={`${UPLOAD_NAME}__flow-button`}
-                      onClick={(e: MouseEvent) => this.remove({
-                        e,
-                        index: isBatchFirstRow ? -1 : index,
-                        file: isBatchFirstRow ? null : file,
-                      })
-                      }
-                    >
-                      删除
-                    </span>
-                  </td>
-                ) : (
-                  ''
-                )}
+                {showBatchUploadAction ? this.renderBatchActionCol(index) : this.renderNormalActionCol(file, index)}
               </tr>
             );
           })}
         </table>
+      );
+    },
+
+    renderNormalActionCol(file: UploadFile, index: number) {
+      return (
+        <td>
+          <span
+            class={`${UPLOAD_NAME}__flow-button`}
+            onClick={(e: MouseEvent) => this.remove({
+              e,
+              index,
+              file,
+            })
+            }
+          >
+            删除
+          </span>
+        </td>
+      );
+    },
+
+    // batchUpload action col
+    renderBatchActionCol(index: number) {
+      // 第一行数据才需要合并单元格
+      return index === 0 ? (
+        <td rowspan={this.listFiles.length} class={`${UPLOAD_NAME}__flow-table__batch-row`}>
+          <span
+            class={`${UPLOAD_NAME}__flow-button`}
+            onClick={(e: MouseEvent) => this.remove({
+              e,
+              index: -1,
+              file: null,
+            })
+            }
+          >
+            删除
+          </span>
+        </td>
+      ) : (
+        ''
       );
     },
 

--- a/src/upload/props.ts
+++ b/src/upload/props.ts
@@ -120,6 +120,22 @@ export default {
     type: Boolean,
     default: true,
   },
+  /**
+   * 上传时是否只使用一个接口上传所有的文件，需配合 multiple 使用。
+   * */
+  uploadAllFilesInOneRequest: {
+    type: Boolean,
+    default: false,
+  },
+  /** 
+   * 是否为合并上传模式，配合 multiple 与 uploadAllFilesInOneRequest 一起使用。
+   当处于合并上传模式时，每次选择上传文件都会清空已上传的文件列表，等待再次合并上传。 
+   * */
+  batchUpload: {
+    type: Boolean,
+    default: false,
+  },
+
   /** 上传请求时是否携带 cookie */
   withCredentials: Boolean,
   /** 点击「取消上传」时触发 */

--- a/src/upload/type.ts
+++ b/src/upload/type.ts
@@ -6,6 +6,7 @@
  * */
 
 import { TNode } from '../common';
+import { HTMLInputEvent } from './interface';
 
 export interface TdUploadProps {
   /**
@@ -93,7 +94,7 @@ export interface TdUploadProps {
   /**
    * 自定义上传方法。返回值 status 表示上传成功或失败，error 表示上传失败的原因，response 表示请求上传成功后的返回数据，response.url 表示上传成功后的图片地址。示例一：`{ status: 'fail', error: '上传失败', response }`。示例二：`{ status: 'success', response: { url: 'https://tdesign.gtimg.com/site/avatar.jpg' } }`
    */
-  requestMethod?: (files: UploadFile) => Promise<RequestMethodResponse>;
+  requestMethod?: (files: UploadFile | UploadFile[]) => Promise<RequestMethodResponse>;
   /**
    * 是否显示上传进度
    * @default true
@@ -212,6 +213,7 @@ export type ResponseType = { error?: string; url?: string } & Record<string, any
 
 export interface FormatResponseContext {
   file: UploadFile;
+  currentFiles?: UploadFile[];
 }
 
 export interface RequestMethodResponse {

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -157,6 +157,23 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
     errorClasses(): ClassName {
       return this.tipsClasses.concat(`${name}__tips-error`);
     },
+    uploadInOneRequest(): boolean {
+      return this.multiple && this.uploadAllFilesInOneRequest;
+    },
+    canBatchUpload(): boolean {
+      return this.uploadInOneRequest && this.batchUpload;
+    },
+    uploadListTriggerText(): string {
+      let uploadText = '选择文件';
+      if (this.toUploadFiles?.length > 0 || this.files?.length > 0) {
+        if (this.theme === 'file-input' || (this.files?.length > 0 && this.canBatchUpload)) {
+          uploadText = '重新选择';
+        } else {
+          uploadText = '继续选择';
+        }
+      }
+      return uploadText;
+    },
   },
 
   methods: {
@@ -203,24 +220,37 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
 
     handleMultipleRemove(options: UploadRemoveOptions) {
       const changeCtx = { trigger: 'remove', ...options };
-      const files = this.files.concat();
-      files.splice(options.index, 1);
+      let files: UploadFile[];
+      if (!this.canBatchUpload) {
+        files = this.files.concat();
+        files.splice(options.index, 1);
+      } else {
+        // All files remove in batchUpload
+        files = [];
+        options.files = this.files.concat();
+      }
       this.emitChangeEvent(files, changeCtx);
       this.emitRemoveEvent(options);
     },
 
     handleListRemove(context: FlowRemoveContext) {
       const { file } = context;
-      const index = findIndex(this.toUploadFiles, (o) => o.name === file.name);
+      const index = findIndex(this.toUploadFiles, (o) => o.name === file?.name);
       if (index >= 0) {
         this.toUploadFiles.splice(index, 1);
       } else {
-        const index = findIndex(this.files, (o) => o.name === file.name);
+        const index = findIndex(this.files, (o) => o.name === file?.name);
         this.handleMultipleRemove({ e: context.e, index });
       }
     },
 
     uploadFiles(files: FileList) {
+      // 合并上传前则需要清空已上传列表
+      if (this.canBatchUpload && this.files?.length > 0) {
+        const context = { trigger: 'batch-clear' };
+        this.emitChangeEvent([], context);
+      }
+
       let tmpFiles = [...files];
       if (this.max) {
         tmpFiles = tmpFiles.slice(0, this.max - this.files.length);
@@ -261,27 +291,32 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
       });
     },
 
-    async upload(file: UploadFile): Promise<void> {
+    async upload(currentFiles: UploadFile | UploadFile[]): Promise<void> {
+      // support allFilesInOneRequest upload，兼容原有的单文件模式
+      const innerFiles = Array.isArray(currentFiles) ? currentFiles : [currentFiles];
+
       if (!this.action && !this.requestMethod) {
         console.error('TDesign Upload Error: one of action and requestMethod must be exist.');
         return;
       }
       this.errorMsg = '';
-      file.status = 'progress';
-      this.loadingFile = file;
-      // requestMethod 为父组件定义的自定义上传方法
-      if (this.requestMethod) {
-        this.handleRequestMethod(file);
-      } else {
-        // 模拟进度条
-        if (this.useMockProgress) {
+      innerFiles.forEach((file) => {
+        file.status = 'progress';
+        this.loadingFile = file;
+        if (!this.requestMethod && this.useMockProgress) {
           this.handleMockProgress(file);
         }
+      });
+
+      // requestMethod 为父组件定义的自定义上传方法
+      if (this.requestMethod) {
+        this.handleRequestMethod(innerFiles);
+      } else {
         const request = xhr;
         this.xhrReq = request({
           action: this.action,
           data: this.data,
-          file,
+          files: innerFiles,
           name: this.name,
           headers: this.headers,
           withCredentials: this.withCredentials,
@@ -307,18 +342,24 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
       }, 10);
     },
 
-    handleRequestMethod(file: UploadFile) {
+    handleRequestMethod(files: UploadFile[]) {
       if (!isFunction(this.requestMethod)) {
         console.warn('TDesign Upload Warn: `requestMethod` must be a function.');
         return;
       }
-      this.requestMethod(file).then((res: RequestMethodResponse) => {
+      // requestMethod first argument can be file or currentFiles
+      const requestMethodParam = this.uploadInOneRequest ? files : files[0];
+      this.requestMethod(requestMethodParam).then((res: RequestMethodResponse) => {
         if (!this.handleRequestMethodResponse(res)) return;
         if (res.status === 'success') {
-          this.handleSuccess({ file, response: res.response });
+          this.handleSuccess({ files, response: res.response });
         } else if (res.status === 'fail') {
           const r = res.response || {};
-          this.onError({ file, response: { ...r, error: res.error } });
+          this.onError({
+            file: this.uploadInOneRequest ? null : files[0],
+            files,
+            response: { ...r, error: res.error },
+          });
         }
       });
     },
@@ -346,24 +387,43 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
       return true;
     },
 
-    multipleUpload(files: Array<UploadFile>) {
-      files.forEach((file) => {
-        this.upload(file);
-      });
+    multipleUpload(currentFiles: Array<UploadFile>) {
+      if (this.uploadAllFilesInOneRequest) {
+        // 一个请求同时上传多个文件
+        this.upload(currentFiles);
+      } else {
+        currentFiles.forEach((file) => {
+          this.upload(file);
+        });
+      }
     },
 
-    onError(options: { event?: ProgressEvent; file: UploadFile; response?: any; resFormatted?: boolean }) {
+    onError(options: {
+      event?: ProgressEvent;
+      file: UploadFile;
+      files: UploadFile[];
+      response?: any;
+      resFormatted?: boolean;
+    }) {
       const {
-        event, file, response, resFormatted,
+        event, file, files, response, resFormatted,
       } = options;
-      file.status = 'fail';
-      this.loadingFile = file;
+      const innerFiles = Array.isArray(files) ? files : [file];
+
+      innerFiles.forEach((file) => {
+        file.status = 'fail';
+        this.loadingFile = file;
+      });
       let res = response;
       if (!resFormatted && typeof this.formatResponse === 'function') {
-        res = this.formatResponse(response, { file });
+        res = this.formatResponse(response, { file, currentFiles: files });
       }
       this.errorMsg = res?.error;
-      const context = { e: event, file };
+      const context = {
+        e: event,
+        file: this.uploadInOneRequest ? null : innerFiles[0],
+        currentFiles: innerFiles,
+      };
       emitEvent<Parameters<TdUploadProps['onFail']>>(this, 'fail', context);
     },
 
@@ -382,35 +442,54 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
       emitEvent<Parameters<TdUploadProps['onProgress']>>(this, 'progress', progressCtx);
     },
 
-    handleSuccess({ event, file, response }: SuccessContext) {
-      if (!file) throw new Error('Error file');
-      file.status = 'success';
+    handleSuccess({
+      event, file, files: currentFiles, response,
+    }: SuccessContext) {
+      const innerFiles = Array.isArray(currentFiles) ? currentFiles : [file];
+      if (innerFiles?.length <= 0) throw new Error('Error file');
+
+      innerFiles.forEach((file) => {
+        file.status = 'success';
+      });
+
       let res = response;
       if (typeof this.formatResponse === 'function') {
-        res = this.formatResponse(response, { file });
+        res = this.formatResponse(response, {
+          file: this.uploadInOneRequest ? null : innerFiles[0],
+          currentFiles: innerFiles,
+        });
       }
       // 如果返回值存在 error，则认为当前接口上传失败
       if (res?.error) {
         this.onError({
           event,
-          file,
+          file: this.uploadInOneRequest ? null : innerFiles[0],
+          files: innerFiles,
           response: res,
           resFormatted: true,
         });
         return;
       }
-      file.url = res.url || file.url;
-      // 从待上传文件队列中移除上传成功的文件
-      const index = findIndex(this.toUploadFiles, (o) => o.name === file.name);
-      this.toUploadFiles.splice(index, 1);
+      if (!this.uploadInOneRequest) {
+        innerFiles[0].url = res.url || innerFiles[0].url;
+      }
+
+      innerFiles.forEach((file) => {
+        // 从待上传文件队列中移除上传成功的文件
+        const index = findIndex(this.toUploadFiles, (o) => o.name === file.name);
+        this.toUploadFiles.splice(index, 1);
+      });
+
       // 上传成功的文件发送到 files
-      const newFile: UploadFile = { ...file, response: res };
-      const files = this.multiple ? this.files.concat(newFile) : [newFile];
+      const newFiles = innerFiles.map((file) => ({ ...file, response: res }));
+      const uploadedFiles = this.multiple ? this.files.concat(newFiles) : newFiles;
+
       const context = { e: event, response: res, trigger: 'upload-success' };
-      this.emitChangeEvent(files, context);
+      this.emitChangeEvent(uploadedFiles, context);
       const sContext = {
-        file,
-        fileList: files,
+        file: this.uploadInOneRequest ? null : newFiles[0],
+        fileList: uploadedFiles,
+        currentFiles: newFiles,
         e: event,
         response: res,
       };
@@ -491,7 +570,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
 
     getDefaultTrigger() {
       if (this.theme === 'file-input' || this.showUploadList) {
-        return <TButton variant="outline">{this.files?.length ? '重新上传' : '选择文件'}</TButton>;
+        return <TButton variant="outline">{this.uploadListTriggerText}</TButton>;
       }
       return (
         <TButton variant="outline">
@@ -604,6 +683,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
             upload={this.multipleUpload}
             cancel={this.cancelUpload}
             display={this.theme}
+            batchUpload={this.canBatchUpload}
             onImgPreview={this.handlePreviewImg}
             onChange={this.handleDragChange}
             onDragenter={this.handleDragenter}

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -15503,6 +15503,32 @@ exports[`ssr snapshot test renders ./examples/upload/demos/file-flow-list.vue co
 </div>
 `;
 
+exports[`ssr snapshot test renders ./examples/upload/demos/file-flow-list-batch-upload.vue correctly 1`] = `
+<div class="t-upload__file-flow-demo">
+  <div class="t-upload"><input type="file" multiple="multiple" accept="" hidden="hidden">
+    <div class="t-upload__flow t-upload__flow-file-flow">
+      <div class="t-upload__flow-op">
+        <div class="t-upload__trigger"><button type="button" class="t-button t-size-m t-button--variant-outline t-button--theme-default"><span class="t-button__text">选择文件</span></button></div><small class="t-size-s t-upload__flow-placeholder">批量合并上传，会通过一个接口上传所有的文件</small>
+      </div>
+      <table class="t-upload__flow-table">
+        <tr>
+          <th>文件名</th>
+          <th>大小</th>
+          <th>状态</th>
+          <th>操作</th>
+        </tr>
+        <tr>
+          <td colspan="4">
+            <div class="t-upload__flow-empty">点击上方“选择文件”或将文件拖拽到此区域</div>
+          </td>
+        </tr>
+      </table>
+      <div class="t-upload__flow-bottom"><button type="button" class="t-button t-size-m t-button--variant-base t-button--theme-default"><span class="t-button__text">取消</span></button><button type="button" disabled="disabled" class="t-button t-size-m t-button--variant-base t-button--theme-primary t-is-disabled"><span class="t-button__text">开始上传</span></button></div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`ssr snapshot test renders ./examples/upload/demos/image.vue correctly 1`] = `
 <div class="tdesign-demo-upload">
   <div class="tdesign-demo-upload-item">

--- a/test/unit/upload/__snapshots__/demo.test.js.snap
+++ b/test/unit/upload/__snapshots__/demo.test.js.snap
@@ -1,5 +1,179 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Upload base comp works fine 1`] = `
+<div
+  class="t-upload"
+>
+  <input
+    accept=""
+    hidden="hidden"
+    type="file"
+  />
+  <div
+    class="t-upload__single t-upload__single-file"
+  >
+    <div
+      class="t-upload__trigger"
+    >
+      <button
+        class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+        type="button"
+      >
+        <svg
+          class="t-icon t-icon-upload"
+          fill="none"
+          height="1em"
+          viewBox="0 0 16 16"
+          width="1em"
+        >
+          <path
+            d="M3.74 6.68L7.5 2.9v8.59h1V2.91l3.76 3.77.71-.7-4.62-4.63a.5.5 0 00-.7 0L3.03 5.97l.7.7z"
+            fill="currentColor"
+            fill-opacity="0.9"
+          />
+          <path
+            d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2h-1v2H3v-2H2z"
+            fill="currentColor"
+            fill-opacity="0.9"
+          />
+        </svg>
+        <span
+          class="t-button__text"
+        >
+          点击上传
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Upload base customDrag works fine 1`] = `
+<div
+  class="tdesign-demo-upload t-upload"
+>
+  <button
+    class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+    type="button"
+  >
+    <svg
+      class="t-icon t-icon-cloud-upload"
+      fill="none"
+      height="1em"
+      viewBox="0 0 16 16"
+      width="1em"
+    >
+      <path
+        d="M4.73 6.26l-.71.09A2.32 2.32 0 002 8.67c0 1.2.89 2.18 2 2.31v1a3.31 3.31 0 01-3-3.31 3.32 3.32 0 012.9-3.32A4.2 4.2 0 018 2c2 0 3.69 1.43 4.1 3.35 1.63.2 2.9 1.6 2.9 3.32a3.31 3.31 0 01-3 3.32v-1c1.11-.14 2-1.11 2-2.32 0-1.22-.9-2.2-2.02-2.32l-.71-.09-.15-.7A3.2 3.2 0 008 3a3.2 3.2 0 00-3.12 2.56l-.15.7z"
+        fill="currentColor"
+        fill-opacity="0.9"
+      />
+      <path
+        d="M6.14 10.72L7.5 9.39l.03 5.12 1.01-.01-.03-5.1 1.37 1.34.72-.7-2.26-2.2a.5.5 0 00-.7 0l-2.22 2.18.72.7z"
+        fill="currentColor"
+        fill-opacity="0.9"
+      />
+    </svg>
+    <span
+      class="t-button__text"
+    >
+      点击上传
+  
+    </span>
+  </button>
+   
+  <br />
+  <br />
+   
+  <div
+    class="t-upload"
+  >
+    <input
+      accept=""
+      hidden="hidden"
+      type="file"
+    />
+    <div
+      class="t-upload__dragger t-upload__dragger-center"
+    >
+      <div
+        class="t-upload__trigger"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-primary"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            自定义拖拽区域
+          </span>
+        </button>
+         
+        <!---->
+         
+        <br />
+        <br />
+      </div>
+    </div>
+    <transition-stub
+      class="t-upload__dialog"
+      duration="300"
+      name="t-dialog-zoom__vue"
+    >
+      <div
+        class="t-dialog__ctx t-dialog__ctx--fixed"
+        style="display: none;"
+      >
+        <div
+          class="t-dialog__mask"
+        />
+        <div
+          class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+          style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+        >
+          <div
+            class="t-dialog__header"
+          />
+          <span
+            class="t-dialog__close"
+          >
+            <svg
+              class="t-icon t-icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <div
+            class="t-dialog__body"
+          >
+            <div
+              class="t__dialog-body-img-box"
+            >
+              <img
+                alt=""
+                src=""
+              />
+            </div>
+          </div>
+          <div
+            class="t-dialog__footer"
+          />
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+</div>
+`;
+
 exports[`Upload base demo works fine 1`] = `
 <div
   class="t-upload"
@@ -46,4 +220,1291 @@ exports[`Upload base demo works fine 1`] = `
     </div>
   </div>
 </div>
+`;
+
+exports[`Upload base draggable works fine 1`] = `
+<div
+  class="tdesign-demo-block-column-large"
+>
+  <div
+    class="tdesign-demo-block-column"
+  >
+    <div>
+      是否自动上传：
+      <div
+        class="t-switch t-size-m t-is-checked"
+      >
+        <span
+          class="t-switch__handle"
+        />
+        <div
+          class="t-switch__content t-size-m"
+        />
+      </div>
+    </div>
+     
+    <div>
+      <div
+        class="t-radio-group t-size-m t-radio-group--filled"
+      >
+        <label
+          class="t-radio-button t-is-checked"
+        >
+          <input
+            class="t-radio-button__former"
+            name=""
+            type="radio"
+            value="file"
+          />
+          <span
+            class="t-radio-button__input"
+          />
+          <span
+            class="t-radio-button__label"
+          >
+            文件拖拽上传
+          </span>
+        </label>
+         
+        <label
+          class="t-radio-button"
+        >
+          <input
+            class="t-radio-button__former"
+            name=""
+            type="radio"
+            value="image"
+          />
+          <span
+            class="t-radio-button__input"
+          />
+          <span
+            class="t-radio-button__label"
+          >
+            图片拖拽上传
+          </span>
+        </label>
+        <div
+          class="t-radio-group__bg-block"
+          style="width: 0px; left: 0px;"
+        />
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="t-upload"
+  >
+    <input
+      accept=""
+      hidden="hidden"
+      type="file"
+    />
+    <div
+      class="t-upload__dragger t-upload__dragger-center"
+    >
+      <div
+        class="t-upload__trigger"
+      >
+        <div>
+          <span
+            class="t-upload--highlight"
+          >
+            点击上传
+          </span>
+          <span>
+              /  拖拽到此区域
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Upload base fileFlowList works fine 1`] = `
+<div
+  class="t-upload__file-flow-demo"
+>
+  <div
+    class="t-upload"
+  >
+    <input
+      accept=""
+      hidden="hidden"
+      multiple="multiple"
+      type="file"
+    />
+    <div
+      class="t-upload__flow t-upload__flow-file-flow"
+    >
+      <div
+        class="t-upload__flow-op"
+      >
+        <div
+          class="t-upload__trigger"
+        >
+          <button
+            class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+            type="button"
+          >
+            <span
+              class="t-button__text"
+            >
+              选择文件
+            </span>
+          </button>
+        </div>
+        <small
+          class="t-size-s t-upload__flow-placeholder"
+        >
+          支持批量上传文件，文件格式不限，最多只能上传 10 份文件
+        </small>
+      </div>
+      <table
+        class="t-upload__flow-table"
+      >
+        <tr>
+          <th>
+            文件名
+          </th>
+          <th>
+            大小
+          </th>
+          <th>
+            状态
+          </th>
+          <th>
+            操作
+          </th>
+        </tr>
+        <tr>
+          <td
+            colspan="4"
+          >
+            <div
+              class="t-upload__flow-empty"
+            >
+              点击上方“选择文件”或将文件拖拽到此区域
+            </div>
+          </td>
+        </tr>
+      </table>
+      <div
+        class="t-upload__flow-bottom"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-default"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            取消
+          </span>
+        </button>
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-primary t-is-disabled"
+          disabled="disabled"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            开始上传
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Upload base fileFlowListBatchUpload works fine 1`] = `
+<div
+  class="t-upload__file-flow-demo"
+>
+  <div
+    class="t-upload"
+  >
+    <input
+      accept=""
+      hidden="hidden"
+      multiple="multiple"
+      type="file"
+    />
+    <div
+      class="t-upload__flow t-upload__flow-file-flow"
+    >
+      <div
+        class="t-upload__flow-op"
+      >
+        <div
+          class="t-upload__trigger"
+        >
+          <button
+            class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+            type="button"
+          >
+            <span
+              class="t-button__text"
+            >
+              选择文件
+            </span>
+          </button>
+        </div>
+        <small
+          class="t-size-s t-upload__flow-placeholder"
+        >
+          批量合并上传，会通过一个接口上传所有的文件
+        </small>
+      </div>
+      <table
+        class="t-upload__flow-table"
+      >
+        <tr>
+          <th>
+            文件名
+          </th>
+          <th>
+            大小
+          </th>
+          <th>
+            状态
+          </th>
+          <th>
+            操作
+          </th>
+        </tr>
+        <tr>
+          <td
+            colspan="4"
+          >
+            <div
+              class="t-upload__flow-empty"
+            >
+              点击上方“选择文件”或将文件拖拽到此区域
+            </div>
+          </td>
+        </tr>
+      </table>
+      <div
+        class="t-upload__flow-bottom"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-default"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            取消
+          </span>
+        </button>
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-primary t-is-disabled"
+          disabled="disabled"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            开始上传
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Upload base image works fine 1`] = `
+<div
+  class="tdesign-demo-upload"
+>
+  <div
+    class="tdesign-demo-upload-item"
+  >
+    <div
+      class="t-upload"
+    >
+      <input
+        accept="image/*"
+        hidden="hidden"
+        type="file"
+      />
+      <ul
+        class="t-upload__card"
+        touploadfiles=""
+      >
+        <li
+          class="t-upload__card-item t-is--background"
+        >
+          <div
+            class="t-upload__card-container t-upload__card-box"
+          >
+            <svg
+              class="t-icon t-icon-add"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+            <p
+              class="t-size-s"
+            >
+              点击上传图片
+            </p>
+          </div>
+        </li>
+      </ul>
+      <transition-stub
+        class="t-upload__dialog"
+        duration="300"
+        name="t-dialog-zoom__vue"
+      >
+        <div
+          class="t-dialog__ctx t-dialog__ctx--fixed"
+          style="display: none;"
+        >
+          <div
+            class="t-dialog__mask"
+          />
+          <div
+            class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+            style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+          >
+            <div
+              class="t-dialog__header"
+            />
+            <span
+              class="t-dialog__close"
+            >
+              <svg
+                class="t-icon t-icon-close"
+                fill="none"
+                height="1em"
+                viewBox="0 0 16 16"
+                width="1em"
+              >
+                <path
+                  d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+            </span>
+            <div
+              class="t-dialog__body"
+            >
+              <div
+                class="t__dialog-body-img-box"
+              >
+                <img
+                  alt=""
+                  src=""
+                />
+              </div>
+            </div>
+            <div
+              class="t-dialog__footer"
+            />
+          </div>
+        </div>
+      </transition-stub>
+      <small
+        class="t-upload__tips t-size-s"
+      >
+        请选择单张图片文件上传（上传成功状态演示）
+      </small>
+    </div>
+  </div>
+   
+  <div
+    class="tdesign-demo-upload-item"
+  >
+    <div
+      class="t-upload"
+    >
+      <input
+        accept="image/*"
+        hidden="hidden"
+        type="file"
+      />
+      <ul
+        class="t-upload__card"
+        touploadfiles=""
+      >
+        <li
+          class="t-upload__card-item t-is--background"
+        >
+          <div
+            class="t-upload__card-container t-upload__card-box"
+          >
+            <svg
+              class="t-icon t-icon-add"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+            <p
+              class="t-size-s"
+            >
+              点击上传图片
+            </p>
+          </div>
+        </li>
+      </ul>
+      <transition-stub
+        class="t-upload__dialog"
+        duration="300"
+        name="t-dialog-zoom__vue"
+      >
+        <div
+          class="t-dialog__ctx t-dialog__ctx--fixed"
+          style="display: none;"
+        >
+          <div
+            class="t-dialog__mask"
+          />
+          <div
+            class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+            style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+          >
+            <div
+              class="t-dialog__header"
+            />
+            <span
+              class="t-dialog__close"
+            >
+              <svg
+                class="t-icon t-icon-close"
+                fill="none"
+                height="1em"
+                viewBox="0 0 16 16"
+                width="1em"
+              >
+                <path
+                  d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+            </span>
+            <div
+              class="t-dialog__body"
+            >
+              <div
+                class="t__dialog-body-img-box"
+              >
+                <img
+                  alt=""
+                  src=""
+                />
+              </div>
+            </div>
+            <div
+              class="t-dialog__footer"
+            />
+          </div>
+        </div>
+      </transition-stub>
+      <small
+        class="t-upload__tips t-size-s"
+      >
+        请选择单张图片文件上传（上传失败状态演示）
+      </small>
+    </div>
+  </div>
+   
+  <div
+    class="tdesign-demo-upload-item"
+  >
+    <div
+      class="t-upload"
+    >
+      <input
+        accept="image/*"
+        hidden="hidden"
+        type="file"
+      />
+      <ul
+        class="t-upload__card"
+        touploadfiles=""
+      >
+        <li
+          class="t-upload__card-item t-is--background"
+        >
+          <div
+            class="t-upload__card-container t-upload__card-box"
+          >
+            <svg
+              class="t-icon t-icon-add"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+            <p
+              class="t-size-s"
+            >
+              点击上传图片
+            </p>
+          </div>
+        </li>
+      </ul>
+      <transition-stub
+        class="t-upload__dialog"
+        duration="300"
+        name="t-dialog-zoom__vue"
+      >
+        <div
+          class="t-dialog__ctx t-dialog__ctx--fixed"
+          style="display: none;"
+        >
+          <div
+            class="t-dialog__mask"
+          />
+          <div
+            class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+            style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+          >
+            <div
+              class="t-dialog__header"
+            />
+            <span
+              class="t-dialog__close"
+            >
+              <svg
+                class="t-icon t-icon-close"
+                fill="none"
+                height="1em"
+                viewBox="0 0 16 16"
+                width="1em"
+              >
+                <path
+                  d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+            </span>
+            <div
+              class="t-dialog__body"
+            >
+              <div
+                class="t__dialog-body-img-box"
+              >
+                <img
+                  alt=""
+                  src=""
+                />
+              </div>
+            </div>
+            <div
+              class="t-dialog__footer"
+            />
+          </div>
+        </div>
+      </transition-stub>
+      <small
+        class="t-upload__tips t-size-s"
+      >
+        请选择单张图片文件上传（自定义预览图片地址）
+      </small>
+    </div>
+  </div>
+   
+  <div
+    class="tdesign-demo-upload-item"
+  >
+    <div
+      class="t-upload"
+    >
+      <input
+        accept="image/*"
+        hidden="hidden"
+        multiple="multiple"
+        type="file"
+      />
+      <ul
+        class="t-upload__card"
+        touploadfiles=""
+      >
+        <li
+          class="t-upload__card-item t-is--background"
+        >
+          <div
+            class="t-upload__card-container t-upload__card-box"
+          >
+            <svg
+              class="t-icon t-icon-add"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M7.35 8.65v3.85h1.3V8.65h3.85v-1.3H8.65V3.5h-1.3v3.85H3.5v1.3h3.85z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+            <p
+              class="t-size-s"
+            >
+              点击上传图片
+            </p>
+          </div>
+        </li>
+      </ul>
+      <transition-stub
+        class="t-upload__dialog"
+        duration="300"
+        name="t-dialog-zoom__vue"
+      >
+        <div
+          class="t-dialog__ctx t-dialog__ctx--fixed"
+          style="display: none;"
+        >
+          <div
+            class="t-dialog__mask"
+          />
+          <div
+            class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+            style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+          >
+            <div
+              class="t-dialog__header"
+            />
+            <span
+              class="t-dialog__close"
+            >
+              <svg
+                class="t-icon t-icon-close"
+                fill="none"
+                height="1em"
+                viewBox="0 0 16 16"
+                width="1em"
+              >
+                <path
+                  d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+            </span>
+            <div
+              class="t-dialog__body"
+            >
+              <div
+                class="t__dialog-body-img-box"
+              >
+                <img
+                  alt=""
+                  src=""
+                />
+              </div>
+            </div>
+            <div
+              class="t-dialog__footer"
+            />
+          </div>
+        </div>
+      </transition-stub>
+      <small
+        class="t-upload__tips t-size-s"
+      >
+        允许选择多张图片文件上传，最多只能上传 3 张图片
+      </small>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Upload base imgFlowList works fine 1`] = `
+<div
+  class="t-upload__img-flow-demo"
+>
+  <div
+    class="t-upload"
+  >
+    <input
+      accept="image/*"
+      hidden="hidden"
+      multiple="multiple"
+      type="file"
+    />
+    <div
+      class="t-upload__flow t-upload__flow-image-flow"
+    >
+      <div
+        class="t-upload__flow-op"
+      >
+        <div
+          class="t-upload__trigger"
+        >
+          <button
+            class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+            type="button"
+          >
+            <span
+              class="t-button__text"
+            >
+              选择文件
+            </span>
+          </button>
+        </div>
+        <small
+          class="t-size-s t-upload__flow-placeholder"
+        >
+          支持批量上传图片文件
+        </small>
+      </div>
+      <div
+        class="t-upload__flow-card-area"
+      >
+        <div
+          class="t-upload__flow-empty"
+        >
+          点击上方“选择文件”或将文件拖拽到此区域
+        </div>
+      </div>
+      <div
+        class="t-upload__flow-bottom"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-default"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            取消
+          </span>
+        </button>
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-primary t-is-disabled"
+          disabled="disabled"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            开始上传
+          </span>
+        </button>
+      </div>
+    </div>
+    <transition-stub
+      class="t-upload__dialog"
+      duration="300"
+      name="t-dialog-zoom__vue"
+    >
+      <div
+        class="t-dialog__ctx t-dialog__ctx--fixed"
+        style="display: none;"
+      >
+        <div
+          class="t-dialog__mask"
+        />
+        <div
+          class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+          style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+        >
+          <div
+            class="t-dialog__header"
+          />
+          <span
+            class="t-dialog__close"
+          >
+            <svg
+              class="t-icon t-icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <div
+            class="t-dialog__body"
+          >
+            <div
+              class="t__dialog-body-img-box"
+            >
+              <img
+                alt=""
+                src=""
+              />
+            </div>
+          </div>
+          <div
+            class="t-dialog__footer"
+          />
+        </div>
+      </div>
+    </transition-stub>
+  </div>
+</div>
+`;
+
+exports[`Upload base listType works fine 1`] = `
+<section
+  class="tdesign-demo-upload"
+>
+  <header
+    class="tdesign-demo-upload-header"
+  >
+    <div
+      class="t-upload"
+      showfilelist="true"
+    >
+      <input
+        accept=""
+        hidden="hidden"
+        multiple="multiple"
+        type="file"
+      />
+      <div
+        class="t-upload__single t-upload__single-file"
+      >
+        <div
+          class="t-upload__trigger"
+        >
+          <div>
+            <button
+              class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+              type="button"
+            >
+              <svg
+                class="t-icon t-icon-upload"
+                fill="none"
+                height="1em"
+                viewBox="0 0 16 16"
+                width="1em"
+              >
+                <path
+                  d="M3.74 6.68L7.5 2.9v8.59h1V2.91l3.76 3.77.71-.7-4.62-4.63a.5.5 0 00-.7 0L3.03 5.97l.7.7z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+                <path
+                  d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2h-1v2H3v-2H2z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+              <span
+                class="t-button__text"
+              >
+                选择文件
+              </span>
+            </button>
+             
+            <p
+              class="describe"
+            >
+              请上传txt文件，大小在60M以内
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+</section>
+`;
+
+exports[`Upload base requestMethod works fine 1`] = `
+<div
+  class="tdesign-demo-block-column-large"
+>
+  <div>
+    <div
+      class="t-radio-group t-size-m t-radio-group--filled"
+    >
+      <label
+        class="t-radio-button t-is-checked"
+      >
+        <input
+          class="t-radio-button__former"
+          name=""
+          type="radio"
+          value="requestSuccessMethod"
+        />
+        <span
+          class="t-radio-button__input"
+        />
+        <span
+          class="t-radio-button__label"
+        >
+          上传成功示例
+        </span>
+      </label>
+       
+      <label
+        class="t-radio-button"
+      >
+        <input
+          class="t-radio-button__former"
+          name=""
+          type="radio"
+          value="requestFailMethod"
+        />
+        <span
+          class="t-radio-button__input"
+        />
+        <span
+          class="t-radio-button__label"
+        >
+          上传失败示例
+        </span>
+      </label>
+      <div
+        class="t-radio-group__bg-block"
+        style="width: 0px; left: 0px;"
+      />
+    </div>
+  </div>
+   
+  <div
+    class="t-upload"
+  >
+    <input
+      accept=""
+      hidden="hidden"
+      type="file"
+    />
+    <div
+      class="t-upload__single t-upload__single-file"
+    >
+      <div
+        class="t-upload__trigger"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+          type="button"
+        >
+          <svg
+            class="t-icon t-icon-upload"
+            fill="none"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M3.74 6.68L7.5 2.9v8.59h1V2.91l3.76 3.77.71-.7-4.62-4.63a.5.5 0 00-.7 0L3.03 5.97l.7.7z"
+              fill="currentColor"
+              fill-opacity="0.9"
+            />
+            <path
+              d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2h-1v2H3v-2H2z"
+              fill="currentColor"
+              fill-opacity="0.9"
+            />
+          </svg>
+          <span
+            class="t-button__text"
+          >
+            点击上传
+          </span>
+        </button>
+      </div>
+    </div>
+    <small
+      class="t-upload__tips t-size-s"
+    >
+      自定义上传方法需要返回成功或失败信息
+    </small>
+  </div>
+</div>
+`;
+
+exports[`Upload base singleCustom works fine 1`] = `
+<div
+  class="tdesign-demo-upload"
+>
+  <div>
+    <div
+      class="t-upload"
+    >
+      <input
+        accept=""
+        hidden="hidden"
+        multiple="multiple"
+        type="file"
+      />
+      <div
+        class="t-upload__trigger"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-base t-button--theme-primary"
+          type="button"
+        >
+          <span
+            class="t-button__text"
+          >
+            自定义上传
+          </span>
+        </button>
+      </div>
+      <transition-stub
+        class="t-upload__dialog"
+        duration="300"
+        name="t-dialog-zoom__vue"
+      >
+        <div
+          class="t-dialog__ctx t-dialog__ctx--fixed"
+          style="display: none;"
+        >
+          <div
+            class="t-dialog__mask"
+          />
+          <div
+            class="t-dialog t-dialog--default t-dialog--top t-dialog__modal-default t-dialog--fixed"
+            style="width: auto; top: 10%; transform: translate(-50%, 0); transform-origin: 25% 25%; max-height: calc(100% - 10%);"
+          >
+            <div
+              class="t-dialog__header"
+            />
+            <span
+              class="t-dialog__close"
+            >
+              <svg
+                class="t-icon t-icon-close"
+                fill="none"
+                height="1em"
+                viewBox="0 0 16 16"
+                width="1em"
+              >
+                <path
+                  d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                  fill="currentColor"
+                  fill-opacity="0.9"
+                />
+              </svg>
+            </span>
+            <div
+              class="t-dialog__body"
+            >
+              <div
+                class="t__dialog-body-img-box"
+              >
+                <img
+                  alt=""
+                  src=""
+                />
+              </div>
+            </div>
+            <div
+              class="t-dialog__footer"
+            />
+          </div>
+        </div>
+      </transition-stub>
+      <small
+        class="t-upload__tips t-size-s"
+      >
+        上传文件大小在 5M 以内
+      </small>
+    </div>
+     
+    <!---->
+  </div>
+</div>
+`;
+
+exports[`Upload base singleInput works fine 1`] = `
+<div
+  class="tdesign-demo-upload"
+>
+  <div
+    style="width: 350px;"
+  >
+    <div
+      class="t-upload"
+    >
+      <input
+        accept=""
+        hidden="hidden"
+        type="file"
+      />
+      <div
+        class="t-upload__single t-upload__single-file-input"
+      >
+        <div
+          class="t-upload__single-input-preview t-input"
+        >
+          <div
+            class="t-input__inner t-upload__placeholder"
+          >
+            <span
+              class="t-upload__single-input-text"
+            >
+              未选择文件
+            </span>
+          </div>
+        </div>
+        <div
+          class="t-upload__trigger"
+        >
+          <button
+            class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+            type="button"
+          >
+            <span
+              class="t-button__text"
+            >
+              选择文件
+            </span>
+          </button>
+        </div>
+      </div>
+      <small
+        class="t-upload__tips t-size-s"
+      >
+        上传文件大小在 5M 以内
+      </small>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Upload base table works fine 1`] = `
+<section
+  class="tdesign-demo-upload-multiple"
+  style="width: 570px;"
+>
+  <header
+    class="tdesign-demo-upload-multiple-header"
+  >
+    <div
+      class="t-upload"
+    >
+      <input
+        accept="image/*"
+        hidden="hidden"
+        multiple="multiple"
+        type="file"
+      />
+      <div
+        class="t-upload__single t-upload__single-file"
+      >
+        <div
+          class="t-upload__trigger"
+        >
+          <button
+            class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+            type="button"
+          >
+            <svg
+              class="t-icon t-icon-upload"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M3.74 6.68L7.5 2.9v8.59h1V2.91l3.76 3.77.71-.7-4.62-4.63a.5.5 0 00-.7 0L3.03 5.97l.7.7z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+              <path
+                d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2h-1v2H3v-2H2z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+            <span
+              class="t-button__text"
+            >
+              选择文件
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </header>
+   
+  <div
+    class="tdesign-demo-upload-table"
+  >
+    <div
+      class="tdesign-demo-upload-table-header"
+    >
+      <div
+        class="tdesign-demo-upload-table__name"
+      >
+        文件名
+      </div>
+       
+      <div
+        class="tdesign-demo-upload-table__size"
+      >
+        大小
+      </div>
+       
+      <div
+        class="tdesign-demo-upload-table__status"
+      >
+        状态
+      </div>
+       
+      <div
+        class="tdesign-demo-upload-table__operator"
+      >
+        操作
+      </div>
+    </div>
+     
+    <div
+      class="tdesign-demo-upload-table--empty"
+    >
+      <p>
+        点击上方“选择文件”或将文件拖拽到此区域
+      </p>
+    </div>
+     
+  </div>
+   
+  <div
+    class="tdesign-demo-upload-bottom"
+  >
+    <button
+      class="t-button t-button--line"
+    >
+      取消
+    </button>
+     
+    <button
+      class="t-button t-button--primary"
+    >
+      开始上传
+    </button>
+  </div>
+</section>
 `;

--- a/test/unit/upload/__snapshots__/demo.test.js.snap
+++ b/test/unit/upload/__snapshots__/demo.test.js.snap
@@ -174,54 +174,6 @@ exports[`Upload base customDrag works fine 1`] = `
 </div>
 `;
 
-exports[`Upload base demo works fine 1`] = `
-<div
-  class="t-upload"
->
-  <input
-    accept=""
-    hidden="hidden"
-    type="file"
-  />
-  <div
-    class="t-upload__single t-upload__single-file"
-  >
-    <div
-      class="t-upload__trigger"
-    >
-      <button
-        class="t-button t-size-m t-button--variant-outline t-button--theme-default"
-        type="button"
-      >
-        <svg
-          class="t-icon t-icon-upload"
-          fill="none"
-          height="1em"
-          viewBox="0 0 16 16"
-          width="1em"
-        >
-          <path
-            d="M3.74 6.68L7.5 2.9v8.59h1V2.91l3.76 3.77.71-.7-4.62-4.63a.5.5 0 00-.7 0L3.03 5.97l.7.7z"
-            fill="currentColor"
-            fill-opacity="0.9"
-          />
-          <path
-            d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2h-1v2H3v-2H2z"
-            fill="currentColor"
-            fill-opacity="0.9"
-          />
-        </svg>
-        <span
-          class="t-button__text"
-        >
-          点击上传
-        </span>
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Upload base draggable works fine 1`] = `
 <div
   class="tdesign-demo-block-column-large"

--- a/test/unit/upload/__snapshots__/index.test.js.snap
+++ b/test/unit/upload/__snapshots__/index.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Upload :props :batchUpload 1`] = `
+<div class="t-upload"><input type="file" multiple="multiple" accept="" hidden="hidden">
+  <div class="t-upload__single t-upload__single-file">
+    <div class="t-upload__trigger"><button type="button" class="t-button t-size-m t-button--variant-outline t-button--theme-default"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-upload">
+          <path fill="currentColor" d="M3.74 6.68L7.5 2.9v8.59h1V2.91l3.76 3.77.71-.7-4.62-4.63a.5.5 0 00-.7 0L3.03 5.97l.7.7z" fill-opacity="0.9"></path>
+          <path fill="currentColor" d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2h-1v2H3v-2H2z" fill-opacity="0.9"></path>
+        </svg><span class="t-button__text">点击上传</span></button></div>
+  </div>
+</div>
+`;

--- a/test/unit/upload/demo.test.js
+++ b/test/unit/upload/demo.test.js
@@ -1,10 +1,69 @@
 import { mount } from '@vue/test-utils';
 import demo from '@/src/upload/index.ts';
+import customDrag from '@/examples/upload/demos/custom-drag.vue';
+import draggable from '@/examples/upload/demos/draggable.vue';
+import fileFlowListBatchUpload from '@/examples/upload/demos/file-flow-list-batch-upload.vue';
+import fileFlowList from '@/examples/upload/demos/file-flow-list.vue';
+import listType from '@/examples/upload/demos/listType.vue';
+import image from '@/examples/upload/demos/image.vue';
+import imgFlowList from '@/examples/upload/demos/img-flow-list.vue';
+import requestMethod from '@/examples/upload/demos/request-method.vue';
+import singleCustom from '@/examples/upload/demos/single-custom.vue';
+import singleInput from '@/examples/upload/demos/single-input.vue';
+import table from '@/examples/upload/demos/table.vue';
 
 // unit test for component in examples.
 describe('Upload', () => {
-  it('base demo works fine', () => {
+  it('base comp works fine', () => {
     const wrapper = mount(demo);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  // it('base demo works fine', () => {
+  //   const wrapper = mount(base);
+  //   expect(wrapper.element).toMatchSnapshot();
+  // });
+  it('base customDrag works fine', () => {
+    const wrapper = mount(customDrag);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base draggable works fine', () => {
+    const wrapper = mount(draggable);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base fileFlowListBatchUpload works fine', () => {
+    const wrapper = mount(fileFlowListBatchUpload);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base fileFlowList works fine', () => {
+    const wrapper = mount(fileFlowList);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base listType works fine', () => {
+    const wrapper = mount(listType);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base image works fine', () => {
+    const wrapper = mount(image);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base imgFlowList works fine', () => {
+    const wrapper = mount(imgFlowList);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base requestMethod works fine', () => {
+    const wrapper = mount(requestMethod);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base singleCustom works fine', () => {
+    const wrapper = mount(singleCustom);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base singleInput works fine', () => {
+    const wrapper = mount(singleInput);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+  it('base table works fine', () => {
+    const wrapper = mount(table);
     expect(wrapper.element).toMatchSnapshot();
   });
 });

--- a/test/unit/upload/index.test.js
+++ b/test/unit/upload/index.test.js
@@ -13,10 +13,21 @@ describe('Upload', () => {
       });
       expect(wrapper.exists()).toBe(true);
     });
+
+    it(':batchUpload', () => {
+      const wrapper = mount({
+        render() {
+          return <Upload multiple uploadAllFilesInOneRequest batchUpload></Upload>;
+        },
+      });
+
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 
   // test events
-  // describe('@event', () => {});
+  // describe('@event', () => {
+  // });
 
   // // test slots
   // describe('<slot>', () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [x] 新特性提交

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

暂无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

具体场景：
多文件上传时， 可以支持一个请求包含多个文件同时上传的能力。当前 TD 只支持单文件上传的模式。

增加新的API：

* uploadAllFilesInOneRequest: 上传时是否只使用一个接口上传所有的文件，需配合 multiple 使用。
* batchUpload: 是否为合并上传模式，配合 multiple 与 uploadAllFilesInOneRequest 一起使用。当处于合并上传模式时，每次选择上传文件都会清空已上传的文件列表，等待再次合并上传。

<img width="852" alt="image" src="https://user-images.githubusercontent.com/8725110/156569614-adf027e4-fd8b-43cb-ad61-81f79e6fd1ce.png">


<img width="638" alt="image" src="https://user-images.githubusercontent.com/8725110/156568692-9bee98ca-9636-4a08-ac52-29841d251bed.png">

注：需要配合 tdesign-common 的 PR 共同使用
[#267 feat: 用于支持单个请求可以上传多个文件](https://github.com/Tencent/tdesign-common/pull/267)


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Uploader): 支持一个请求合并上传文件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
