### PR TITLE
fix(tree-select): 支持treeProps.keys.children字段配置

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -214,6 +214,13 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
       }
       return 'value';
     },
+    realChildren(): string {
+      const { treeProps } = this;
+      if (!isEmpty(treeProps) && !isEmpty(treeProps.keys)) {
+        return treeProps.keys.children || 'children';
+      }
+      return 'children';
+    },
     tagList(): Array<TreeSelectValue> {
       if (this.nodeInfo && isArray(this.nodeInfo)) {
         return this.nodeInfo.map((node) => node.label);
@@ -381,7 +388,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
         if (data[i][this.realValue] === targetValue) {
           return { label: data[i][this.realLabel], value: data[i][this.realValue] };
         }
-        const childrenData = data[i]?.children;
+        const childrenData = data[i][this.realChildren];
         if (childrenData) {
           const data = Array.isArray(childrenData) ? childrenData : this.getTreeData();
           const result = this.getTreeNode(data, targetValue);

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -216,10 +216,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
     },
     realChildren(): string {
       const { treeProps } = this;
-      if (!isEmpty(treeProps) && !isEmpty(treeProps.keys)) {
-        return treeProps.keys.children || 'children';
-      }
-      return 'children';
+      return treeProps?.keys?.children || 'children';
     },
     tagList(): Array<TreeSelectValue> {
       if (this.nodeInfo && isArray(this.nodeInfo)) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
Fixes #888 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
配置treeProps.keys的children为自定义值。选中子节点， 选中展示的是value值， 应该展示label。
经排查是tree-select未支持自定义的treeProps.keys.children配置

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree-select): 支持treeProps.keys.children字段配置

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
