### PR TITLE
fix(input-number): fix events after use t-input

### DIFF
--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -278,7 +278,7 @@ export default Vue.extend({
       emitEvent<Parameters<TdInputNumberProps['onKeyup']>>(this, 'keyup', value, ctx);
     },
     handleKeypress(value: number, ctx: { e: KeyboardEvent }) {
-      emitEvent<Parameters<TdInputNumberProps['onKeypress']>>(this, 'keypress', this.value, ctx);
+      emitEvent<Parameters<TdInputNumberProps['onKeypress']>>(this, 'keypress', value, ctx);
       this.handlePressKey(value, ctx);
     },
     handlePressKey(value: number, ctx: { e: KeyboardEvent }) {

--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -18,15 +18,15 @@ type InputNumberEvent = {
   on: {
     input?: (e: InputEvent) => void;
     click?: (e: MouseEvent) => void;
-    blur?: (e: FocusEvent) => void;
-    focus?: (e: FocusEvent) => void;
-    keydown?: (e: KeyboardEvent) => void;
-    keyup?: (e: KeyboardEvent) => void;
-    keypress?: (e: KeyboardEvent) => void;
+    blur?: (value: number, ctx: { e: FocusEvent }) => void;
+    focus?: (value: number, ctx: { e: FocusEvent }) => void;
+    keydown?: (value: number, ctx: { e: KeyboardEvent }) => void;
+    keyup?: (value: number, ctx: { e: KeyboardEvent }) => void;
+    keypress?: (value: number, ctx: { e: KeyboardEvent }) => void;
   };
 };
 
-type ChangeContextEvent = InputEvent | MouseEvent | FocusEvent;
+type ChangeContextEvent = InputEvent | MouseEvent | FocusEvent | KeyboardEvent;
 
 type InputNumberAttr = {
   attrs: {
@@ -62,6 +62,7 @@ export default Vue.extend({
       filterValue: null,
       isError: false,
       inputting: false,
+      enter: false,
     };
   },
   computed: {
@@ -172,7 +173,7 @@ export default Vue.extend({
     },
     displayValue(): string | number {
       // inputting
-      if (this.inputting && this.userInput !== null) {
+      if (this.inputting && !this.enter && this.userInput !== null) {
         return this.filterValue;
       }
       if (this.value === undefined || this.value === null) return '';
@@ -242,47 +243,60 @@ export default Vue.extend({
       this.updateValue(value);
       emitEvent<Parameters<TdInputNumberProps['onChange']>>(this, 'change', value, ctx);
     },
-    async handleBlur(e: FocusEvent) {
-      await this.handleEndInput(e);
+    handleBlur(value: number, ctx: { e: FocusEvent }) {
+      this.handleEndInput(ctx.e);
       this.clearFilterValue();
-      emitEvent<Parameters<TdInputNumberProps['onBlur']>>(this, 'blur', this.value, { e });
+      emitEvent<Parameters<TdInputNumberProps['onBlur']>>(this, 'blur', value, ctx);
     },
-    handleFocus(e: FocusEvent) {
+    handleFocus(value: number, ctx: { e: FocusEvent }) {
       this.handleStartInput();
-      emitEvent<Parameters<TdInputNumberProps['onFocus']>>(this, 'focus', this.value, { e });
+      emitEvent<Parameters<TdInputNumberProps['onFocus']>>(this, 'focus', value, ctx);
     },
-    handleKeydownEnter(e: KeyboardEvent) {
-      if (!['Enter', 'NumpadEnter'].includes(e.code || e.key)) return;
-      emitEvent<Parameters<TdInputNumberProps['onEnter']>>(this, 'enter', this.value, { e });
+    handleKeypressEnter(value: number, ctx: { e: KeyboardEvent }) {
+      this.handleEndInput(ctx.e);
+      emitEvent<Parameters<TdInputNumberProps['onEnter']>>(this, 'enter', value, ctx);
+      this.inputting = true;
+      this.enter = true;
+      this.filterValue = String(this.value);
     },
-    handleKeydown(e: KeyboardEvent) {
-      emitEvent<Parameters<TdInputNumberProps['onKeydown']>>(this, 'keydown', this.value, { e });
-      this.handleKey(e);
+    handleKeydown(value: number, ctx: { e: KeyboardEvent }) {
+      emitEvent<Parameters<TdInputNumberProps['onKeydown']>>(this, 'keydown', value, ctx);
+      this.handleDownKey(ctx.e);
     },
-    handleKey(e: KeyboardEvent) {
+    handleDownKey(e: KeyboardEvent) {
       const keyEvent = {
         ArrowUp: this.handleAdd,
         ArrowDown: this.handleReduce,
-        Enter: this.handleKeydownEnter,
-        NumpadEnter: this.handleKeydownEnter,
       };
       const code = e.code || e.key;
       if (keyEvent[code] !== undefined) {
         keyEvent[code](e);
       }
     },
-    handleKeyup(e: KeyboardEvent) {
-      emitEvent<Parameters<TdInputNumberProps['onKeyup']>>(this, 'keyup', this.value, { e });
+    handleKeyup(value: number, ctx: { e: KeyboardEvent }) {
+      this.enter = false;
+      emitEvent<Parameters<TdInputNumberProps['onKeyup']>>(this, 'keyup', value, ctx);
     },
-    handleKeypress(e: KeyboardEvent) {
-      emitEvent<Parameters<TdInputNumberProps['onKeypress']>>(this, 'keypress', this.value, { e });
+    handleKeypress(value: number, ctx: { e: KeyboardEvent }) {
+      emitEvent<Parameters<TdInputNumberProps['onKeypress']>>(this, 'keypress', this.value, ctx);
+      this.handlePressKey(value, ctx);
+    },
+    handlePressKey(value: number, ctx: { e: KeyboardEvent }) {
+      const keyEvent = {
+        Enter: this.handleKeypressEnter,
+        NumpadEnter: this.handleKeypressEnter,
+      };
+      const code = ctx.e.code || ctx.e.key;
+      if (keyEvent[code] !== undefined) {
+        keyEvent[code](value, ctx);
+      }
     },
     handleStartInput() {
       this.inputting = true;
       if (this.value === undefined || this.value === null) return;
       this.filterValue = this.value.toFixed(this.digitsNum);
     },
-    handleEndInput(e: FocusEvent) {
+    handleEndInput(e: FocusEvent | KeyboardEvent) {
       this.inputting = false;
       let value = this.toValidNumber(this.filterValue);
       if (value !== undefined) {
@@ -372,7 +386,7 @@ export default Vue.extend({
         <t-input
           {...this.inputAttrs}
           {...this.inputEvents}
-          props={this.inputProps}
+          // props={this.inputProps}
           value={this.displayValue}
           onChange={(val: string, { e }: { e: InputEvent }) => this.handleInput(val, e)}
         />

--- a/src/input-number/input-number.tsx
+++ b/src/input-number/input-number.tsx
@@ -246,21 +246,21 @@ export default Vue.extend({
     handleBlur(value: number, ctx: { e: FocusEvent }) {
       this.handleEndInput(ctx.e);
       this.clearFilterValue();
-      emitEvent<Parameters<TdInputNumberProps['onBlur']>>(this, 'blur', value, ctx);
+      emitEvent<Parameters<TdInputNumberProps['onBlur']>>(this, 'blur', this.value, ctx);
     },
     handleFocus(value: number, ctx: { e: FocusEvent }) {
       this.handleStartInput();
-      emitEvent<Parameters<TdInputNumberProps['onFocus']>>(this, 'focus', value, ctx);
+      emitEvent<Parameters<TdInputNumberProps['onFocus']>>(this, 'focus', this.value, ctx);
     },
     handleKeypressEnter(value: number, ctx: { e: KeyboardEvent }) {
       this.handleEndInput(ctx.e);
-      emitEvent<Parameters<TdInputNumberProps['onEnter']>>(this, 'enter', value, ctx);
+      emitEvent<Parameters<TdInputNumberProps['onEnter']>>(this, 'enter', this.value, ctx);
       this.inputting = true;
       this.enter = true;
       this.filterValue = String(this.value);
     },
     handleKeydown(value: number, ctx: { e: KeyboardEvent }) {
-      emitEvent<Parameters<TdInputNumberProps['onKeydown']>>(this, 'keydown', value, ctx);
+      emitEvent<Parameters<TdInputNumberProps['onKeydown']>>(this, 'keydown', this.value, ctx);
       this.handleDownKey(ctx.e);
     },
     handleDownKey(e: KeyboardEvent) {
@@ -274,11 +274,11 @@ export default Vue.extend({
       }
     },
     handleKeyup(value: number, ctx: { e: KeyboardEvent }) {
+      emitEvent<Parameters<TdInputNumberProps['onKeyup']>>(this, 'keyup', this.value, ctx);
       this.enter = false;
-      emitEvent<Parameters<TdInputNumberProps['onKeyup']>>(this, 'keyup', value, ctx);
     },
     handleKeypress(value: number, ctx: { e: KeyboardEvent }) {
-      emitEvent<Parameters<TdInputNumberProps['onKeypress']>>(this, 'keypress', value, ctx);
+      emitEvent<Parameters<TdInputNumberProps['onKeypress']>>(this, 'keypress', this.value, ctx);
       this.handlePressKey(value, ctx);
     },
     handlePressKey(value: number, ctx: { e: KeyboardEvent }) {
@@ -386,7 +386,7 @@ export default Vue.extend({
         <t-input
           {...this.inputAttrs}
           {...this.inputEvents}
-          // props={this.inputProps}
+          props={this.inputProps}
           value={this.displayValue}
           onChange={(val: string, { e }: { e: InputEvent }) => this.handleInput(val, e)}
         />

--- a/src/input-number/type.ts
+++ b/src/input-number/type.ts
@@ -116,7 +116,7 @@ export interface TdInputNumberProps {
 
 export interface ChangeContext {
   type: ChangeSource;
-  e: InputEvent | MouseEvent | FocusEvent;
+  e: InputEvent | MouseEvent | FocusEvent | KeyboardEvent;
 }
 
 export type ChangeSource = 'add' | 'reduce' | 'input' | '';


### PR DESCRIPTION
fix #1033

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[https://github.com/Tencent/tdesign-vue/issues/1033](https://github.com/Tencent/tdesign-vue/issues/1033)

### 💡 需求背景和解决方案

1. 要解决的具体问题：1）enter 事件应从 keypress 监听，keydown 监听不到；2）事件响应出错
2. 列出最终的 API 实现和用法：1）enter 事件转移至 keypress 下监听；2）[PR 541](https://github.com/Tencent/tdesign-vue/pull/541) 将原生 `input` 更新为了 `t-input`，Event 参数需一起由1个变成2个
3. 涉及UI/交互变动需要有截图或 GIF：

修改前：
<img width="425" alt="image" src="https://user-images.githubusercontent.com/11224001/175815026-02d15adf-f73c-4f44-85e0-95d9ebeb0e72.png">


修改后：
<img width="274" alt="image" src="https://user-images.githubusercontent.com/11224001/175815923-f06f9106-ece8-422b-9aaf-9e807c55527a.png">



### 📝 更新日志


- fix(input-number): enter 等事件响应

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
