### PR TITLE
fix(ConfigProvider): 修复 config-provider 同时存在 provide 和 setup#provide 导致卡顿的性能问题

### DIFF
--- a/src/config-provider/config-provider.tsx
+++ b/src/config-provider/config-provider.tsx
@@ -1,6 +1,5 @@
 import Vue, { PropType, VNode } from 'vue';
 import cloneDeep from 'lodash/cloneDeep';
-import { provide, computed } from '@vue/composition-api';
 import { GlobalConfigProvider } from './type';
 import { defaultGlobalConfig, mergeWith } from './context';
 

--- a/src/config-provider/config-provider.tsx
+++ b/src/config-provider/config-provider.tsx
@@ -2,7 +2,7 @@ import Vue, { PropType, VNode } from 'vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { provide, computed } from '@vue/composition-api';
 import { GlobalConfigProvider } from './type';
-import { configProviderInjectKey, defaultGlobalConfig, mergeWith } from './context';
+import { defaultGlobalConfig, mergeWith } from './context';
 
 const ConfigProvider = Vue.extend({
   name: 'TConfigProvider',
@@ -27,14 +27,6 @@ const ConfigProvider = Vue.extend({
       const mergedGlobalConfig = mergeWith(this.defaultData, this.globalConfig);
       return mergedGlobalConfig;
     },
-  },
-
-  setup(props) {
-    const defaultData = cloneDeep(defaultGlobalConfig);
-    provide(
-      configProviderInjectKey,
-      computed(() => mergeWith(defaultData, props.globalConfig)),
-    );
   },
 
   render(): VNode {

--- a/src/config-provider/context.ts
+++ b/src/config-provider/context.ts
@@ -18,8 +18,6 @@ export type Locale = typeof defaultZhCN;
 // 导出全局配置（包括语言配置）全部类型
 export * from './type';
 
-export const configProviderInjectKey: InjectionKey<ComputedRef<GlobalConfigProvider>> = Symbol('configProvide');
-
 // deal with https://github.com/lodash/lodash/issues/1313
 export const mergeWith = (defaultGlobalConfig: GlobalConfigProvider, injectConfig: GlobalConfigProvider) => _mergeWith(defaultGlobalConfig, injectConfig, (objValue, srcValue) => {
   if (Array.isArray(objValue)) {

--- a/src/config-provider/context.ts
+++ b/src/config-provider/context.ts
@@ -1,4 +1,3 @@
-import { InjectionKey, ComputedRef } from '@vue/composition-api';
 import merge from 'lodash/merge';
 import _mergeWith from 'lodash/mergeWith';
 import defaultConfig from '../_common/js/global-config/default-config';

--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -9,7 +9,7 @@ import { GlobalConfigProvider, defaultGlobalConfig } from './context';
  */
 export function useConfig<T extends keyof GlobalConfigProvider>(componentName?: T) {
   const injectGlobalConfig = inject<GlobalConfigProvider>('globalConfig', null);
-  const mergedGlobalConfig = computed(() => injectGlobalConfig?.value || defaultGlobalConfig);
+  const mergedGlobalConfig = computed(() => injectGlobalConfig || defaultGlobalConfig);
   const global = computed(() => mergedGlobalConfig.value[componentName]);
 
   const classPrefix = computed(() => mergedGlobalConfig.value.classPrefix);

--- a/src/config-provider/useConfig.tsx
+++ b/src/config-provider/useConfig.tsx
@@ -1,5 +1,5 @@
 import { computed, inject, h } from '@vue/composition-api';
-import { GlobalConfigProvider, defaultGlobalConfig, configProviderInjectKey } from './context';
+import { GlobalConfigProvider, defaultGlobalConfig } from './context';
 
 /**
  * component global config
@@ -8,7 +8,7 @@ import { GlobalConfigProvider, defaultGlobalConfig, configProviderInjectKey } fr
  * useConfig('pagination')
  */
 export function useConfig<T extends keyof GlobalConfigProvider>(componentName?: T) {
-  const injectGlobalConfig = inject(configProviderInjectKey, null);
+  const injectGlobalConfig = inject<GlobalConfigProvider>('globalConfig', null);
   const mergedGlobalConfig = computed(() => injectGlobalConfig?.value || defaultGlobalConfig);
   const global = computed(() => mergedGlobalConfig.value[componentName]);
 


### PR DESCRIPTION
…导致卡顿的性能问题

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

目前在内存较大的页面再 window.open() tdesign 的表格组件，此时会卡顿，最根本原因是 config-provider 提供了两种 provide，导致有冲突，改成一种形式即可解决

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(ConfigProvider): 修复 config-provider 同时存在 provide 和 setup#provide 导致卡顿的性能问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
