### PR TITLE
fix: Ie not method IntersectionObserver

### DIFF
--- a/src/table/tr.tsx
+++ b/src/table/tr.tsx
@@ -171,7 +171,7 @@ export default defineComponent({
 
     const observe = (element: HTMLElement, root: HTMLElement, callback: Function, marginBottom: number) => {
       if (!window || !window.IntersectionObserver) {
-        callback(); // fix: Ie not method IntersectionObserver
+        callback();
         return;
       }
       try {

--- a/src/table/tr.tsx
+++ b/src/table/tr.tsx
@@ -171,6 +171,7 @@ export default defineComponent({
 
     const observe = (element: HTMLElement, root: HTMLElement, callback: Function, marginBottom: number) => {
       if (!window || !window.IntersectionObserver) {
+        callback(); // fix: Ie not method IntersectionObserver
         return;
       }
       try {


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 处理IE浏览器下无`IntersectionObserver`方法，无法调用回调函数执行方法的兼容问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
