### PR TITLE
refactor(input): refactor input wrap

### DIFF
--- a/examples/input/input.md
+++ b/examples/input/input.md
@@ -6,19 +6,21 @@
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 align | String | left | 文本内容位置，居左/居中/居右。可选项：left/center/right | N
-autocomplete | String | - | 是否开启自动填充功能，HTML5 原生属性，[点击查看详情](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)。可选项：on/off | N
+autocomplete | String | - | 是否开启自动填充功能，HTML5 原生属性，[点击查看详情](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) | N
 autofocus | Boolean | false | 自动聚焦 | N
 autoWidth | Boolean | false | 宽度随内容自适应 | N
 clearable | Boolean | false | 是否可清空 | N
 disabled | Boolean | false | 是否禁用输入框 | N
-format | Function | - | 指定输入框展示值的格式。TS 类型：`(value: InputValue) => number | string` | N
+format | Function | - | 【开发中】指定输入框展示值的格式。TS 类型：`(value: InputValue) => number | string` | N
+inputClass | String / Object / Array | - | t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`。TS 类型：`ClassName`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 label | String / Slot / Function | - | 左侧文本。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 maxcharacter | Number | - | 用户最多可以输入的字符个数，一个中文汉字表示两个字符长度。`maxcharacter` 和 `maxlength` 二选一使用 | N
-maxlength | Number | - | 用户最多可以输入的文本长度。值小于等于 0 的时候，则不限制输入长度。`maxcharacter` 和 `maxlength` 二选一使用 | N
+maxlength | Number | - | 用户最多可以输入的文本长度，一个中文等于一个计数长度。值小于等于 0 的时候，则表示不限制输入长度。`maxcharacter` 和 `maxlength` 二选一使用 | N
 name | String | - | 名称 | N
 placeholder | String | undefined | 占位符 | N
 prefixIcon | Slot / Function | - | 组件前置图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
-readonly | Boolean | false | 输入框是否只读 | N
+readonly | Boolean | false | 只读状态 | N
+showClearIconOnEmpty | Boolean | false | 输入框内容为空时，悬浮状态是否显示清空按钮，默认不显示 | N
 size | String | medium | 输入框尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 status | String | - | 输入框状态。可选项：success/warning/error | N
 suffix | String / Slot / Function | - | 后置图标前的后置内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N

--- a/examples/select-input/demos/custom-tag.vue
+++ b/examples/select-input/demos/custom-tag.vue
@@ -3,7 +3,7 @@
     <!-- 单选，使用 valueDisplay 插槽定义选中的某一项的内容，也可使用同名渲染函数 props.valueDisplay -->
     <t-select-input :value="selectValue1" placeholder="Please Select" clearable @clear="onClear">
       <template #valueDisplay>
-        <span class="displaySpan">
+        <span v-if="selectValue1" class="displaySpan">
           <control-platform-icon class="tdesign-demo-select-input__img" />
           {{ selectValue1.label }}
         </span>

--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -2,12 +2,11 @@ import Vue, { VNode } from 'vue';
 
 // utils
 import isEqual from 'lodash/isEqual';
-import isEmpty from 'lodash/isEmpty';
 import { prefix } from '../config';
 import TreeStore from '../_common/js/tree/tree-store';
 import { emitEvent } from '../utils/event';
 import { getPropsApiByEvent } from '../utils/helper';
-import { getTreeValue, getValue } from './utils/helper';
+import { getTreeValue, getValue, isEmptyValues } from './utils/helper';
 
 // common logic
 import { treeNodesEffect, treeStoreExpendEffect } from './utils/cascader';
@@ -185,7 +184,7 @@ export default Vue.extend({
       setValue(val, 'invalid-value');
       console.warn('TDesign Cascader Warn:', 'cascader props value invalid, v-model automatic calibration');
     }
-    if (!isEmpty(value)) {
+    if (!isEmptyValues(value)) {
       this.scopeVal = getValue(value, valueType, multiple);
     }
 

--- a/src/cascader/utils/cascader.ts
+++ b/src/cascader/utils/cascader.ts
@@ -47,7 +47,10 @@ export const treeStoreExpendEffect = (
     if (val) {
       expandedMap.set(val, true);
       const node = treeStore.getNode(val);
-      if (!node) return;
+      if (!node) {
+        treeStore.refreshNodes();
+        return;
+      }
       node.getParents().forEach((tn: TreeNode) => {
         expandedMap.set(tn.value, true);
       });

--- a/src/cascader/utils/helper.ts
+++ b/src/cascader/utils/helper.ts
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash/isEmpty';
 import {
   TreeNode,
   CascaderContextType,
@@ -58,6 +59,17 @@ export const getValue = (value: CascaderValue, valueType: CascaderProps['valueTy
   }
   return value[(value as Array<CascaderValue>).length - 1];
 };
+
+/**
+ * 空值校验
+ * 补充value为Number时的空值校验逻辑，排除NaN
+ * @param value
+ * @returns
+ */
+export function isEmptyValues(value: unknown): boolean {
+  if (typeof value === 'number' && !isNaN(value)) return false;
+  return isEmpty(value);
+}
 
 export default {
   getFullPathLabel,

--- a/src/common.ts
+++ b/src/common.ts
@@ -8,7 +8,7 @@ export type TNode<T = undefined> = T extends undefined
 export type JsxNode = TNodeReturnValue;
 
 export type AttachNodeReturnValue = HTMLElement | Element | Document;
-export type AttachNode = CSSSelector | (() => AttachNodeReturnValue);
+export type AttachNode = CSSSelector | ((triggerNode?: HTMLElement) => AttachNodeReturnValue);
 
 // 与滚动相关的容器类型，因为 document 上没有 scroll 相关属性, 因此排除document
 export type ScrollContainerElement = Window | HTMLElement;

--- a/src/config-provider/context.ts
+++ b/src/config-provider/context.ts
@@ -1,0 +1,33 @@
+import defaultConfig from './zh_CN_config';
+
+// TODO 替换 zh_CN_config 配置拆分，local内未走查，走查后更换，暂时使用现有配置
+// import defaultLocale from '../_common/js/locale/zh_CN';
+// export type Locale = typeof defaultLocale;
+
+export enum EAnimationType {
+  ripple = 'ripple',
+  expand = 'expand',
+  fade = 'fade',
+}
+
+export const defaultClassPrefix = 't';
+
+export const defaultAnimation: {
+  include: string[];
+  exclude: string[];
+} = {
+  include: [EAnimationType.ripple, EAnimationType.expand, EAnimationType.fade],
+  exclude: [],
+};
+
+export const defaultGlobalConfig = {
+  animation: defaultAnimation,
+  classPrefix: defaultClassPrefix,
+  ...defaultConfig,
+};
+
+export type GlobalConfig = typeof defaultGlobalConfig;
+
+export interface Config {
+  globalConfig?: GlobalConfig;
+}

--- a/src/config-provider/index.ts
+++ b/src/config-provider/index.ts
@@ -2,5 +2,8 @@ import withInstall from '../utils/withInstall';
 import _ConnfigProvider from './config-provider';
 
 export * from './type';
+
+export * from './useConfig';
+
 export const ConnfigProvider = withInstall(_ConnfigProvider);
 export default ConnfigProvider;

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -42,7 +42,6 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       focused: false,
       renderType: this.type,
       inputValue: this.value,
-      attrInputClass: [],
     };
   },
   computed: {
@@ -112,18 +111,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       this.addListenders();
     }
   },
-  mounted() {
-    this.getAttrClass();
-  },
   methods: {
-    // fix behave differently with vue3 https://v3.cn.vuejs.org/guide/migration/attrs-includes-class-style.html
-    getAttrClass() {
-      const classList = [...this.$el.classList];
-      if (classList.includes(INPUT_WRAP_CLASS)) {
-        this.attrInputClass = classList.filter((item) => item !== INPUT_WRAP_CLASS);
-      }
-      this.$el.setAttribute('class', INPUT_WRAP_CLASS);
-    },
     addListenders() {
       this.$watch(
         () => this.value + this.placeholder,
@@ -304,11 +292,11 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
 
     const classes = [
       this.inputClasses,
+      this.inputClass,
       {
         [`${name}--prefix`]: prefixIcon || labelContent,
         [`${name}--suffix`]: suffixIcon || suffixContent,
       },
-      ...this.attrInputClass,
     ];
     const inputNode = (
       <div

--- a/src/input/props.ts
+++ b/src/input/props.ts
@@ -34,6 +34,10 @@ export default {
   format: {
     type: Function as PropType<TdInputProps['format']>,
   },
+  /** t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]` */
+  inputClass: {
+    type: [String, Object, Array] as PropType<TdInputProps['inputClass']>,
+  },
   /** 左侧文本 */
   label: {
     type: [String, Function] as PropType<TdInputProps['label']>,
@@ -60,7 +64,7 @@ export default {
   prefixIcon: {
     type: Function as PropType<TdInputProps['prefixIcon']>,
   },
-  /** 输入框是否只读 */
+  /** 只读状态 */
   readonly: Boolean,
   /** 输入框内容为空时，悬浮状态是否显示清空按钮，默认不显示 */
   showClearIconOnEmpty: Boolean,

--- a/src/input/type.ts
+++ b/src/input/type.ts
@@ -4,7 +4,7 @@
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
  * */
 
-import { TNode, SizeEnum } from '../common';
+import { TNode, SizeEnum, ClassName } from '../common';
 
 export interface TdInputProps {
   /**
@@ -42,6 +42,10 @@ export interface TdInputProps {
    */
   format?: (value: InputValue) => number | string;
   /**
+   * t-input 同级类名，示例：'name1 name2 name3' 或 `['name1', 'name2']` 或 `[{ 'name1': true }]`
+   */
+  inputClass?: ClassName;
+  /**
    * 左侧文本
    */
   label?: string | TNode;
@@ -67,7 +71,7 @@ export interface TdInputProps {
    */
   prefixIcon?: TNode;
   /**
-   * 输入框是否只读
+   * 只读状态
    * @default false
    */
   readonly?: boolean;

--- a/src/select-input/select-input.tsx
+++ b/src/select-input/select-input.tsx
@@ -55,6 +55,8 @@ export default defineComponent({
 
   render(h) {
     // 浮层显示的受控与非受控
+    // 浮层显示的受控与非受控
+    const visibleProps = { visible: this.popupVisible ?? this.innerPopupVisible };
 
     const mainContent = (
       <Popup
@@ -76,10 +78,11 @@ export default defineComponent({
             {
               commonInputProps: this.commonInputProps,
               onInnerClear: this.onInnerClear,
+              popupVisible: visibleProps.visible,
             },
             h,
           )
-          : this.renderSelectSingle(h)}
+          : this.renderSelectSingle(h, visibleProps.visible)}
       </Popup>
     );
 

--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -9,10 +9,12 @@ import { InputValue } from '../input';
 import TagInput, { TagInputValue, InputValueChangeContext } from '../tag-input';
 import Loading from '../loading';
 import useDefaultValue from '../hooks/useDefaultValue';
+import { usePrefixClass } from '../config-provider';
 
 export interface RenderSelectMultipleParams {
   commonInputProps: SelectInputCommonProperties;
   onInnerClear: (context: { e: MouseEvent }) => void;
+  popupVisible: boolean;
 }
 
 const DEFAULT_KEYS = {
@@ -23,6 +25,7 @@ const DEFAULT_KEYS = {
 
 export default function useMultiple(props: TdSelectInputProps, context: SetupContext) {
   const { inputValue } = toRefs(props);
+  const classPrefix = usePrefixClass();
   const instance = getCurrentInstance();
   const tagInputRef = ref();
   const [tInputValue, setTInputValue] = useDefaultValue(
@@ -67,6 +70,12 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
       valueDisplay: props.valueDisplay,
       value: tags.value,
       inputValue: tInputValue.value || '',
+      inputProps: {
+        readonly: !props.allowInput || props.readonly,
+        inputClass: {
+          [`${classPrefix.value}-input--focused`]: p.popupVisible,
+        },
+      },
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
     };
 

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -1,5 +1,5 @@
 import {
-  SetupContext, ref, watch, computed, toRefs, getCurrentInstance,
+  SetupContext, ref, computed, toRefs, getCurrentInstance,
 } from '@vue/composition-api';
 
 import isObject from 'lodash/isObject';
@@ -11,6 +11,8 @@ import Input, { InputValue } from '../input';
 import Loading from '../loading';
 
 import { useTNodeJSX } from '../hooks/tnode';
+import { usePrefixClass } from '../config-provider';
+import useDefaultValue from '../hooks/useDefaultValue';
 
 // single 和 multiple 共有特性
 const COMMON_PROPERTIES = [
@@ -41,9 +43,18 @@ function getInputValue(value: TdSelectInputProps['value'], keys: TdSelectInputPr
 export default function useSingle(props: TdSelectInputProps, context: SetupContext) {
   const instance = getCurrentInstance();
 
-  const { value, keys } = toRefs(props);
+  const { value, keys, inputValue: propsInputValue } = toRefs(props);
+  const classPrefix = usePrefixClass();
+
+  const [inputValue, setInputValue] = useDefaultValue(
+    propsInputValue,
+    props.defaultInputValue ?? '',
+    props.onInputChange,
+    'inputValue',
+    'input-change',
+  );
+
   const inputRef = ref();
-  const inputValue = ref<string | number>('');
   const renderTNode = useTNodeJSX();
 
   const commonInputProps = computed<SelectInputCommonProperties>(() => pick(props, COMMON_PROPERTIES));
@@ -52,37 +63,33 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
     context?.e?.stopPropagation();
     props.onClear?.(context);
     instance.emit('clear', context);
-    inputValue.value = '';
+    setInputValue('', { trigger: 'clear' });
   };
 
   const onInnerInputChange = (value: InputValue, context: { e: InputEvent | MouseEvent }) => {
     if (props.allowInput) {
-      inputValue.value = value;
-      props.onInputChange?.(value, { ...context, trigger: 'input' });
-      instance.emit('input-change', value, { ...context, trigger: 'input' });
+      setInputValue(value, { ...context, trigger: 'input' });
     }
   };
 
-  watch(
-    [value],
-    () => {
-      inputValue.value = getInputValue(value.value, keys.value);
-    },
-    { immediate: true },
-  );
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const renderSelectSingle = (h: Vue.CreateElement) => {
+  const renderSelectSingle = (h: Vue.CreateElement, popupVisible: boolean) => {
     const singleValueDisplay = renderTNode('valueDisplay');
+    const displayedValue = popupVisible && props.allowInput ? inputValue : getInputValue(value.value, keys.value);
     const prefixContent = [singleValueDisplay, renderTNode('label')];
     const inputProps = {
       ...commonInputProps.value,
       ...props.inputProps,
-      value: singleValueDisplay ? undefined : inputValue.value,
+      value: singleValueDisplay ? undefined : displayedValue,
       label: prefixContent.length ? () => prefixContent : undefined,
       autoWidth: props.autoWidth,
       readonly: !props.allowInput,
       placeholder: singleValueDisplay ? '' : props.placeholder,
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
+      showClearIconOnEmpty: Boolean(props.clearable && inputValue.value),
+      inputClass: {
+        [`${classPrefix.value}-input--focused`]: popupVisible,
+      },
     };
 
     return (
@@ -93,13 +100,13 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
         onChange={onInnerInputChange}
         onClear={onInnerClear}
         onBlur={(val: InputValue, context: { e: MouseEvent }) => {
-          props.onBlur?.(value, { ...context, inputValue: val });
+          props.onBlur?.(value.value, { ...context, inputValue: val });
+          instance.emit('blur', value.value, { ...context, inputValue: val });
           inputValue.value = getInputValue(value.value, keys.value);
-          instance.emit('blur', props.value, { ...context, inputValue: val });
         }}
         onFocus={(val: InputValue, context: { e: MouseEvent }) => {
-          props.onFocus?.(value, { ...context, inputValue: val });
-          instance.emit('focus', props.value, { ...context, tagInputValue: val });
+          props.onFocus?.(value.value, { ...context, inputValue: val });
+          instance.emit('focus', value.value, { ...context, tagInputValue: val });
         }}
       />
     );

--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -128,6 +128,7 @@ export default defineComponent({
     return (
       <TInput
         ref="tagInputRef"
+        readonly={this.readonly}
         {...this.inputProps}
         value={this.tInputValue}
         onChange={(val: InputValue, context?: { e?: InputEvent | MouseEvent }) => {
@@ -136,7 +137,6 @@ export default defineComponent({
         onMousewheel={this.onWheel}
         autoWidth={this.autoWidth}
         size={this.size}
-        readonly={this.readonly}
         disabled={this.disabled}
         label={() => this.renderLabel({ displayNode, label }, h)}
         class={this.classes}

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -10,7 +10,6 @@ import { renderTNodeJSX } from '../utils/render-tnode';
 import { ClassName } from '../common';
 
 const name = `${prefix}-textarea`;
-const TEXTAREA_WRAP_CLASS = `${prefix}-textarea__wrap`;
 const TEXTAREA_TIPS_CLASS = `${prefix}-textarea__tips`;
 const TEXTAREA_LIMIT = `${name}__limit`;
 
@@ -173,7 +172,8 @@ export default Vue.extend({
         [`${prefix}-resize-none`]: typeof this.autosize === 'object',
       },
     ];
-    const textareaNode = (
+    const tips = renderTNodeJSX(this, 'tips');
+    return (
       <div class={this.textareaClasses}>
         <textarea
           onInput={this.handleInput}
@@ -188,18 +188,10 @@ export default Vue.extend({
         {!this.maxcharacter && this.maxlength ? (
           <span class={TEXTAREA_LIMIT}>{`${this.value ? String(this.value)?.length : 0}/${this.maxlength}`}</span>
         ) : null}
+        {tips && (
+          <div class={`${TEXTAREA_TIPS_CLASS} ${prefix}-textarea__tips--${this.status || 'normal'}`}>{tips}</div>
+        )}
       </div>
     );
-
-    const tips = renderTNodeJSX(this, 'tips');
-    if (tips) {
-      return (
-        <div class={TEXTAREA_WRAP_CLASS}>
-          {textareaNode}
-          <div class={`${TEXTAREA_TIPS_CLASS} ${prefix}-textarea__tips--${this.status || 'normal'}`}>{tips}</div>
-        </div>
-      );
-    }
-    return textareaNode;
   },
 });

--- a/src/time-picker/time-picker.tsx
+++ b/src/time-picker/time-picker.tsx
@@ -324,7 +324,6 @@ export default mixins(getConfigReceiverMixins<TimePickerInstance, TimePickerConf
             clearable={this.clearable}
             placeholder=" "
             value={this.time ? ' ' : undefined}
-            class={this.isShowPanel ? `${prefix}-is-focused` : ''}
             onFocus={this.handleTInputFocus}
             ref="tInput"
           >

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -327,7 +327,6 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
           onError: this.onError,
           onProgress: this.handleProgress,
           onSuccess: this.handleSuccess,
-          method: this.method,
         });
       }
     },

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -327,6 +327,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
           onError: this.onError,
           onProgress: this.handleProgress,
           onSuccess: this.handleSuccess,
+          method: this.method,
         });
       }
     },

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -14356,20 +14356,16 @@ exports[`ssr snapshot test renders ./examples/textarea/demos/type.vue correctly 
 <div class="tdesign-demo-block-column">
   <div class="t-textarea t-is-disabled"><textarea disabled="disabled" unselectable="off" class="t-textarea__inner t-is-disabled">禁用状态</textarea></div>
   <div class="t-textarea t-is-readonly"><textarea readonly="readonly" unselectable="on" class="t-textarea__inner">只读状态</textarea></div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner">普通状态</textarea></div>
+  <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner">普通状态</textarea>
     <div class="t-textarea__tips t-textarea__tips--normal">这是普通文本提示</div>
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner t-is-success">成功状态</textarea></div>
+  <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner t-is-success">成功状态</textarea>
     <div class="t-textarea__tips t-textarea__tips--success">校验通过文本提示</div>
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner t-is-warning">警告状态</textarea></div>
+  <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner t-is-warning">警告状态</textarea>
     <div class="t-textarea__tips t-textarea__tips--warning">校验不通过文本提示</div>
   </div>
-  <div class="t-textarea__wrap">
-    <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner t-is-error">错误状态</textarea></div>
+  <div class="t-textarea"><textarea unselectable="off" class="t-textarea__inner t-is-error">错误状态</textarea>
     <div class="t-textarea__tips t-textarea__tips--error">校验存在严重问题文本提示</div>
   </div>
 </div>

--- a/test/unit/select/__snapshots__/demo.test.js.snap
+++ b/test/unit/select/__snapshots__/demo.test.js.snap
@@ -342,7 +342,7 @@ exports[`Steps Steps creatable demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -768,7 +768,7 @@ exports[`Steps Steps filterable demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -815,7 +815,7 @@ exports[`Steps Steps filterable demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -867,7 +867,7 @@ exports[`Steps Steps group demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -913,7 +913,7 @@ exports[`Steps Steps group demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -1672,7 +1672,7 @@ exports[`Steps Steps remoteSearch demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"
@@ -1719,7 +1719,7 @@ exports[`Steps Steps remoteSearch demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m t-is-readonly"

--- a/test/unit/tag-input/__snapshots__/demo.test.js.snap
+++ b/test/unit/tag-input/__snapshots__/demo.test.js.snap
@@ -6,7 +6,7 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -62,7 +62,7 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -123,7 +123,7 @@ exports[`TagInput TagInput baseVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -191,7 +191,7 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -234,7 +234,7 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -295,7 +295,7 @@ exports[`TagInput TagInput collapsedVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -381,7 +381,7 @@ exports[`TagInput TagInput customTagVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -459,7 +459,7 @@ exports[`TagInput TagInput customTagVue demo works fine 1`] = `
   <br />
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -564,7 +564,7 @@ exports[`TagInput TagInput excessVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -625,7 +625,7 @@ exports[`TagInput TagInput excessVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input t-tag-input--break-line"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -692,7 +692,7 @@ exports[`TagInput TagInput maxVue demo works fine 1`] = `
   style="width: 100%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -718,7 +718,7 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-s t-input--prefix"
@@ -774,7 +774,7 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -830,7 +830,7 @@ exports[`TagInput TagInput sizeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-l t-input--prefix"
@@ -900,7 +900,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
         class="t-input t-size-m t-is-disabled t-input--prefix"
@@ -944,7 +944,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
         class="t-input t-size-m t-is-readonly t-input--prefix"
@@ -993,7 +993,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
         class="t-input t-size-m t-is-success t-input--prefix"
@@ -1080,7 +1080,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
         class="t-input t-size-m t-is-warning t-input--prefix"
@@ -1167,7 +1167,7 @@ exports[`TagInput TagInput statusVue demo works fine 1`] = `
     </label>
      
     <div
-      class="t-input__wrap"
+      class="t-input__wrap t-tag-input"
     >
       <div
         class="t-input t-size-m t-is-error t-input--prefix"
@@ -1254,7 +1254,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   style="width: 80%;"
 >
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -1328,7 +1328,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -1402,7 +1402,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"
@@ -1476,7 +1476,7 @@ exports[`TagInput TagInput themeVue demo works fine 1`] = `
   </div>
    
   <div
-    class="t-input__wrap"
+    class="t-input__wrap t-tag-input"
   >
     <div
       class="t-input t-size-m t-input--prefix"

--- a/test/unit/textarea/__snapshots__/demo.test.js.snap
+++ b/test/unit/textarea/__snapshots__/demo.test.js.snap
@@ -117,16 +117,12 @@ exports[`Textarea type demo works fine 1`] = `
   </div>
    
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner"
-        unselectable="off"
-      />
-    </div>
+    <textarea
+      class="t-textarea__inner"
+      unselectable="off"
+    />
     <div
       class="t-textarea__tips t-textarea__tips--normal"
     >
@@ -135,16 +131,12 @@ exports[`Textarea type demo works fine 1`] = `
   </div>
    
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner t-is-success"
-        unselectable="off"
-      />
-    </div>
+    <textarea
+      class="t-textarea__inner t-is-success"
+      unselectable="off"
+    />
     <div
       class="t-textarea__tips t-textarea__tips--success"
     >
@@ -153,16 +145,12 @@ exports[`Textarea type demo works fine 1`] = `
   </div>
    
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner t-is-warning"
-        unselectable="off"
-      />
-    </div>
+    <textarea
+      class="t-textarea__inner t-is-warning"
+      unselectable="off"
+    />
     <div
       class="t-textarea__tips t-textarea__tips--warning"
     >
@@ -171,16 +159,12 @@ exports[`Textarea type demo works fine 1`] = `
   </div>
    
   <div
-    class="t-textarea__wrap"
+    class="t-textarea"
   >
-    <div
-      class="t-textarea"
-    >
-      <textarea
-        class="t-textarea__inner t-is-error"
-        unselectable="off"
-      />
-    </div>
+    <textarea
+      class="t-textarea__inner t-is-error"
+      unselectable="off"
+    />
     <div
       class="t-textarea__tips t-textarea__tips--error"
     >

--- a/test/unit/tree-select/__snapshots__/demo.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/demo.test.js.snap
@@ -23,7 +23,7 @@ exports[`TreeSelect base demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
       >
         <div
           class="t-input t-size-m"
@@ -168,7 +168,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         +1
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -308,7 +308,7 @@ exports[`TreeSelect collapsed demo works fine 1`] = `
         更多...
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -461,7 +461,7 @@ exports[`TreeSelect filterable demo works fine 1`] = `
         shenzhen
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -558,7 +558,7 @@ exports[`TreeSelect lazy demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -704,7 +704,7 @@ exports[`TreeSelect multiple demo works fine 1`] = `
         +2
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -812,7 +812,7 @@ exports[`TreeSelect prefix demo works fine 1`] = `
         +0
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -916,7 +916,7 @@ exports[`TreeSelect props demo works fine 1`] = `
         shenzhen
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -1020,7 +1020,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         [object Object]
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div
@@ -1160,7 +1160,7 @@ exports[`TreeSelect valuetype demo works fine 1`] = `
         +2
       </span>
       <div
-        class="t-input__wrap"
+        class="t-input__wrap t-select__input"
         style="display: none;"
       >
         <div

--- a/test/unit/tree-select/__snapshots__/index.test.js.snap
+++ b/test/unit/tree-select/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TreeSelect :props :clearable 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -26,7 +26,7 @@ exports[`TreeSelect :props :defaultValue 1`] = `
     </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" title="guangzhou"><span class="t-tag--text" style="max-width: 300px;">guangzhou</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
       <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
     </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+2</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -45,7 +45,7 @@ exports[`TreeSelect :props :defaultValue 1`] = `
 exports[`TreeSelect :props :disabled 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m t-is-disabled"><input disabled="disabled" autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -64,7 +64,7 @@ exports[`TreeSelect :props :disabled 1`] = `
 exports[`TreeSelect :props :empty string 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -83,7 +83,7 @@ exports[`TreeSelect :props :empty string 1`] = `
 exports[`TreeSelect :props :filterable 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap">
+    <div class="t-input__wrap t-select__input">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -102,7 +102,7 @@ exports[`TreeSelect :props :filterable 1`] = `
 exports[`TreeSelect :props :loading 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
@@ -119,7 +119,7 @@ exports[`TreeSelect :props :loading 1`] = `
 exports[`TreeSelect :props :loadingText 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -138,7 +138,7 @@ exports[`TreeSelect :props :loadingText 1`] = `
 exports[`TreeSelect :props :max 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -157,7 +157,7 @@ exports[`TreeSelect :props :max 1`] = `
 exports[`TreeSelect :props :minCollapsedNum 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+-1</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -176,7 +176,7 @@ exports[`TreeSelect :props :minCollapsedNum 1`] = `
 exports[`TreeSelect :props :multiple 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -195,7 +195,7 @@ exports[`TreeSelect :props :multiple 1`] = `
 exports[`TreeSelect :props :placeholder 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">please select address</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="please select address" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -214,7 +214,7 @@ exports[`TreeSelect :props :placeholder 1`] = `
 exports[`TreeSelect :props :popupProps 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -233,7 +233,7 @@ exports[`TreeSelect :props :popupProps 1`] = `
 exports[`TreeSelect :props :size 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-l t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-l t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-l"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: large;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -252,7 +252,7 @@ exports[`TreeSelect :props :size 1`] = `
 exports[`TreeSelect :props :treeProps 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -271,7 +271,7 @@ exports[`TreeSelect :props :treeProps 1`] = `
 exports[`TreeSelect :props :value 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="shenzhen" class="t-select__single">shenzhen</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="shenzhen" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -290,7 +290,7 @@ exports[`TreeSelect :props :value 1`] = `
 exports[`TreeSelect :props :valueType 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select-selected t-select__popup-reference"><span class="t-select__placeholder" style="display: none;">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="[object Object]" class="t-select__single">[object Object]</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="[object Object]" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -309,7 +309,7 @@ exports[`TreeSelect :props :valueType 1`] = `
 exports[`TreeSelect <slot> <collapsedItems> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -328,7 +328,7 @@ exports[`TreeSelect <slot> <collapsedItems> 1`] = `
 exports[`TreeSelect <slot> <empty> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -347,7 +347,7 @@ exports[`TreeSelect <slot> <empty> 1`] = `
 exports[`TreeSelect <slot> <loadingText> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
@@ -364,7 +364,7 @@ exports[`TreeSelect <slot> <loadingText> 1`] = `
 exports[`TreeSelect <slot> <prefixIcon> 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"><div><i>icon</i></div></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -383,7 +383,7 @@ exports[`TreeSelect <slot> <prefixIcon> 1`] = `
 exports[`TreeSelect function :collapsedItems 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -402,7 +402,7 @@ exports[`TreeSelect function :collapsedItems 1`] = `
 exports[`TreeSelect function :empty 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -421,7 +421,7 @@ exports[`TreeSelect function :empty 1`] = `
 exports[`TreeSelect function :loadingText 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close-circle-filled t-size-m t-select__right-icon t-select__right-icon-polyfill t-select__right-icon-clear" style="display: none;">
       <path fill="currentColor" d="M15 8A7 7 0 101 8a7 7 0 0014 0zM5.67 4.95L8 7.29l2.33-2.34.7.7L8.7 8l2.34 2.35-.71.7L8 8.71l-2.33 2.34-.7-.7L7.3 8 4.96 5.65l.71-.7z" fill-opacity="0.9"></path>
@@ -438,7 +438,7 @@ exports[`TreeSelect function :loadingText 1`] = `
 exports[`TreeSelect function :prefixIcon 1`] = `
 <div class="t-select__wrap">
   <div class="t-select t-select-polyfill t-size-m t-has-prefix t-select__popup-reference"><span class="t-select__left-icon"></span><span class="t-select__placeholder">请选择</span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span>
-    <div class="t-input__wrap" style="display: none;">
+    <div class="t-input__wrap t-select__input" style="display: none;">
       <div class="t-input t-size-m"><input autocomplete="" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
     </div><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill" style="font-size: medium;">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

关联common PR https://github.com/Tencent/tdesign-common/pull/325
- [x] 新特性提交

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

**TimePicker focused 态样式修复**

before

<img width="342" alt="image" src="https://user-images.githubusercontent.com/35833812/159638926-09341ff2-40fe-45a1-a138-e5ced14d5478.png">

after

<img width="345" alt="image" src="https://user-images.githubusercontent.com/35833812/159639015-3deb4a0b-3c36-4dbe-8a3e-c7fad15cfe2e.png">

**DatePicker focused 态样式修复**

before
<img width="340" alt="image" src="https://user-images.githubusercontent.com/35833812/159639172-288dc8a8-2b84-4d8a-9895-53b21a182230.png">

after
<img width="354" alt="image" src="https://user-images.githubusercontent.com/35833812/159639133-a193abd1-df21-44a1-bd4f-cc63919c6e5f.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- refactor(input):
  -  外部传入样式挂载至 `t-input__wrap`, breaking-change
  -  feat(input): 增加 inputClass API，用于透传class到 t-input 同级
- refactor(textarea): 去除 `t-textarea__wrap`, breaking-change
- fix(date-picker): focused 态样式修复
- fix(time-picker): focused 态样式修复
- fix(upload): 修复upload组件 method props 失效
- fix(select-input): 
   - 修复在非输入状态下无focused态
   - 修复在非输入状态下不能显示清除按钮
   - 修复在`single`模式下inputValue 的受控表现
- fix(cascader): 
  - 修复value为number类型时无法回显 https://github.com/Tencent/tdesign-vue/issues/619
  -  修复动态改options为空数组不生效 https://github.com/Tencent/tdesign-vue/issues/467

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
