### PR TITLE
fix(tree-select): add tree-select class polyfill

### DIFF
--- a/src/cascader/utils/item.ts
+++ b/src/cascader/utils/item.ts
@@ -19,7 +19,7 @@ export function getNodeStatusClass(node: TreeNode, CLASSNAMES: any, cascaderCont
   const {
     checkStrictly, multiple, value, max,
   } = cascaderContext;
-  const expandedActive = !checkStrictly && node.expanded && (multiple ? !node.isLeaf() : true);
+  const expandedActive = (!checkStrictly && node.expanded && (multiple ? !node.isLeaf() : true)) || (checkStrictly && node.expanded);
 
   const isLeaf = node.isLeaf();
 

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -120,6 +120,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       if (classList.includes(INPUT_WRAP_CLASS)) {
         this.attrInputClass = classList.filter((item) => item !== INPUT_WRAP_CLASS);
       }
+      this.$el.setAttribute('class', INPUT_WRAP_CLASS);
     },
     addListenders() {
       this.$watch(

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -75,6 +75,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
     classes(): ClassName {
       return [
         `${prefix}-select`,
+        `${prefix}-select-polyfill`,
         {
           [CLASSNAMES.STATUS.disabled]: this.tDisabled,
           [CLASSNAMES.STATUS.active]: this.visible,
@@ -471,25 +472,29 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
             {searchInput}
             {this.showArrow && !this.showLoading && (
               <FakeArrow
-                overlayClassName={`${prefix}-select__right-icon`}
+                overlayClassName={`${prefix}-select__right-icon ${prefix}-select__right-icon-polyfill`}
                 overlayStyle={iconStyle}
                 isActive={this.visible && !this.tDisabled}
               />
             )}
             <CloseCircleFilledIcon
               v-show={this.showClose && !this.showLoading}
-              class={[`${prefix}-select__right-icon`, `${prefix}-select__right-icon-clear`]}
+              class={[
+                `${prefix}-select__right-icon`,
+                `${prefix}-select__right-icon-polyfill`,
+                `${prefix}-select__right-icon-clear`,
+              ]}
               size={this.size}
               nativeOnClick={this.clear}
             />
             <Loading
               v-show={this.showLoading}
-              class={`${prefix}-select__right-icon ${prefix}-select__active-icon`}
+              class={`${prefix}-select__right-icon ${prefix}-select__right-icon-polyfill ${prefix}-select__active-icon`}
               size="small"
             />
           </div>
           <div slot="content">
-            <p v-show={this.showLoading} class={`${prefix}-select__loading-tips`}>
+            <p v-show={this.showLoading} class={`${prefix}-select__loading-tips ${prefix}-select__right-icon-polyfill`}>
               {this.loadingTextSlot}
             </p>
             {treeItem}

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -2916,15 +2916,15 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
     </svg></div> <br><br>
   <div class="t-select__wrap" style="width:400px;">
-    <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">see empty data in TreeSelect</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">see empty data in TreeSelect</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="see empty data in TreeSelect" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -2932,13 +2932,13 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
     </div>
   </div> <br><br>
   <div class="t-select__wrap" style="width:400px;">
-    <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">see loading text in TreeSelect</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">see loading text in TreeSelect</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="see loading text in TreeSelect" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -2946,15 +2946,15 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
     </div>
   </div> <br><br>
   <div class="t-select__wrap" style="width:400px;">
-    <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">tree select</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">tree select</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
       <div class="t-input__wrap t-select__input">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="tree select" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -4000,15 +4000,15 @@ exports[`ssr snapshot test renders ./examples/form/demos/disabled.vue correctly 
       <div class="t-form__controls" style="margin-left:100px;">
         <div class="t-form__controls-content">
           <div class="t-select__wrap">
-            <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
               <div class="t-input__wrap t-select__input" style="display:none;">
                 <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"></div>
-              </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+              </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-              </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+              </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
                 <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
               </svg>
-              <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+              <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
                   <foreignObject x="1" y="1" width="12" height="12">
                     <div class="t-loading__gradient-conic"></div>
                   </foreignObject>
@@ -15647,15 +15647,15 @@ exports[`ssr snapshot test renders ./examples/tree/demos/sync.vue correctly 1`] 
 exports[`ssr snapshot test renders ./examples/tree-select/demos/base.vue correctly 1`] = `
 <div class="tdesign-tree-select-base">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
       <div class="t-input__wrap t-select__input">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="请选择" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15668,19 +15668,19 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/base.vue correct
 exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue correctly 1`] = `
 <div class="tdesign-tree-select-collapsed">
   <div class="demo-space t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="guangzhou" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="guangzhou" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span title="shenzhen" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;"><span class="t-tag--text" style="max-width:300px;">shenzhen</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark">+1</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15688,19 +15688,19 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
     </div>
   </div>
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="guangzhou" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="guangzhou" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span title="shenzhen" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;"><span class="t-tag--text" style="max-width:300px;">shenzhen</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark">更多...</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15713,15 +15713,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/collapsed.vue co
 exports[`ssr snapshot test renders ./examples/tree-select/demos/dvalue.vue correctly 1`] = `
 <div class="tdesign-tree-select-base">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="shenzhen,guangzhou" class="t-select__single">shenzhen,guangzhou</span>
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="shenzhen,guangzhou" class="t-select__single">shenzhen,guangzhou</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen,guangzhou" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15739,15 +15739,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/filterable.vue c
     </div>
   </div>
   <div class="t-select__wrap" style="width:300px;">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15760,15 +15760,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/filterable.vue c
 exports[`ssr snapshot test renders ./examples/tree-select/demos/lazy.vue correctly 1`] = `
 <div class="tdesign-tree-select-lazy">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="请选择" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15781,19 +15781,19 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/lazy.vue correct
 exports[`ssr snapshot test renders ./examples/tree-select/demos/multiple.vue correctly 1`] = `
 <div class="tdesign-tree-select-multiple">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="guangzhou" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="guangzhou" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span title="shenzhen" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">shenzhen</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15806,15 +15806,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/multiple.vue cor
 exports[`ssr snapshot test renders ./examples/tree-select/demos/prefix.vue correctly 1`] = `
 <div class="tdesign-tree-select-prefix">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"><svg class="t-icon t-icon-user"><use href="#t-icon-user"></use></svg></span><span class="t-select__placeholder">请输入</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
+    <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"><svg class="t-icon t-icon-user"><use href="#t-icon-user"></use></svg></span><span class="t-select__placeholder">请输入</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="请输入" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15827,15 +15827,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/prefix.vue corre
 exports[`ssr snapshot test renders ./examples/tree-select/demos/props.vue correctly 1`] = `
 <div class="tdesign-tree-select-base">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15848,14 +15848,14 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/props.vue correc
 exports[`ssr snapshot test renders ./examples/tree-select/demos/valuedisplay.vue correctly 1`] = `
 <div class="tdesign-tree-select-valuedisplay">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span> () <div class="t-input__wrap t-select__input" style="display:none;">
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span> () <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15863,15 +15863,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuedisplay.vue
     </div>
   </div>
   <div class="tree-select-multiple t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span>
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span>
       <div class="t-input__wrap t-select__input">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15884,15 +15884,15 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuedisplay.vue
 exports[`ssr snapshot test renders ./examples/tree-select/demos/valuetype.vue correctly 1`] = `
 <div class="tdesign-tree-select-base">
   <div class="t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="[object Object]" class="t-select__single">[object Object]</span>
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="[object Object]" class="t-select__single">[object Object]</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="[object Object]" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>
@@ -15900,19 +15900,19 @@ exports[`ssr snapshot test renders ./examples/tree-select/demos/valuetype.vue co
     </div>
   </div>
   <div class="tree-select-multiple t-select__wrap">
-    <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="[object Object]" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">undefined</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display:none;">请选择</span><span title="[object Object]" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">undefined</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span title="[object Object]" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"><span class="t-tag--text" style="max-width:300px;">undefined</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span>
       <div class="t-input__wrap t-select__input" style="display:none;">
         <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"></div>
-      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size:medium;">
+      </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size:medium;">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display:none;">
+      </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display:none;">
         <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
       </svg>
-      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
+      <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display:none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
           <foreignObject x="1" y="1" width="12" height="12">
             <div class="t-loading__gradient-conic"></div>
           </foreignObject>

--- a/test/unit/select/__snapshots__/demo.test.js.snap
+++ b/test/unit/select/__snapshots__/demo.test.js.snap
@@ -342,7 +342,7 @@ exports[`Steps Steps creatable demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -768,7 +768,7 @@ exports[`Steps Steps filterable demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -815,7 +815,7 @@ exports[`Steps Steps filterable demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -867,7 +867,7 @@ exports[`Steps Steps group demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -913,7 +913,7 @@ exports[`Steps Steps group demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -1672,7 +1672,7 @@ exports[`Steps Steps remoteSearch demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -1719,7 +1719,7 @@ exports[`Steps Steps remoteSearch demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m t-is-readonly"

--- a/test/unit/tag-input/__snapshots__/demo.test.js.snap
+++ b/test/unit/tag-input/__snapshots__/demo.test.js.snap
@@ -6,7 +6,7 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -62,7 +62,7 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -123,7 +123,7 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -191,7 +191,7 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -234,7 +234,7 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -295,7 +295,7 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -381,7 +381,7 @@ exports[`TagInput TagInput customTagVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -459,7 +459,7 @@ exports[`TagInput TagInput customTagVue demo works fine 1`] = `
   <br />
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -564,7 +564,7 @@ exports[`TagInput TagInput excessVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -625,7 +625,7 @@ exports[`TagInput TagInput excessVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -692,7 +692,7 @@ exports[`TagInput TagInput maxVue demo works fine 1`] = `
   style="width: 100%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -718,7 +718,7 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-s t-input--prefix"
@@ -774,7 +774,7 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -830,7 +830,7 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-l t-input--prefix"
@@ -900,7 +900,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap t-tag-input"
+      class="t-input__wrap"
     >
       <div
         class="t-input t-size-m t-is-disabled t-input--prefix"
@@ -944,7 +944,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap t-tag-input"
+      class="t-input__wrap"
     >
       <div
         class="t-input t-size-m t-is-readonly t-input--prefix"
@@ -993,7 +993,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap t-tag-input"
+      class="t-input__wrap"
     >
       <div
         class="t-input t-size-m t-is-success t-input--prefix"
@@ -1080,7 +1080,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap t-tag-input"
+      class="t-input__wrap"
     >
       <div
         class="t-input t-size-m t-is-warning t-input--prefix"
@@ -1167,7 +1167,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap t-tag-input"
+      class="t-input__wrap"
     >
       <div
         class="t-input t-size-m t-is-error t-input--prefix"
@@ -1254,7 +1254,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -1328,7 +1328,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -1402,7 +1402,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -1476,7 +1476,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap t-tag-input"
+    class="t-input__wrap"
   >
     <div
       class="t-input t-size-m t-input--prefix"

--- a/test/unit/tree-select/__snapshots__/demo.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/demo.test.js.snap
@@ -23,7 +23,7 @@ exports[`TreeSelect base demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
       >
         <div
           class="t-input t-size-m"
@@ -168,7 +168,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         +1
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -308,7 +308,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         更多...
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -461,7 +461,7 @@ exports[`TreeSelect filterable demo works fine 1`] = `
         shenzhen
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -558,7 +558,7 @@ exports[`TreeSelect lazy demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -704,7 +704,7 @@ exports[`TreeSelect multiple demo works fine 1`] = `
         +2
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -812,7 +812,7 @@ exports[`TreeSelect prefix demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -916,7 +916,7 @@ exports[`TreeSelect props demo works fine 1`] = `
         shenzhen
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -1020,7 +1020,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         [object Object]
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div
@@ -1160,7 +1160,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         +2
       </span>
       <div
-        class="t-input__wrap t-select__input"
+        class="t-input__wrap"
         style="display: none;"
       >
         <div

--- a/test/unit/tree-select/__snapshots__/demo.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/demo.test.js.snap
@@ -8,7 +8,7 @@ exports[`TreeSelect base demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -38,7 +38,7 @@ exports[`TreeSelect base demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -54,7 +54,7 @@ exports[`TreeSelect base demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -68,7 +68,7 @@ exports[`TreeSelect base demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -105,7 +105,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
     class="demo-space t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -184,7 +184,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -200,7 +200,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -214,7 +214,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -245,7 +245,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -324,7 +324,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -340,7 +340,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -354,7 +354,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -440,7 +440,7 @@ exports[`TreeSelect filterable demo works fine 1`] = `
     style="width: 300px;"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -477,7 +477,7 @@ exports[`TreeSelect filterable demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -493,7 +493,7 @@ exports[`TreeSelect filterable demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -507,7 +507,7 @@ exports[`TreeSelect filterable demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -544,7 +544,7 @@ exports[`TreeSelect lazy demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -574,7 +574,7 @@ exports[`TreeSelect lazy demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -590,7 +590,7 @@ exports[`TreeSelect lazy demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -604,7 +604,7 @@ exports[`TreeSelect lazy demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -641,7 +641,7 @@ exports[`TreeSelect multiple demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -720,7 +720,7 @@ exports[`TreeSelect multiple demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -736,7 +736,7 @@ exports[`TreeSelect multiple demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -750,7 +750,7 @@ exports[`TreeSelect multiple demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -787,7 +787,7 @@ exports[`TreeSelect prefix demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-has-prefix t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"
     >
       <span
         class="t-select__left-icon"
@@ -828,7 +828,7 @@ exports[`TreeSelect prefix demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -844,7 +844,7 @@ exports[`TreeSelect prefix demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -858,7 +858,7 @@ exports[`TreeSelect prefix demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -895,7 +895,7 @@ exports[`TreeSelect props demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -932,7 +932,7 @@ exports[`TreeSelect props demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -948,7 +948,7 @@ exports[`TreeSelect props demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -962,7 +962,7 @@ exports[`TreeSelect props demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -999,7 +999,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
     class="t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -1036,7 +1036,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -1052,7 +1052,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -1066,7 +1066,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg
@@ -1097,7 +1097,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
     class="tree-select-multiple t-select__wrap"
   >
     <div
-      class="t-select t-size-m t-select-selected t-select__popup-reference"
+      class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"
     >
       <span
         class="t-select__placeholder"
@@ -1176,7 +1176,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         </div>
       </div>
       <svg
-        class="t-fake-arrow t-select__right-icon"
+        class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill"
         fill="none"
         height="16"
         style="font-size: medium;"
@@ -1192,7 +1192,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         />
       </svg>
       <svg
-        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear"
+        class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear"
         fill="none"
         height="1em"
         style="display: none;"
@@ -1206,7 +1206,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         />
       </svg>
       <div
-        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"
+        class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"
         style="display: none;"
       >
         <svg

--- a/test/unit/tree-select/__snapshots__/index.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/index.test.js.snap
@@ -2,15 +2,15 @@
 
 exports[`TreeSelect :props :clearable 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -21,19 +21,19 @@ exports[`TreeSelect :props :clearable 1`] = `
 
 exports[`TreeSelect :props :defaultValue 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" title="shenzhen"><span class="t-tag--text" style="max-width: 300px;">shenzhen</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+  <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" title="shenzhen"><span class="t-tag--text" style="max-width: 300px;">shenzhen</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
       <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
     </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" title="guangzhou"><span class="t-tag--text" style="max-width: 300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
       <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
     </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+2</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -44,15 +44,15 @@ exports[`TreeSelect :props :defaultValue 1`] = `
 
 exports[`TreeSelect :props :disabled 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-is-disabled t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m t-is-disabled"><input disabled="disabled" autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -63,15 +63,15 @@ exports[`TreeSelect :props :disabled 1`] = `
 
 exports[`TreeSelect :props :empty string 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -82,15 +82,15 @@ exports[`TreeSelect :props :empty string 1`] = `
 
 exports[`TreeSelect :props :filterable 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -101,13 +101,13 @@ exports[`TreeSelect :props :filterable 1`] = `
 
 exports[`TreeSelect :props :loading 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -118,15 +118,15 @@ exports[`TreeSelect :props :loading 1`] = `
 
 exports[`TreeSelect :props :loadingText 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -137,15 +137,15 @@ exports[`TreeSelect :props :loadingText 1`] = `
 
 exports[`TreeSelect :props :max 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -156,15 +156,15 @@ exports[`TreeSelect :props :max 1`] = `
 
 exports[`TreeSelect :props :minCollapsedNum 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+-1</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+-1</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -175,15 +175,15 @@ exports[`TreeSelect :props :minCollapsedNum 1`] = `
 
 exports[`TreeSelect :props :multiple 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -194,15 +194,15 @@ exports[`TreeSelect :props :multiple 1`] = `
 
 exports[`TreeSelect :props :placeholder 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">please select address</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">please select address</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="please select address" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -213,15 +213,15 @@ exports[`TreeSelect :props :placeholder 1`] = `
 
 exports[`TreeSelect :props :popupProps 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -232,15 +232,15 @@ exports[`TreeSelect :props :popupProps 1`] = `
 
 exports[`TreeSelect :props :size 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-l t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-l t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-l t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-l t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-l"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: large;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: large;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-l t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-l t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -251,15 +251,15 @@ exports[`TreeSelect :props :size 1`] = `
 
 exports[`TreeSelect :props :treeProps 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -270,15 +270,15 @@ exports[`TreeSelect :props :treeProps 1`] = `
 
 exports[`TreeSelect :props :value 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
+  <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -289,15 +289,15 @@ exports[`TreeSelect :props :value 1`] = `
 
 exports[`TreeSelect :props :valueType 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="[object Object]" class="t-select__single">[object Object]</span>
+  <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="[object Object]" class="t-select__single">[object Object]</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="[object Object]" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -308,15 +308,15 @@ exports[`TreeSelect :props :valueType 1`] = `
 
 exports[`TreeSelect <slot> <collapsedItems> 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -327,15 +327,15 @@ exports[`TreeSelect <slot> <collapsedItems> 1`] = `
 
 exports[`TreeSelect <slot> <empty> 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -346,13 +346,13 @@ exports[`TreeSelect <slot> <empty> 1`] = `
 
 exports[`TreeSelect <slot> <loadingText> 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -363,15 +363,15 @@ exports[`TreeSelect <slot> <loadingText> 1`] = `
 
 exports[`TreeSelect <slot> <prefixIcon> 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"><div><i>icon</i></div></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"><div><i>icon</i></div></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -382,15 +382,15 @@ exports[`TreeSelect <slot> <prefixIcon> 1`] = `
 
 exports[`TreeSelect function :collapsedItems 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -401,15 +401,15 @@ exports[`TreeSelect function :collapsedItems 1`] = `
 
 exports[`TreeSelect function :empty 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -420,13 +420,13 @@ exports[`TreeSelect function :empty 1`] = `
 
 exports[`TreeSelect function :loadingText 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -437,15 +437,15 @@ exports[`TreeSelect function :loadingText 1`] = `
 
 exports[`TreeSelect function :prefixIcon 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
+  <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
     <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
-    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon" style="font-size: medium;">
+    </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
-    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-clear" style="display: none;">
+    </svg><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
     </svg>
-    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
+    <div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__right-icon-polyfill t-select__active-icon" style="display: none;"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" class="t-loading__gradient t-icon-loading" size="small">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>

--- a/test/unit/tree-select/__snapshots__/index.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TreeSelect :props :clearable 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -26,7 +26,7 @@ exports[`TreeSelect :props :defaultValue 1`] = `
     </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" title="guangzhou"><span class="t-tag--text" style="max-width: 300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
       <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
     </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+2</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -45,7 +45,7 @@ exports[`TreeSelect :props :defaultValue 1`] = `
 exports[`TreeSelect :props :disabled 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m t-is-disabled"><input disabled="disabled" autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -64,7 +64,7 @@ exports[`TreeSelect :props :disabled 1`] = `
 exports[`TreeSelect :props :empty string 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -83,7 +83,7 @@ exports[`TreeSelect :props :empty string 1`] = `
 exports[`TreeSelect :props :filterable 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input">
+    <div class="t-input__wrap">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -102,7 +102,7 @@ exports[`TreeSelect :props :filterable 1`] = `
 exports[`TreeSelect :props :loading 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
@@ -119,7 +119,7 @@ exports[`TreeSelect :props :loading 1`] = `
 exports[`TreeSelect :props :loadingText 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -138,7 +138,7 @@ exports[`TreeSelect :props :loadingText 1`] = `
 exports[`TreeSelect :props :max 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -157,7 +157,7 @@ exports[`TreeSelect :props :max 1`] = `
 exports[`TreeSelect :props :minCollapsedNum 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+-1</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -176,7 +176,7 @@ exports[`TreeSelect :props :minCollapsedNum 1`] = `
 exports[`TreeSelect :props :multiple 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -195,7 +195,7 @@ exports[`TreeSelect :props :multiple 1`] = `
 exports[`TreeSelect :props :placeholder 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">please select address</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="please select address" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -214,7 +214,7 @@ exports[`TreeSelect :props :placeholder 1`] = `
 exports[`TreeSelect :props :popupProps 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -233,7 +233,7 @@ exports[`TreeSelect :props :popupProps 1`] = `
 exports[`TreeSelect :props :size 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-l t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-l t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-l"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: large;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -252,7 +252,7 @@ exports[`TreeSelect :props :size 1`] = `
 exports[`TreeSelect :props :treeProps 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -271,7 +271,7 @@ exports[`TreeSelect :props :treeProps 1`] = `
 exports[`TreeSelect :props :value 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -290,7 +290,7 @@ exports[`TreeSelect :props :value 1`] = `
 exports[`TreeSelect :props :valueType 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="[object Object]" class="t-select__single">[object Object]</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="[object Object]" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -309,7 +309,7 @@ exports[`TreeSelect :props :valueType 1`] = `
 exports[`TreeSelect <slot> <collapsedItems> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -328,7 +328,7 @@ exports[`TreeSelect <slot> <collapsedItems> 1`] = `
 exports[`TreeSelect <slot> <empty> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -347,7 +347,7 @@ exports[`TreeSelect <slot> <empty> 1`] = `
 exports[`TreeSelect <slot> <loadingText> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
@@ -364,7 +364,7 @@ exports[`TreeSelect <slot> <loadingText> 1`] = `
 exports[`TreeSelect <slot> <prefixIcon> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"><div><i>icon</i></div></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -383,7 +383,7 @@ exports[`TreeSelect <slot> <prefixIcon> 1`] = `
 exports[`TreeSelect function :collapsedItems 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -402,7 +402,7 @@ exports[`TreeSelect function :collapsedItems 1`] = `
 exports[`TreeSelect function :empty 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -421,7 +421,7 @@ exports[`TreeSelect function :empty 1`] = `
 exports[`TreeSelect function :loadingText 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
@@ -438,7 +438,7 @@ exports[`TreeSelect function :loadingText 1`] = `
 exports[`TreeSelect function :prefixIcon 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap t-select__input" style="display: none;">
+    <div class="t-input__wrap" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

关联common修复PR：

https://github.com/Tencent/tdesign-common/pull/286
https://github.com/Tencent/tdesign-common/pull/287

### 🤔 这个 PR 的性质是？

<!--
我们的大致分类有
日常 bug 修复 | 新特性提交 ｜ 文档改进 ｜ 演示代码改进 ｜ 组件样式/交互改进 |  CI/CD改进 ｜
重构 | 代码风格优化 |测试用例 | 分支合并 ｜其他
-->

- [x] 日常 bug 修复
修复因select，重构导致的样式问题


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
### tree-select 样式修复
before

<img width="706" alt="image" src="https://user-images.githubusercontent.com/35833812/157580572-caf04755-d194-46a9-aea0-3769328e1464.png">

after

<img width="633" alt="image" src="https://user-images.githubusercontent.com/35833812/157580595-66a9bb29-b4bc-4538-8711-e4cc6af939e9.png">

### cascader样式修复

before
<img width="908" alt="image" src="https://user-images.githubusercontent.com/35833812/157629066-19e7e019-acf4-489a-a9d0-bf3d01bdbf51.png">


after
<img width="844" alt="image" src="https://user-images.githubusercontent.com/35833812/157628956-72209cd3-27aa-4e10-a80c-c9e7cca96de9.png">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: cascade可选任意一级缺少高亮状态。 https://github.com/Tencent/tdesign-vue-next/issues/114
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
