### PR TITLE
fix: 去掉在ie9中会删除disabled属性

### DIFF
--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -5,7 +5,6 @@ import TLoading from '../loading';
 import props from './props';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
 import ripple from '../utils/ripple';
-import { getIEVersion } from '../_common/js/utils/helper';
 import { getKeepAnimationMixins } from '../config-provider/config-receiver';
 import mixins from '../utils/mixins';
 
@@ -25,26 +24,6 @@ export default mixins(keepAnimationMixins).extend({
   props,
 
   directives: { ripple },
-
-  methods: {
-    handleIE() {
-      if (getIEVersion() <= 9) {
-        this.$nextTick(() => {
-          this.$el.removeAttribute('disabled');
-        });
-      }
-    },
-  },
-
-  watch: {
-    disabled() {
-      this.handleIE();
-    },
-
-    loading() {
-      this.handleIE();
-    },
-  },
 
   render(): VNode {
     let buttonContent = renderContent(this, 'default', 'content');
@@ -96,9 +75,5 @@ export default mixins(keepAnimationMixins).extend({
         {buttonContent}
       </button>
     );
-  },
-
-  mounted() {
-    this.handleIE();
   },
 });


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
之前为了解决ie9下disabled属性会让文字的覆盖样式失效，把disabled属性给去掉了，可这样影响到了事件的禁用。
所以优先功能，去掉删除disabled这个方案。

- fix(button): 去掉删除disabled
