### PR TITLE
fix(treeselect): fix TreeSelect async data can't show correct label

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -25,6 +25,7 @@ import { TreeSelectValue, TdTreeSelectProps, TreeSelectNodeValue } from './type'
 import { ClassName, TreeOptionData } from '../common';
 import { prefix } from '../config';
 import { RemoveOptions, NodeOptions } from './interface';
+import { TreeInstanceFunctions } from '../tree/type';
 
 export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect')).extend({
   name: 'TTreeSelect',
@@ -314,6 +315,13 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
       };
       this.search(this.filterText);
     },
+    // get tree data, even load async load
+    getTreeData() {
+      return ((this.$refs.tree as TreeInstanceFunctions)?.getItems() || []).map((item) => ({
+        label: item.data[this.realLabel],
+        value: item.data[this.realValue],
+      }));
+    },
     async changeNodeInfo() {
       await this.value;
 
@@ -343,8 +351,10 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
         if (data[i][this.realValue] === targetValue) {
           return { label: data[i][this.realLabel], value: data[i][this.realValue] };
         }
-        if (data[i]?.children) {
-          const result = this.getTreeNode(data[i]?.children, targetValue);
+        const childrenData = data[i]?.children;
+        if (childrenData) {
+          const data = Array.isArray(childrenData) ? childrenData : this.getTreeData();
+          const result = this.getTreeNode(data, targetValue);
           if (!isNil(result)) {
             return result;
           }


### PR DESCRIPTION
fix #537 

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[TreeSelect] treeSelect异步加载的时候，选中后，input框显示的是value的值不是lable的值
https://github.com/Tencent/tdesign-vue/issues/537

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

当前获取 Children 节点数据时，并未考虑到异步数据的情况，不支持 `children: true`的模式。

本次修复：
当 children 不是 Array 数组时，通过 Tree 获取实际节点来生成 data 数据。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TreeSelect): 异步加载数据的情况下，label 展示错误的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
