### PR TITLE
fix: pagination inputnumber placeholder

### DIFF
--- a/src/pagination/pagination.tsx
+++ b/src/pagination/pagination.tsx
@@ -393,6 +393,7 @@ export default mixins(getConfigReceiverMixins<Vue, PaginationConfig>('pagination
               max={this.pageCount}
               min={min}
               theme="normal"
+              placeholder=""
             />
             {this.t(this.global.page)}
           </div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -3043,7 +3043,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/pagination.v
     </svg></div>
   <div class="t-pagination__jump">jump to<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
       <div class="t-input__wrap">
-        <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="please enter" type="text" unselectable="off" value="1" class="t-input__inner"></div>
+        <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" value="1" class="t-input__inner"></div>
       </div>
     </div>
   </div>
@@ -8245,7 +8245,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/customizable.vue 
       </svg></div>
     <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
         <div class="t-input__wrap">
-          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="请输入" type="text" unselectable="off" value="1" class="t-input__inner"></div>
+          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" value="1" class="t-input__inner"></div>
         </div>
       </div>页</div>
   </div>
@@ -8280,7 +8280,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/disabled.vue corr
       </svg></div>
     <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
         <div class="t-input__wrap">
-          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="请输入" type="text" unselectable="off" value="1" class="t-input__inner"></div>
+          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" value="1" class="t-input__inner"></div>
         </div>
       </div>页</div>
   </div>
@@ -8338,7 +8338,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/jump.vue correctl
       </svg></div>
     <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
         <div class="t-input__wrap">
-          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="请输入" type="text" unselectable="off" value="1" class="t-input__inner"></div>
+          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" value="1" class="t-input__inner"></div>
         </div>
       </div>页</div>
   </div>
@@ -13728,7 +13728,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination.vue correct
           </svg></div>
         <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
             <div class="t-input__wrap">
-              <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="请输入" type="text" unselectable="off" value="2" class="t-input__inner"></div>
+              <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" value="2" class="t-input__inner"></div>
             </div>
           </div>页</div>
       </div>
@@ -13794,7 +13794,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination-ajax.vue co
         </svg></div>
       <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
           <div class="t-input__wrap">
-            <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="请输入" type="text" unselectable="off" value="1" class="t-input__inner"></div>
+            <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" value="1" class="t-input__inner"></div>
           </div>
         </div>页</div>
     </div>

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -3172,7 +3172,7 @@ exports[`ConfigProvider ConfigProvider paginationVue demo works fine 1`] = `
           <input
             autocomplete="off"
             class="t-input__inner"
-            placeholder="please enter"
+            placeholder=""
             type="text"
             unselectable="off"
           />

--- a/test/unit/pagination/__snapshots__/demo.test.js.snap
+++ b/test/unit/pagination/__snapshots__/demo.test.js.snap
@@ -262,7 +262,7 @@ exports[`Pagination customizable demo works fine 1`] = `
       </svg></div>
     <div class="t-pagination__jump">跳至<div class="t-input-number t-size-m t-input-number--normal t-pagination__input">
         <div class="t-input__wrap">
-          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="请输入" type="text" unselectable="off" class="t-input__inner"></div>
+          <div ref="refInputElem" class="t-input t-size-m"><input autocomplete="off" placeholder="" type="text" unselectable="off" class="t-input__inner"></div>
         </div>
       </div>页</div>
   </div>
@@ -419,7 +419,7 @@ exports[`Pagination disabled demo works fine 1`] = `
             <input
               autocomplete="off"
               class="t-input__inner"
-              placeholder="请输入"
+              placeholder=""
               type="text"
               unselectable="off"
             />
@@ -675,7 +675,7 @@ exports[`Pagination jump demo works fine 1`] = `
             <input
               autocomplete="off"
               class="t-input__inner"
-              placeholder="请输入"
+              placeholder=""
               type="text"
               unselectable="off"
             />

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -13499,7 +13499,7 @@ exports[`Table Table paginationAjaxVue demo works fine 1`] = `
               <input
                 autocomplete="off"
                 class="t-input__inner"
-                placeholder="请输入"
+                placeholder=""
                 type="text"
                 unselectable="off"
               />
@@ -13954,7 +13954,7 @@ exports[`Table Table paginationVue demo works fine 1`] = `
                 <input
                   autocomplete="off"
                   class="t-input__inner"
-                  placeholder="请输入"
+                  placeholder=""
                   type="text"
                   unselectable="off"
                 />


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
inputnumber 未配置 placeholder 时会有默认文案填充：
![image](https://user-images.githubusercontent.com/7600149/160551237-964f5da6-2823-4569-8941-bdb5c7a85100.png)
pagination 中引入 inputnumber 时需要手动设置 placeholder 为空

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Pagination): 修复跳转页输入框展示了额外 placeholder 默认内容的问题

- [] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
