### PR TITLE
fix(timepicker): clear value reset current time

### DIFF
--- a/src/date-picker/date-picker.tsx
+++ b/src/date-picker/date-picker.tsx
@@ -185,7 +185,9 @@ export default mixins(
     handleTInputFocus() {
       // TODO: 待改成select-input后删除
       // hack 在input聚焦时马上blur 避免出现输入光标
-      (this.$refs.native as HTMLInputElement).blur();
+      this.$nextTick(() => {
+        (this.$refs.native as HTMLInputElement).blur();
+      });
     },
     handleTimePick(col: EPickerCols, time: number, index: number) {
       if (!this.range || index === 0) {

--- a/src/time-picker/time-picker.tsx
+++ b/src/time-picker/time-picker.tsx
@@ -85,20 +85,12 @@ export default mixins(getConfigReceiverMixins<TimePickerInstance, TimePickerConf
       return [dayjs().hour(0).minute(0).second(0)];
     },
     textClassName(): string {
-      const isDefault = (this.inputTime as any).some(
-        (item: InputTime) => !!item.hour && !!item.minute && !!item.second,
-      );
+      const isDefault = !!this.inputTime?.hour && !!this.inputTime?.minute && !!this.inputTime?.second;
       return isDefault ? '' : `${name}__group-text`;
     },
   },
 
   watch: {
-    // 监听选中时间变动
-    time: {
-      handler() {
-        this.output();
-      },
-    },
     value: {
       handler() {
         this.time = this.value ? dayjs(this.value, this.format) : undefined;
@@ -306,7 +298,9 @@ export default mixins(getConfigReceiverMixins<TimePickerInstance, TimePickerConf
     handleTInputFocus() {
       // TODO: 待改成select-input后删除
       // hack 在input聚焦时马上blur 避免出现输入光标
-      (this.$refs.tInput as HTMLInputElement).blur();
+      this.$nextTick(() => {
+        (this.$refs.tInput as HTMLInputElement).blur();
+      });
     },
     renderInput() {
       const classes = [

--- a/src/time-picker/time-range-picker.tsx
+++ b/src/time-picker/time-range-picker.tsx
@@ -261,7 +261,9 @@ export default mixins(getConfigReceiverMixins<TimePickerInstance, TimePickerConf
     handleTInputFocus() {
       // TODO: 待改成select-input后删除
       // hack 在input聚焦时马上blur 避免出现输入光标
-      (this.$refs.tInput as HTMLInputElement).blur();
+      this.$nextTick(() => {
+        (this.$refs.tInput as HTMLInputElement).blur();
+      });
     },
     renderInput() {
       const classes = [


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- 日常 bug 修复 修复time-picker手动情况value的异常
- 修复点击clear按钮 timepicker和datepicker样式的异常

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
<img width="747" alt="image" src="https://user-images.githubusercontent.com/26377630/162934520-9d893d6c-6f0f-413d-91ef-d02adcf086b7.png">

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(timepicker): 修复time-picker手动清空value的异常

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
