### PR TITLE
fix: cascader ellipisis tooltip

### DIFF
--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -32,7 +32,9 @@ export default mixins(keepAnimationMixins).extend({
   name,
 
   directives: { ripple },
-
+  components: {
+    Tooltip,
+  },
   props: {
     node: {
       type: Object as PropType<CascaderItemPropsType['node']>,
@@ -109,12 +111,12 @@ export default mixins(keepAnimationMixins).extend({
       const isEllipsis = getLabelIsEllipsis(node, cascaderContext.size);
       if (isEllipsis) {
         return (
-          <span class={`${ComponentClassName}-label`} role="label">
-            {label}
-            <div class={`${ComponentClassName}-label--ellipsis`}>
-              <Tooltip content={node.label} placement="top-left" />
-            </div>
-          </span>
+          <Tooltip content={node.label} placement="top-left">
+            <span class={`${ComponentClassName}-label`} role="label">
+              {label}
+              <div class={`${ComponentClassName}-label--ellipsis`}></div>
+            </span>
+          </Tooltip>
         );
       }
       return (

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -109,21 +109,19 @@ export default mixins(keepAnimationMixins).extend({
     function RenderLabelContent(node: TreeNode, cascaderContext: CascaderContextType) {
       const label = RenderLabelInner(node, cascaderContext);
       const isEllipsis = getLabelIsEllipsis(node, cascaderContext.size);
-      if (isEllipsis) {
-        return (
-          <Tooltip content={node.label} placement="top-left">
-            <span class={`${ComponentClassName}-label`} role="label">
-              {label}
-              <div class={`${ComponentClassName}-label--ellipsis`}></div>
-            </span>
-          </Tooltip>
-        );
-      }
-      return (
+      const labelNode = (
         <span class={[`${ComponentClassName}-label`]} role="label">
           {label}
         </span>
       );
+      if (isEllipsis) {
+        return (
+          <Tooltip content={node.label} placement="top-left">
+            {labelNode}
+          </Tooltip>
+        );
+      }
+      return labelNode;
     }
 
     function RenderCheckBox(


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

resolve #561

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

修复文字过长时不显示 tooltip

before

<img width="404" alt="image" src="https://user-images.githubusercontent.com/35833812/158344141-86179e84-f964-43c9-987f-c2a41f3f0fcd.png">

after

<img width="871" alt="image" src="https://user-images.githubusercontent.com/35833812/158344306-0421697b-413c-4c71-94ff-5b218e0b194d.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(cascader): 修复文字过长时不显示 `tooltip`


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
