### PR TITLE
feat(t-select): 新增属性adornmentWidth

### DIFF
--- a/examples/input-adornment/demos/select.vue
+++ b/examples/input-adornment/demos/select.vue
@@ -24,7 +24,7 @@ export default {
       protocolSelect: () => (
         <t-select
           bordered={false}
-          autoWidth
+          adornmentWidth
           options={['http://', 'https://'].map((value) => ({ label: value, value }))}
           defaultValue="http://"
         />

--- a/examples/select/select.md
+++ b/examples/select/select.md
@@ -6,6 +6,7 @@
 名称 | 类型 | 默认值 | 说明 | 必传
 -- | -- | -- | -- | --
 autoWidth | Boolean | false | 宽度随内容自适应 | N
+adornmentWidth | Boolean | false | 宽度随输入装饰器自适应 | N
 bordered | Boolean | true | 是否有边框 | N
 borderless | Boolean | false | 无边框模式 | N
 clearable | Boolean | false | 是否可以清空选项 | N

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -82,7 +82,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
           [`${prefix}-is-disabled`]: this.tDisabled,
           [`${prefix}-is-readonly`]: this.readonly,
           [`${name}--focused`]: this.focused,
-          [`${name}--auto-width`]: this.autoWidth,
+          [`${name}--auto-width`]: this.autoWidth || this.adornmentWidth,
         },
       ];
     },
@@ -108,7 +108,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
 
   created() {
     this.composing = false;
-    if (this.autoWidth) {
+    if (this.autoWidth || this.adornmentWidth) {
       this.addListeners();
     }
   },
@@ -117,10 +117,10 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       this.$watch(
         () => this.value + this.placeholder,
         () => {
-          if (!this.autoWidth) return;
-          this.$nextTick(() => {
-            this.updateInputWidth();
-          });
+          (this.autoWidth || this.adornmentWidth)
+            && this.$nextTick(() => {
+              this.updateInputWidth();
+            });
         },
         { immediate: true },
       );
@@ -316,7 +316,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
           onInput={this.handleInput}
           onCompositionend={this.compositionendHandler}
         />
-        {this.autoWidth && (
+        {(this.autoWidth || this.adornmentWidth) && (
           <span ref="inputPreRef" class={`${prefix}-input__input-pre`}>
             {this.value || this.tPlaceholder}
           </span>

--- a/src/input/props.ts
+++ b/src/input/props.ts
@@ -26,6 +26,8 @@ export default {
   autofocus: Boolean,
   /** 宽度随内容自适应 */
   autoWidth: Boolean,
+  /* 宽度随输入装饰器自适应 */
+  adornmentWidth: Boolean,
   /** 是否可清空 */
   clearable: Boolean,
   /** 是否禁用输入框 */

--- a/src/input/type.ts
+++ b/src/input/type.ts
@@ -28,6 +28,11 @@ export interface TdInputProps {
    */
   autoWidth?: boolean;
   /**
+   * 宽度随输入装饰器自适应
+   * @default false
+   */
+  adornmentWidth?: boolean;
+  /**
    * 是否可清空
    * @default false
    */

--- a/src/select-input/props.ts
+++ b/src/select-input/props.ts
@@ -12,6 +12,8 @@ export default {
   allowInput: Boolean,
   /** 宽度随内容自适应 */
   autoWidth: Boolean,
+  /** 宽度随输入装饰器自适应 */
+  adornmentWidth: Boolean,
   /** 无边框模式 */
   borderless: Boolean,
   /** 是否可清空 */

--- a/src/select-input/type.ts
+++ b/src/select-input/type.ts
@@ -23,6 +23,11 @@ export interface TdSelectInputProps {
    */
   autoWidth?: boolean;
   /**
+   * 宽度随输入装饰器自适应
+   * @default false
+   */
+  adornmentWidth?: boolean;
+  /**
    * 无边框模式
    * @default false
    */

--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -62,6 +62,7 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
       tagProps: props.tagProps,
       label: props.label,
       autoWidth: props.autoWidth,
+      adornmentWidth: props.adornmentWidth,
       placeholder: tPlaceholder.value,
       minCollapsedNum: props.minCollapsedNum,
       collapsedItems: props.collapsedItems,

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -73,12 +73,14 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
     const singleValueDisplay = renderTNode('valueDisplay');
     const displayedValue = popupVisible && props.allowInput ? inputValue.value : getInputValue(value.value, keys.value);
     const prefixContent = [singleValueDisplay, renderTNode('label')];
+
     const inputProps = {
       ...commonInputProps.value,
       ...props.inputProps,
       value: singleValueDisplay ? undefined : displayedValue,
       label: prefixContent.length ? () => prefixContent : undefined,
       autoWidth: props.autoWidth,
+      adornmentWidth: props.adornmentWidth,
       readonly: !props.allowInput,
       placeholder: singleValueDisplay ? '' : props.placeholder,
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,

--- a/src/select/props.ts
+++ b/src/select/props.ts
@@ -10,6 +10,8 @@ import { PropType } from 'vue';
 export default {
   /** 宽度随内容自适应 */
   autoWidth: Boolean,
+  /** 宽度随输入装饰器适应 */
+  adornmentWidth: Boolean,
   /** 是否有边框 */
   bordered: {
     type: Boolean,

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -691,6 +691,7 @@ export default defineComponent({
     const {
       multiple,
       autoWidth,
+      adornmentWidth,
       bordered,
       readonly,
       selectedValue,
@@ -735,12 +736,14 @@ export default defineComponent({
     const prefixIcon = () => renderTNode('prefixIcon');
     const collapsedItems = () => renderCollapsedItems();
     const { overlayClassName, ...restPopupProps } = popupProps || {};
+
     return (
       <div ref="select" class={`${name}__wrap`}>
         <SelectInput
           ref="selectInputRef"
           class={name}
           autoWidth={autoWidth}
+          adornmentWidth={adornmentWidth}
           borderless={borderless || !bordered}
           readonly={readonly}
           allowInput={showFilter}

--- a/src/select/type.ts
+++ b/src/select/type.ts
@@ -21,6 +21,11 @@ export interface TdSelectProps<T extends SelectOption = SelectOption> {
    */
   autoWidth?: boolean;
   /**
+   * 宽度随输入装饰器适应
+   * @default false
+   */
+  adornmentWidth: Boolean;
+  /**
    * 是否有边框
    * @default true
    */


### PR DESCRIPTION
使用输入装饰器时，t-select组件设置adornmentWidth属性使下拉框宽度与装饰器相同

fix #988

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/988

### 💡 需求背景和解决方案

根据issue中提出的需求修改输入装饰器中的下拉框宽度与触发元素相同。为了不影响autoWidth的使用以及继续支持autoWidth的配置，所以在t-select组件中新增了adornmentWidth属性。当使用autoWidth时按照原有效果展示，当使用adornmentWidth属性时，下拉框则根据装饰器的宽度显示。

### 📝 更新日志

t-select组件新增adornmentWidth属性，在InputAdornment组件中的装饰器里嵌套t-select组件时，可以使用autoWidth属性实现根据内容自适应宽度，也可以使用adornmentWidth属性使下拉框宽度和装饰器宽度一致。

- fix(Select): 新增属性adornmentWidth

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
