### PR TITLE
fix: table loading props enum size

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -386,7 +386,7 @@ export default defineComponent({
         text={customLoadingText ? () => customLoadingText : undefined}
         attach={this.tableRef ? () => this.tableRef : undefined}
         showOverlay
-        props={this.loadingProps}
+        props={{ size: 'small', ...this.loadingProps }}
       ></Loading>
     );
 

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -14524,7 +14524,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/drag-sort-handler.vue 
           <!---->
         </table>
       </div>
-      <div class="t-loading--center t-size-m t-loading"></div>
+      <div class="t-loading--center t-size-s t-loading"></div>
     </div>
   </div>
 </div>
@@ -15807,7 +15807,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/loading.vue correctly 
         <!---->
       </table>
     </div>
-    <div class="t-loading--center t-size-m t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="medium" class="t-loading__gradient t-icon-loading">
+    <div class="t-loading--center t-size-s t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -15863,7 +15863,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/loading.vue correctly 
         <!---->
       </table>
     </div>
-    <div class="t-loading--center t-size-m t-loading">
+    <div class="t-loading--center t-size-s t-loading">
       <div class="t-loading__text">
         <div class="t-table--loading-message">😊 这里使用插槽自定义加载状态 😊</div>
       </div>
@@ -15919,7 +15919,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/loading.vue correctly 
         <!---->
       </table>
     </div>
-    <div class="t-loading--center t-size-m t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="medium" class="t-loading__gradient t-icon-loading">
+    <div class="t-loading--center t-size-s t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading">
         <foreignObject x="1" y="1" width="12" height="12">
           <div class="t-loading__gradient-conic"></div>
         </foreignObject>
@@ -16410,7 +16410,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination-ajax.vue co
       <!---->
     </table>
   </div>
-  <div class="t-loading--center t-size-m t-loading"></div>
+  <div class="t-loading--center t-size-s t-loading"></div>
   <div class="t-table__pagination">
     <div class="t-pagination t-size-m">
       <div class="t-pagination__total">共 0 项数据</div>

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -4100,7 +4100,7 @@ exports[`Table Table dragSortHandlerVue demo works fine 1`] = `
         </table>
       </div>
       <div
-        class="t-loading--center t-size-m t-loading"
+        class="t-loading--center t-size-s t-loading"
       />
     </div>
   </div>
@@ -15714,12 +15714,12 @@ exports[`Table Table loadingVue demo works fine 1`] = `
       </table>
     </div>
     <div
-      class="t-loading--center t-size-m t-loading"
+      class="t-loading--center t-size-s t-loading"
     >
       <svg
         class="t-loading__gradient t-icon-loading"
         height="1em"
-        size="medium"
+        size="small"
         version="1.1"
         viewBox="0 0 14 14"
         width="1em"
@@ -15870,7 +15870,7 @@ exports[`Table Table loadingVue demo works fine 1`] = `
       </table>
     </div>
     <div
-      class="t-loading--center t-size-m t-loading"
+      class="t-loading--center t-size-s t-loading"
     >
       <div
         class="t-loading__text"
@@ -16015,12 +16015,12 @@ exports[`Table Table loadingVue demo works fine 1`] = `
       </table>
     </div>
     <div
-      class="t-loading--center t-size-m t-loading"
+      class="t-loading--center t-size-s t-loading"
     >
       <svg
         class="t-loading__gradient t-icon-loading"
         height="1em"
-        size="medium"
+        size="small"
         version="1.1"
         viewBox="0 0 14 14"
         width="1em"
@@ -17237,7 +17237,7 @@ exports[`Table Table paginationAjaxVue demo works fine 1`] = `
     </table>
   </div>
   <div
-    class="t-loading--center t-size-m t-loading"
+    class="t-loading--center t-size-s t-loading"
   />
   <div
     class="t-table__pagination"


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复table透传loading size为枚举无效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
