### PR TITLE
fix(input): input readonly not emit focus

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -217,7 +217,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     },
     emitFocus(e: FocusEvent) {
       this.inputValue = this.value;
-      if (this.tDisabled || this.readonly) return;
+      if (this.tDisabled) return;
       this.focused = true;
       emitEvent<Parameters<TdInputProps['onFocus']>>(this, 'focus', this.value, { e });
     },


### PR DESCRIPTION
fix #580

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#580 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

需要和原生浏览器保持一致，当前仅会触发 blur 事件，不会触发 focus 事件

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): focus 事件触发不应该因为 readonly 而停止 emit

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
