### PR TITLE
fix(select): 去掉select选中和下拉项中的title属性

### DIFF
--- a/src/select/option.tsx
+++ b/src/select/option.tsx
@@ -161,7 +161,6 @@ export default mixins(keepAnimationMixins).extend({
       <li
         v-show={show}
         class={classes}
-        title={labelText}
         onMouseenter={this.mouseEvent.bind(true)}
         onMouseleave={this.mouseEvent.bind(false)}
         onClick={this.select}

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -788,7 +788,6 @@ export default mixins(getConfigReceiverMixins<Vue, SelectConfig>('select')).exte
                     disabled={tDisabled}
                     style="max-width: 100%;"
                     maxWidth="100%"
-                    title={get(item, realLabel)}
                     onClose={this.removeTag.bind(null, index)}
                   >
                     {get(item, realLabel)}
@@ -807,11 +806,7 @@ export default mixins(getConfigReceiverMixins<Vue, SelectConfig>('select')).exte
                 {`+${selectedMultiple.length - this.minCollapsedNum}`}
               </tag>
             )}
-            {!multiple && !showPlaceholder && !showFilter && (
-              <span title={selectedSingle} class={`${name}__single`}>
-                {selectedSingle}
-              </span>
-            )}
+            {!multiple && !showPlaceholder && !showFilter && <span class={`${name}__single`}>{selectedSingle}</span>}
             {showFilter && (
               <t-input
                 ref="input"

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -808,14 +808,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/base.vue correctly 
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -898,7 +898,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/card.vue correctly 
 <div class="tdesign-demo-block-column-large">
   <div><label>请选择风格：</label>
     <div class="demo-select-base t-select__wrap">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="card" class="t-select__single">card</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">card</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div> <button type="button" class="t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">今天（当前高亮日期）</span></button>
@@ -914,14 +914,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/card.vue correctly 
       <div class="t-calendar__control-section">
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
         </div>
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
@@ -1006,14 +1006,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/cell.vue correctly 
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -1285,14 +1285,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/cell-append.vue cor
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -1445,14 +1445,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/controller-config.v
       <div class="t-calendar__control-section">
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
         </div>
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
@@ -1540,14 +1540,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/events.vue correctl
       <div class="t-calendar__control-section">
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
         </div>
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
@@ -1631,7 +1631,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/first-day-of-week.v
 <div class="tdesign-demo-block-column-large">
   <div><label>日历的第一列为：</label>
     <div class="demo-select-base t-select__wrap">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="3" class="t-select__single">3</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">3</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -1642,14 +1642,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/first-day-of-week.v
       <div class="t-calendar__control-section">
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
         </div>
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
@@ -1740,14 +1740,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/head.vue correctly 
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -1830,7 +1830,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/mode.vue correctly 
 <div class="tdesign-demo-block-column-large">
   <div><label>可以在组件外切换成：</label>
     <div class="demo-select-base t-select__wrap">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="year" class="t-select__single">year</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">year</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -1841,7 +1841,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/mode.vue correctly 
       <div class="t-calendar__control-section">
         <div class="t-calendar__control-section-cell">
           <div class="t-select__wrap">
-            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>
@@ -1889,14 +1889,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/range.vue correctly
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -1984,14 +1984,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/slot-props-api.vue 
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -2221,14 +2221,14 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/value.vue correctly
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="1998" class="t-select__single">1998</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">1998</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="11" class="t-select__single">11</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">11</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -3234,14 +3234,14 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/calendar.vue
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="2021" class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">2021</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -3583,7 +3583,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/pagination.v
 <div class="t-pagination t-size-m" style="padding:16px;">
   <div class="t-pagination__total">Total 36 items</div>
   <div class="t-select__wrap t-pagination__select">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="10" class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
@@ -8820,7 +8820,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/base.vue correctl
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 36 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -8844,7 +8844,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/base.vue correctl
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 36 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="10" class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -8869,7 +8869,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/customizable.vue 
   <div show-sizer="" class="t-pagination t-size-m">
     <div class="t-pagination__total">共 200 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="20" class="t-select__single">20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -8905,7 +8905,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/disabled.vue corr
   <div show-sizer="" class="t-pagination t-size-m t-is-disabled">
     <div class="t-pagination__total">共 100 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -8940,7 +8940,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/few.vue correctly
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 49 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="10" class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -8966,7 +8966,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/jump.vue correctl
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 101 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="20" class="t-select__single">20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -8998,7 +8998,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/mini.vue correctl
   <div class="t-pagination t-size-s">
     <div class="t-pagination__total">共 100 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -9028,7 +9028,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/more.vue correctl
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 100 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -9062,7 +9062,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/page-num.vue corr
   <div show-sizer="" class="t-pagination t-size-m">
     <div class="t-pagination__total">共 645 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="30" class="t-select__single">30</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">30</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -9092,7 +9092,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/simple.vue correc
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 100 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -9100,7 +9100,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/simple.vue correc
         <path fill="currentColor" d="M9.54 3.54l.92.92L6.92 8l3.54 3.54-.92.92L5.08 8l4.46-4.46z" fill-opacity="0.9"></path>
       </svg></div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="1/20" class="t-select__single">1/20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">1/20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -9115,7 +9115,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/simple-mini.vue c
 <div class="t-pagination t-size-s">
   <div class="t-pagination__total">共 100 项数据</div>
   <div class="t-select__wrap t-pagination__select">
-    <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
@@ -9123,7 +9123,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/simple-mini.vue c
       <path fill="currentColor" d="M9.54 3.54l.92.92L6.92 8l3.54 3.54-.92.92L5.08 8l4.46-4.46z" fill-opacity="0.9"></path>
     </svg></div>
   <div class="t-select__wrap t-pagination__select">
-    <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="1/20" class="t-select__single">1/20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">1/20</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
@@ -9138,7 +9138,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/total.vue correct
   <div class="t-pagination t-size-m">
     <div class="t-pagination__total">共 685 项数据</div>
     <div class="t-select__wrap t-pagination__select">
-      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="10" class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+      <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
           <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
         </svg></div>
     </div>
@@ -9869,27 +9869,27 @@ exports[`ssr snapshot test renders ./examples/select/demos/base.vue correctly 1`
 exports[`ssr snapshot test renders ./examples/select/demos/collapsed.vue correctly 1`] = `
 <div>
   <div class="t-select__wrap">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="选项一" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="选项三" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项三</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项三</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark">+1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div> <br><br>
   <div class="t-select__wrap">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="选项一" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="选项三" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项三</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项三</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span style="color:#ED7B2F;">+1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div> <br><br>
   <div class="t-select__wrap">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="选项一" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="选项三" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项三</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项三</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span> <span style="color:#00A870;">+1</span></span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -9958,7 +9958,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/disabled.vue correctl
       </svg></div>
   </div>
   <div class="t-select__wrap" style="width:200px;display:inline-block;">
-    <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span title="选项一" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-is-disabled t-tag--disabled" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span></span><span title="选项二" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-is-disabled t-tag--disabled" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项二</span></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-is-disabled t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-is-disabled t-tag--disabled" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-is-disabled t-tag--disabled" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项二</span></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
@@ -10014,12 +10014,12 @@ exports[`ssr snapshot test renders ./examples/select/demos/group.vue correctly 1
 exports[`ssr snapshot test renders ./examples/select/demos/label-in-value.vue correctly 1`] = `
 <div>
   <div class="t-select__wrap" style="width:200px;display:inline-block;margin-right:20px;">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="选项一" class="t-select__single">选项一</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">选项一</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
   <div class="t-select__wrap" style="width:200px;display:inline-block;">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="选项一" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -10041,39 +10041,39 @@ exports[`ssr snapshot test renders ./examples/select/demos/max.vue correctly 1`]
 exports[`ssr snapshot test renders ./examples/select/demos/multiple.vue correctly 1`] = `
 <div class="tdesign-demo-select-base">
   <div class="t-select__wrap">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="区块链" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">区块链</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">区块链</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="人工智能" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">人工智能</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">人工智能</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+2</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div> <br><br>
   <div class="t-select__wrap">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="1" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">1</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">1</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="2" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">2</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">2</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="3" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">3</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">3</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="4" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">4</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">4</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="5" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">5</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">5</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="6" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">6</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">6</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+6</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div> <br><br>
   <div class="t-select__wrap">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span title="区块链" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">区块链</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">区块链</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="人工智能" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">人工智能</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">人工智能</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="计算场景" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">计算场景</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">计算场景</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
-      </svg></span><span title="大数据" class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">大数据</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
+      </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close" style="display:none;max-width:100%;"><span class="t-tag--text" style="max-width:100%px;">大数据</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close">
         <path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path>
       </svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark">+2</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
@@ -10085,7 +10085,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/multiple.vue correctl
 exports[`ssr snapshot test renders ./examples/select/demos/noborder.vue correctly 1`] = `
 <div>
   <div class="t-select__wrap" style="width:200px;">
-    <div class="t-select t-select-polyfill t-size-m t-no-border t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="已选择的选项" class="t-select__single">已选择的选项</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-m t-no-border t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">已选择的选项</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
@@ -10110,12 +10110,12 @@ exports[`ssr snapshot test renders ./examples/select/demos/panel.vue correctly 1
 exports[`ssr snapshot test renders ./examples/select/demos/popup-props.vue correctly 1`] = `
 <div>
   <div class="t-select__wrap" style="width:200px;display:inline-block;">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="已选择的选项" class="t-select__single">已选择的选项</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">已选择的选项</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
   <div class="t-select__wrap" style="width:200px;display:inline-block;margin-left:20px;">
-    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="已选择的选项" class="t-select__single">已选择的选项</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+    <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">已选择的选项</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
         <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
       </svg></div>
   </div>
@@ -12135,7 +12135,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/base.vue correctly 1`]
       <div class="t-pagination t-size-m">
         <div class="t-pagination__total">共 28 项数据</div>
         <div class="t-select__wrap t-pagination__select">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -12314,7 +12314,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/custom-col.vue correct
       <div class="t-pagination t-size-m">
         <div class="t-pagination__total">共 100 项数据</div>
         <div class="t-select__wrap t-pagination__select">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -12448,7 +12448,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/custom-col-button.vue 
       <div class="t-pagination t-size-m">
         <div class="t-pagination__total">共 100 项数据</div>
         <div class="t-select__wrap t-pagination__select">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -14623,7 +14623,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination.vue correct
       <div class="t-pagination t-size-m">
         <div class="t-pagination__total">共 60 项数据</div>
         <div class="t-select__wrap t-pagination__select">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="5" class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">5</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -14697,7 +14697,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination-ajax.vue co
     <div class="t-pagination t-size-m">
       <div class="t-pagination__total">共 0 项数据</div>
       <div class="t-select__wrap t-pagination__select">
-        <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="10" class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+        <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
             <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
           </svg></div>
       </div>
@@ -15234,7 +15234,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
       <div class="t-pagination t-size-m">
         <div class="t-pagination__total">共 100 项数据</div>
         <div class="t-select__wrap t-pagination__select">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span title="10" class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display:none;">+0</span><span class="t-select__single">10</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -16577,7 +16577,7 @@ exports[`ssr snapshot test renders ./examples/transfer/demos/pagination.vue corr
               <path fill="currentColor" d="M9.54 3.54l.92.92L6.92 8l3.54 3.54-.92.92L5.08 8l4.46-4.46z" fill-opacity="0.9"></path>
             </svg></div>
           <div class="t-select__wrap t-pagination__select">
-            <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span title="1/2" class="t-select__single">1/2</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+            <div class="t-select t-select-polyfill t-size-s t-select__popup-reference"><span class="t-tag t-tag--default t-size-s t-tag--dark" style="display:none;">+0</span><span class="t-select__single">1/2</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
                 <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
               </svg></div>
           </div>

--- a/test/unit/calendar/__snapshots__/demo.test.js.snap
+++ b/test/unit/calendar/__snapshots__/demo.test.js.snap
@@ -30,7 +30,6 @@ exports[`Calendar Calendar baseVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -69,7 +68,6 @@ exports[`Calendar Calendar baseVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -770,7 +768,6 @@ exports[`Calendar Calendar cardVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="card"
         >
           card
         </span>
@@ -850,7 +847,6 @@ exports[`Calendar Calendar cardVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="2020"
               >
                 2020
               </span>
@@ -889,7 +885,6 @@ exports[`Calendar Calendar cardVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="12"
               >
                 12
               </span>
@@ -1575,7 +1570,6 @@ exports[`Calendar Calendar cellAppendVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -1614,7 +1608,6 @@ exports[`Calendar Calendar cellAppendVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -2332,7 +2325,6 @@ exports[`Calendar Calendar cellVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -2371,7 +2363,6 @@ exports[`Calendar Calendar cellVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -3394,7 +3385,6 @@ exports[`Calendar Calendar controllerConfigVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="2020"
               >
                 2020
               </span>
@@ -3433,7 +3423,6 @@ exports[`Calendar Calendar controllerConfigVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="12"
               >
                 12
               </span>
@@ -4146,7 +4135,6 @@ exports[`Calendar Calendar eventsVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="2020"
               >
                 2020
               </span>
@@ -4185,7 +4173,6 @@ exports[`Calendar Calendar eventsVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="12"
               >
                 12
               </span>
@@ -4887,7 +4874,6 @@ exports[`Calendar Calendar firstDayOfWeekVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="3"
         >
           3
         </span>
@@ -4939,7 +4925,6 @@ exports[`Calendar Calendar firstDayOfWeekVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="2020"
               >
                 2020
               </span>
@@ -4978,7 +4963,6 @@ exports[`Calendar Calendar firstDayOfWeekVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="12"
               >
                 12
               </span>
@@ -5795,7 +5779,6 @@ exports[`Calendar Calendar headVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -5834,7 +5817,6 @@ exports[`Calendar Calendar headVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -6535,7 +6517,6 @@ exports[`Calendar Calendar modeVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="year"
         >
           year
         </span>
@@ -6587,7 +6568,6 @@ exports[`Calendar Calendar modeVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="2020"
               >
                 2020
               </span>
@@ -6900,7 +6880,6 @@ exports[`Calendar Calendar rangeVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -6939,7 +6918,6 @@ exports[`Calendar Calendar rangeVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -7651,7 +7629,6 @@ exports[`Calendar Calendar slotPropsApiVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -7690,7 +7667,6 @@ exports[`Calendar Calendar slotPropsApiVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -8396,7 +8372,6 @@ exports[`Calendar Calendar valueVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="1998"
             >
               1998
             </span>
@@ -8435,7 +8410,6 @@ exports[`Calendar Calendar valueVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="11"
             >
               11
             </span>
@@ -9255,7 +9229,6 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                 </span>
                 <span
                   class="t-select__single"
-                  title="2020"
                 >
                   2020
                 </span>
@@ -9294,7 +9267,6 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                 </span>
                 <span
                   class="t-select__single"
-                  title="12"
                 >
                   12
                 </span>
@@ -10008,7 +9980,6 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                 </span>
                 <span
                   class="t-select__single"
-                  title="2020"
                 >
                   2020
                 </span>
@@ -10047,7 +10018,6 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                 </span>
                 <span
                   class="t-select__single"
-                  title="12"
                 >
                   12
                 </span>
@@ -10747,7 +10717,6 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                 </span>
                 <span
                   class="t-select__single"
-                  title="2020"
                 >
                   2020
                 </span>
@@ -10786,7 +10755,6 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                 </span>
                 <span
                   class="t-select__single"
-                  title="12"
                 >
                   12
                 </span>

--- a/test/unit/calendar/__snapshots__/index.test.js.snap
+++ b/test/unit/calendar/__snapshots__/index.test.js.snap
@@ -7,14 +7,14 @@ exports[`Calendar :props :firstDayOfWeek 1`] = `
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="2020" class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -109,14 +109,14 @@ exports[`Calendar :props :isShowWeekendDefault 1`] = `
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="2020" class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -190,7 +190,7 @@ exports[`Calendar :props :mode 1`] = `
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="2020" class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -237,14 +237,14 @@ exports[`Calendar :props :range 1`] = `
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="2020" class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -330,14 +330,14 @@ exports[`Calendar :props :theme 1`] = `
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="2020" class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">2020</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="12" class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">12</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
@@ -421,14 +421,14 @@ exports[`Calendar :props :value 1`] = `
     <div class="t-calendar__control-section">
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="1998" class="t-select__single">1998</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">1998</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>
       </div>
       <div class="t-calendar__control-section-cell">
         <div class="t-select__wrap">
-          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="11" class="t-select__single">11</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+          <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">11</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
               <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
             </svg></div>
         </div>

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -31,7 +31,6 @@ exports[`ConfigProvider ConfigProvider calendarVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="2020"
             >
               2020
             </span>
@@ -70,7 +69,6 @@ exports[`ConfigProvider ConfigProvider calendarVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="12"
             >
               12
             </span>
@@ -3111,7 +3109,6 @@ exports[`ConfigProvider ConfigProvider paginationVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="10"
       >
         10
       </span>

--- a/test/unit/pagination/__snapshots__/demo.test.js.snap
+++ b/test/unit/pagination/__snapshots__/demo.test.js.snap
@@ -24,7 +24,6 @@ exports[`Pagination Pagination baseVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="5"
         >
           5
         </span>
@@ -150,7 +149,6 @@ exports[`Pagination Pagination baseVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="10"
         >
           10
         </span>
@@ -258,7 +256,6 @@ exports[`Pagination Pagination customizableVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="20"
         >
           20
         </span>
@@ -423,7 +420,6 @@ exports[`Pagination Pagination disabledVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="5"
         >
           5
         </span>
@@ -585,7 +581,6 @@ exports[`Pagination Pagination fewVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="10"
         >
           10
         </span>
@@ -697,7 +692,6 @@ exports[`Pagination Pagination jumpVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="20"
         >
           20
         </span>
@@ -841,7 +835,6 @@ exports[`Pagination Pagination miniVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="5"
         >
           5
         </span>
@@ -976,7 +969,6 @@ exports[`Pagination Pagination moreVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="5"
         >
           5
         </span>
@@ -1133,7 +1125,6 @@ exports[`Pagination Pagination pageNumVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="30"
         >
           30
         </span>
@@ -1267,7 +1258,6 @@ exports[`Pagination Pagination simpleMiniVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="5"
       >
         5
       </span>
@@ -1320,7 +1310,6 @@ exports[`Pagination Pagination simpleMiniVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="1/20"
       >
         1/20
       </span>
@@ -1385,7 +1374,6 @@ exports[`Pagination Pagination simpleVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="5"
         >
           5
         </span>
@@ -1438,7 +1426,6 @@ exports[`Pagination Pagination simpleVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="1/20"
         >
           1/20
         </span>
@@ -1504,7 +1491,6 @@ exports[`Pagination Pagination totalVue demo works fine 1`] = `
         </span>
         <span
           class="t-select__single"
-          title="10"
         >
           10
         </span>

--- a/test/unit/select/__snapshots__/demo.test.js.snap
+++ b/test/unit/select/__snapshots__/demo.test.js.snap
@@ -87,7 +87,6 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="选项一"
       >
         <span
           class="t-tag--text"
@@ -112,7 +111,6 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%; display: none;"
-        title="选项三"
       >
         <span
           class="t-tag--text"
@@ -169,7 +167,6 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="选项一"
       >
         <span
           class="t-tag--text"
@@ -194,7 +191,6 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%; display: none;"
-        title="选项三"
       >
         <span
           class="t-tag--text"
@@ -251,7 +247,6 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="选项一"
       >
         <span
           class="t-tag--text"
@@ -276,7 +271,6 @@ exports[`Select Select collapsedVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%; display: none;"
-        title="选项三"
       >
         <span
           class="t-tag--text"
@@ -705,7 +699,6 @@ exports[`Select Select disabledVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-is-disabled t-tag--disabled"
         style="max-width: 100%;"
-        title="选项一"
       >
         <span
           class="t-tag--text"
@@ -717,7 +710,6 @@ exports[`Select Select disabledVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-is-disabled t-tag--disabled"
         style="max-width: 100%;"
-        title="选项二"
       >
         <span
           class="t-tag--text"
@@ -965,7 +957,6 @@ exports[`Select Select labelInValueVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="选项一"
       >
         选项一
       </span>
@@ -997,7 +988,6 @@ exports[`Select Select labelInValueVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="选项一"
       >
         <span
           class="t-tag--text"
@@ -1098,7 +1088,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="区块链"
       >
         <span
           class="t-tag--text"
@@ -1123,7 +1112,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="人工智能"
       >
         <span
           class="t-tag--text"
@@ -1181,7 +1169,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="1"
       >
         <span
           class="t-tag--text"
@@ -1206,7 +1193,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="2"
       >
         <span
           class="t-tag--text"
@@ -1231,7 +1217,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="3"
       >
         <span
           class="t-tag--text"
@@ -1256,7 +1241,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="4"
       >
         <span
           class="t-tag--text"
@@ -1281,7 +1265,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="5"
       >
         <span
           class="t-tag--text"
@@ -1306,7 +1289,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="6"
       >
         <span
           class="t-tag--text"
@@ -1364,7 +1346,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="区块链"
       >
         <span
           class="t-tag--text"
@@ -1389,7 +1370,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%;"
-        title="人工智能"
       >
         <span
           class="t-tag--text"
@@ -1414,7 +1394,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%; display: none;"
-        title="计算场景"
       >
         <span
           class="t-tag--text"
@@ -1439,7 +1418,6 @@ exports[`Select Select multipleVue demo works fine 1`] = `
       <span
         class="t-tag t-tag--default t-size-m t-tag--dark t-tag--ellipsis t-tag--close"
         style="max-width: 100%; display: none;"
-        title="大数据"
       >
         <span
           class="t-tag--text"
@@ -1503,7 +1481,6 @@ exports[`Select Select noborderVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="已选择的选项"
       >
         已选择的选项
       </span>
@@ -1620,7 +1597,6 @@ exports[`Select Select popupPropsVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="已选择的选项"
       >
         已选择的选项
       </span>
@@ -1657,7 +1633,6 @@ exports[`Select Select popupPropsVue demo works fine 1`] = `
       </span>
       <span
         class="t-select__single"
-        title="已选择的选项"
       >
         已选择的选项
       </span>

--- a/test/unit/select/__snapshots__/index.test.js.snap
+++ b/test/unit/select/__snapshots__/index.test.js.snap
@@ -94,7 +94,7 @@ exports[`Select :props :size 1`] = `
 
 exports[`Select Option :props :disabled 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="1" class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
     </svg></div>
 </div>
@@ -102,7 +102,7 @@ exports[`Select Option :props :disabled 1`] = `
 
 exports[`Select Option :props :label 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="1" class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
     </svg></div>
 </div>
@@ -110,7 +110,7 @@ exports[`Select Option :props :label 1`] = `
 
 exports[`Select Option :props :value 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="1" class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
     </svg></div>
 </div>
@@ -118,7 +118,7 @@ exports[`Select Option :props :value 1`] = `
 
 exports[`Select OptionGroup :props :value 1`] = `
 <div class="t-select__wrap">
-  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span title="1" class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
+  <div class="t-select t-select-polyfill t-size-m t-select__popup-reference"><span class="t-tag t-tag--default t-size-m t-tag--dark" style="display: none;">+0</span><span class="t-select__single">1</span><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon t-select__right-icon-polyfill">
       <path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path>
     </svg></div>
 </div>

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -769,7 +769,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="5"
             >
               5
             </span>
@@ -1506,7 +1505,6 @@ exports[`Table Table customColButtonVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="5"
             >
               5
             </span>
@@ -1946,7 +1944,6 @@ exports[`Table Table customColVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="5"
             >
               5
             </span>
@@ -16644,7 +16641,6 @@ exports[`Table Table paginationAjaxVue demo works fine 1`] = `
           </span>
           <span
             class="t-select__single"
-            title="10"
           >
             10
           </span>
@@ -17059,7 +17055,6 @@ exports[`Table Table paginationVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="5"
             >
               5
             </span>
@@ -19969,7 +19964,6 @@ exports[`Table Table treeVue demo works fine 1`] = `
             </span>
             <span
               class="t-select__single"
-              title="10"
             >
               10
             </span>

--- a/test/unit/transfer/__snapshots__/demo.test.js.snap
+++ b/test/unit/transfer/__snapshots__/demo.test.js.snap
@@ -3339,7 +3339,6 @@ exports[`Transfer Transfer paginationVue demo works fine 1`] = `
               </span>
               <span
                 class="t-select__single"
-                title="1/2"
               >
                 1/2
               </span>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
Fixes #769 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
目前select选中项和select的下拉项中均有title属性， 并且没有提供相应控制。
由于业务上需要自定义提示信息样式，经讨论去掉select选中和下拉项中的title属性

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select): 去掉select选中和下拉项中的title属性

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
