### PR TITLE
fix: popconfirm button size

### DIFF
--- a/src/dialog/actions.tsx
+++ b/src/dialog/actions.tsx
@@ -11,6 +11,7 @@ export type MixnsFooterButton = string | ButtonProps | TNode;
 export interface MixinsConfirmBtn {
   theme?: MixinsThemeType;
   className?: ClassName;
+  size?: ButtonProps['size'];
   confirmBtn: MixnsFooterButton;
   globalConfirm: PopconfirmConfig['confirm'] | DrawerConfig['confirm'] | DialogConfig['confirm'];
   globalConfirmBtnTheme?: PopconfirmConfig['confirmBtnTheme'] | DialogConfig['confirmBtnTheme'];
@@ -18,6 +19,7 @@ export interface MixinsConfirmBtn {
 
 export interface MixinsCancelBtn {
   className?: ClassName;
+  size?: ButtonProps['size'];
   cancelBtn: MixnsFooterButton;
   globalCancel: PopconfirmConfig['cancel'] | DrawerConfig['cancel'] | DialogConfig['cancel'];
 }
@@ -71,9 +73,7 @@ export default Vue.extend({
       } else if (isObject(button)) {
         newOptions = { ...newOptions, ...button };
       }
-      return (
-        <TButton class={className} props={newOptions}/>
-      );
+      return <TButton class={className} props={newOptions} />;
     },
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -88,6 +88,7 @@ export default Vue.extend({
       let props: ButtonProps = {
         theme: defaultTheme,
         content: '确定',
+        size: options.size,
         onClick: (e) => {
           this.confirmBtnAction(e);
         },
@@ -106,6 +107,7 @@ export default Vue.extend({
       let props: ButtonProps = {
         theme: 'default',
         content: '取消',
+        size: options.size,
         onClick: (e) => {
           this.cancelBtnAction(e);
         },
@@ -118,5 +120,4 @@ export default Vue.extend({
       return props;
     },
   },
-
 });

--- a/src/popconfirm/popconfirm.tsx
+++ b/src/popconfirm/popconfirm.tsx
@@ -80,6 +80,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, PopconfirmConfig
     const cancelBtn = this.getCancelBtn({
       cancelBtn: this.cancelBtn,
       globalCancel: this.global.cancel,
+      size: 'small',
       className: `${name}__cancel`,
     });
     // this.getConfirmBtn is a function of ActionMixin
@@ -87,6 +88,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, PopconfirmConfig
       theme: this.theme,
       confirmBtn: this.confirmBtn,
       globalConfirm: this.global.confirm,
+      size: 'small',
       globalConfirmBtnTheme: this.global.confirmBtnTheme,
       className: `${name}__confirm`,
     });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

before
<img width="607" alt="image" src="https://user-images.githubusercontent.com/35833812/160645214-6530fc70-74e5-4387-a74a-9077a290f74e.png">

after

<img width="670" alt="image" src="https://user-images.githubusercontent.com/35833812/160645099-fabd128a-7444-4c22-811b-0b61eb525111.png">


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popConfirm): 修复popConfirm默认按钮大小为small


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
