### PR TITLE
fix: IE9 popup弹出点击空白两次才会消失

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -250,7 +250,7 @@ export default Vue.extend({
       );
     },
     handleDocumentClick() {
-      if (this.contentClicked || this.refClicked) {
+      if (this.contentClicked) {
         if (this.contentClicked) {
           this.contentClicked = false;
         }
@@ -332,12 +332,12 @@ export default Vue.extend({
           directives: destroyOnClose
             ? undefined
             : [
-                {
-                  name: 'show',
-                  rawName: 'v-show',
-                  value: visible,
-                  expression: 'visible',
-                } as VNodeDirective,
+                    {
+                      name: 'show',
+                      rawName: 'v-show',
+                      value: visible,
+                      expression: 'visible',
+                    } as VNodeDirective,
             ],
           on: {
             mousedown: () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
```this.refClicked``` 判断导致IE下需点击两次空白处才能关闭

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): IE9 popup弹出点击空白两次才会消失

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
