### PR TITLE
fix(tree-select):  修复treeProps同时使用keys、load的选中项显示问题

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -319,8 +319,8 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
     // get tree data, even load async load
     getTreeData() {
       return ((this.$refs.tree as TreeInstanceFunctions)?.getItems() || []).map((item) => ({
-        label: item.data[this.realLabel],
-        value: item.data[this.realValue],
+        [this.realLabel]: item.data[this.realLabel],
+        [this.realValue]: item.data[this.realValue],
       }));
     },
     async changeNodeInfo() {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue/issues/622

### 💡 需求背景和解决方案

1.解决透传treeProps时，同时使用keys、load属性导致的选中项显示问题
2.问题的是getTreeNode方法里调用的getTreeData方法返回nodes时没使用keys里的属性别名来命名label、value
3.解决方案是getTreeData方法返回nodes时使用keys里的属性别名来命名label、value

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree-select):  修复treeProps同时使用keys、load的选中项显示问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
