### PR TITLE
fix(treeselect): click twice will disapear select value

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -291,8 +291,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
         return;
       }
 
-      const triggerValue = context.node.data[this.realValue];
-
+      const triggerValue = this.isObjectValue ? context.node.data : context.node.data[this.realValue];
       // 参照 Select 下点击即选中
       this.change(triggerValue, context.node);
       this.actived = [triggerValue];

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -290,15 +290,12 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
       if (this.multiple) {
         return;
       }
-      let current: TreeSelectValue = value;
-      if (this.isObjectValue) {
-        const nodeValue = isEmpty(value) ? '' : value[0];
-        current = this.getTreeNode(this.data, nodeValue);
-      } else {
-        current = isEmpty(value) ? '' : value[0];
-      }
-      this.change(current, context.node);
-      this.actived = value;
+
+      const triggerValue = context.node.data[this.realValue];
+
+      // 参照 Select 下点击即选中
+      this.change(triggerValue, context.node);
+      this.actived = [triggerValue];
       this.visible = false;
     },
     treeNodeExpand(value: Array<TreeNodeValue>) {
@@ -325,7 +322,6 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
     },
     async changeNodeInfo() {
       await this.value;
-
       if (!this.multiple && this.value) {
         const nodeValue = this.isObjectValue ? (this.value as NodeOptions).value : this.value;
         const node = this.getTreeNode(this.data, nodeValue);


### PR DESCRIPTION
fix #617

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
fix #617

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

TreeSelect 与常规的 Select 的交互行为展现不符，多次点击可以取消当前选择，该 PR 用于修复该问题，让 TreeSelect 的交互行为更加接近 Select 组件。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TreeSelect): 修正 TreeSelect 的交互行为，与 Select 保持一致。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
