### PR TITLE
fix: select-input demo style and input focus inputValue

### DIFF
--- a/examples/select-input/demos/collapsed-items.vue
+++ b/examples/select-input/demos/collapsed-items.vue
@@ -151,6 +151,7 @@ export default {
 .tdesign-demo__panel-options-collapsed-items {
   width: 100%;
   padding: 4px 0;
+  display: inline-block;
 }
 .tdesign-demo__panel-options-collapsed-items .t-checkbox {
   display: flex;

--- a/examples/select-input/demos/excess-tags-display-type.vue
+++ b/examples/select-input/demos/excess-tags-display-type.vue
@@ -116,6 +116,7 @@ export default {
 .tdesign-demo__panel-options-excess-tags-display-type {
   width: 100%;
   padding: 4px 0;
+  display: inline-block;
 }
 .tdesign-demo__panel-options-excess-tags-display-type .t-checkbox {
   display: flex;

--- a/examples/select-input/demos/multiple.vue
+++ b/examples/select-input/demos/multiple.vue
@@ -133,7 +133,9 @@ export default {
 .tdesign-demo__panel-options-multiple {
   width: 100%;
   padding: 4px 0;
+  display: inline-block;
 }
+
 .tdesign-demo__panel-options-multiple .t-checkbox {
   display: flex;
   border-radius: 3px;

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -102,11 +102,15 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
         onBlur={(val: InputValue, context: { e: MouseEvent }) => {
           props.onBlur?.(value.value, { ...context, inputValue: val });
           instance.emit('blur', value.value, { ...context, inputValue: val });
-          inputValue.value = getInputValue(value.value, keys.value);
+        }}
+        onEnter={(val: InputValue, context: { e: KeyboardEvent }) => {
+          props.onEnter?.(value.value, { ...context, inputValue: val });
+          instance.emit('enter', value.value, { ...context, inputValue: val });
         }}
         onFocus={(val: InputValue, context: { e: MouseEvent }) => {
           props.onFocus?.(value.value, { ...context, inputValue: val });
           instance.emit('focus', value.value, { ...context, tagInputValue: val });
+          !popupVisible && setInputValue(getInputValue(value.value, keys.value), { ...context, trigger: 'input' }); // 聚焦时拿到value
         }}
       />
     );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

before


<img width="1059" alt="image" src="https://user-images.githubusercontent.com/35833812/160133524-68dec712-36fa-4d98-91da-038a7ad8838c.png">

after

<img width="819" alt="image" src="https://user-images.githubusercontent.com/35833812/160133436-47ecd0d5-0cf7-4ca1-8453-893b4664108c.png">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select-input): 修复单选可输入状态下的 `focus` 时 `inputvalue ` 的错误
- feat(select-input): 实现 `enter` 事件
- docs: 修复文档demo样式


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
