### PR TITLE
fix(progress): display text when percent value=10

### DIFF
--- a/src/progress/progress.tsx
+++ b/src/progress/progress.tsx
@@ -14,7 +14,6 @@ import {
   PRO_THEME, CIRCLE_SIZE, CIRCLE_SIZE_PX, STATUS_ICON, CIRCLE_FONT_SIZE_RATIO,
 } from './constants';
 import props from './props';
-// import { RenderTNodeTemplate } from '../utils/render-tnode';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { Styles } from '../common';
 
@@ -192,7 +191,7 @@ export default Vue.extend({
             <div class={`${name}__inner`} style={this.barStyle}>
               {this.percentage > PLUMP_SEPARATE && labelContent}
             </div>
-            {this.percentage < PLUMP_SEPARATE && labelContent}
+            {this.percentage <= PLUMP_SEPARATE && labelContent}
           </div>
         )}
 

--- a/test/unit/progress/__snapshots__/index.test.js.snap
+++ b/test/unit/progress/__snapshots__/index.test.js.snap
@@ -257,6 +257,25 @@ exports[`Progress :props :theme :theme line and plump progress have t-progress__
 </div>
 `;
 
+exports[`Progress :props :theme :theme line and plump progress have t-progress__inner class 3`] = `
+<div class="t-progress">
+  <div class="t-progress__bar t-progress--plump t-progress--under-ten" style="border-radius: undefinedpx;">
+    <div class="t-progress__inner" style="width: 10%;"></div>
+    <div class="t-progress__info">10%</div>
+  </div>
+</div>
+`;
+
+exports[`Progress :props :theme :theme line and plump progress have t-progress__inner class 4`] = `
+<div class="t-progress">
+  <div class="t-progress__bar t-progress--plump t-progress--over-ten" style="border-radius: undefinedpx;">
+    <div class="t-progress__inner" style="width: 11%;">
+      <div class="t-progress__info">11%</div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Progress :props :theme :theme:circle 1`] = `
 <div class="t-progress">
   <div class="t-progress--circle t-progress--status--undefined" style="width: 112px; height: 112px; font-size: 20px;">

--- a/test/unit/progress/index.test.js
+++ b/test/unit/progress/index.test.js
@@ -33,6 +33,10 @@ describe('Progress', () => {
         });
         const lineClass = lineWrapper.element.querySelector('.t-progress__inner');
 
+        expect(lineClass !== undefined && lineClass !== null).toBe(true);
+        expect(lineWrapper).toMatchSnapshot();
+
+        // < 10% plump
         const plumpWrapper = mount({
           render() {
             return <Progress theme={'plump'}></Progress>;
@@ -40,12 +44,35 @@ describe('Progress', () => {
         });
         const plumpClass = plumpWrapper.element.querySelector('.t-progress__inner');
 
-        expect(lineClass !== undefined && lineClass !== null).toBe(true);
-        expect(lineWrapper).toMatchSnapshot();
-
         expect(plumpClass !== undefined && plumpClass !== null).toBe(true);
         expect(plumpWrapper).toMatchSnapshot();
+        expect(plumpWrapper.element.querySelector('.t-progress__info').innerHTML).toBe('0%');
+
+        // =10% plump
+        const plump10Wrapper = mount({
+          render() {
+            return <Progress theme={'plump'} percentage={10}></Progress>;
+          },
+        });
+        const plump10Class = plump10Wrapper.element.querySelector('.t-progress__inner');
+
+        expect(plump10Class !== undefined && plump10Class !== null).toBe(true);
+        expect(plump10Wrapper).toMatchSnapshot();
+        expect(plump10Wrapper.element.querySelector('.t-progress__info').innerHTML).toBe('10%');
+
+        // >10% plump
+        const plump11Wrapper = mount({
+          render() {
+            return <Progress theme={'plump'} percentage={11}></Progress>;
+          },
+        });
+        const plump11Class = plump11Wrapper.element.querySelector('.t-progress__inner');
+
+        expect(plump11Class !== undefined && plump11Class !== null).toBe(true);
+        expect(plump11Wrapper).toMatchSnapshot();
+        expect(plump11Class.querySelector('.t-progress__info').innerHTML).toBe('11%');
       });
+
       it(':theme circle progress has t-progress__circle-outer and t-progress__circle-inner class', () => {
         const wrapper = mount({
           render() {
@@ -90,6 +117,7 @@ describe('Progress', () => {
       });
     });
 
+    // label相关单测
     describe(':label', () => {
       it(':label is String, equal to "custom label test"', () => {
         const wrapper = mount({
@@ -148,6 +176,7 @@ describe('Progress', () => {
       });
     });
 
+    // color相关单测
     describe(':color', () => {
       it(':color is String, equal to "#aaa"', () => {
         const wrapper = mount({
@@ -188,6 +217,7 @@ describe('Progress', () => {
       });
     });
 
+    // strokeWidth 相关单测
     describe(':strokeWidth', () => {
       it(':strokeWidth is String, equal to "50px"', () => {
         const wrapper = mount({
@@ -209,6 +239,7 @@ describe('Progress', () => {
       });
     });
 
+    // size相关单测
     describe(':size', () => {
       Object.values(CIRCLE_SIZE).forEach((size) => {
         it(`:size is String, equal to "${size}"`, () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 日常 bug 修复
- 增加plump相关更细分的单测


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/569

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(progress): theme为plump时percent为10没有展示文案

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
