### PR TITLE
【Upload】 fix: 修复handleProgress file状态判断

### DIFF
--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -20,7 +20,6 @@ import { renderContent } from '../utils/render-tnode';
 import props from './props';
 import { ClassName } from '../common';
 import { emitEvent } from '../utils/event';
-import { dedupeFile } from './util';
 import {
   HTMLInputEvent,
   SuccessContext,
@@ -257,7 +256,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
 
       let tmpFiles = [...files];
       if (this.max) {
-        tmpFiles = tmpFiles.slice(0, this.max - this.files.length);
+        tmpFiles = tmpFiles.slice(0, this.max - this.toUploadFiles.length - this.files.length);
         if (tmpFiles.length !== files.length) {
           console.warn(`TDesign Upload Warn: you can only upload ${this.max} files`);
         }
@@ -285,11 +284,10 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
         this.handleBeforeUpload(file).then((canUpload) => {
           if (!canUpload) return;
           const newFiles = this.toUploadFiles.concat();
-          newFiles.push(uploadFile);
-          const uploadFileList = !this.allowUploadDuplicateFile
-            ? dedupeFile([...new Set(newFiles)])
-            : [...new Set(newFiles)];
-          this.toUploadFiles = this.max ? uploadFileList.slice(0, this.max - this.files.length) : uploadFileList;
+          if (this.allowUploadDuplicateFile || !this.toUploadFiles.find((file) => file.name === uploadFile.name)) {
+            newFiles.push(uploadFile);
+          }
+          this.toUploadFiles = newFiles;
           this.loadingFile = uploadFile;
           if (this.autoUpload) {
             this.upload(uploadFile);

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -445,6 +445,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
 
       innerFiles.forEach((file) => {
         file.percent = Math.min(percent, 100);
+        // 判断文件状态是否上传完成
         this.loadingFile = file.status === 'success' ? null : file;
       });
       const progressCtx = {

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -286,9 +286,10 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
           if (!canUpload) return;
           const newFiles = this.toUploadFiles.concat();
           newFiles.push(uploadFile);
-          this.toUploadFiles = !this.allowUploadDuplicateFile
+          const uploadFileList = !this.allowUploadDuplicateFile
             ? dedupeFile([...new Set(newFiles)])
             : [...new Set(newFiles)];
+          this.toUploadFiles = this.max ? uploadFileList.slice(0, this.max - this.files.length) : uploadFileList;
           this.loadingFile = uploadFile;
           if (this.autoUpload) {
             this.upload(uploadFile);

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -256,6 +256,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
 
       let tmpFiles = [...files];
       if (this.max) {
+        // 判断当前待上传列表长度
         tmpFiles = tmpFiles.slice(0, this.max - this.toUploadFiles.length - this.files.length);
         if (tmpFiles.length !== files.length) {
           console.warn(`TDesign Upload Warn: you can only upload ${this.max} files`);
@@ -284,6 +285,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
         this.handleBeforeUpload(file).then((canUpload) => {
           if (!canUpload) return;
           const newFiles = this.toUploadFiles.concat();
+          // 判断是否为重复文件条件，已选是否存在检验
           if (this.allowUploadDuplicateFile || !this.toUploadFiles.find((file) => file.name === uploadFile.name)) {
             newFiles.push(uploadFile);
           }

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -445,7 +445,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload')).exte
 
       innerFiles.forEach((file) => {
         file.percent = Math.min(percent, 100);
-        this.loadingFile = file;
+        this.loadingFile = file.status === 'success' ? null : file;
       });
       const progressCtx = {
         percent,

--- a/src/upload/util.ts
+++ b/src/upload/util.ts
@@ -1,6 +1,4 @@
-import uniqWith from 'lodash/uniqWith';
 import { prefix } from '../config';
-import { UploadFile } from './type';
 
 export const UPLOAD_NAME = `${prefix}-upload`;
 
@@ -43,13 +41,4 @@ export function abridgeName(inputName: string, leftCount = 5, rightcount = 7): s
     }
   }
   return name.replace(new RegExp(`^(.{${leftLength}})(.+)(.{${rightLength}})$`), '$1…$3');
-}
-/**
- * 重复数组检查
- * @param files Array
- * @param key string default name
- * @returns Array of files
- */
-export function dedupeFile(files: Array<UploadFile>, key = 'name'): any {
-  return uniqWith(files, (val1, val2) => val1[key] === val2[key]);
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
```js
innerFiles.forEach((file) => {
  file.percent = Math.min(percent, 100);
  this.loadingFile = file.status === 'success' ? null : file;
});
```
### 💡 需求背景和解决方案
添加文件status状态判断
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): 处理 `success` 事件先于 `progress` 事件触发时，上传文件 `loadingFile` 值不正确的场景
- fix(upload): 处理最大数量限制 `max` 在多次文件选择中判断不正确问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
