### PR TITLE
fix(table): 修复可选中行table组件，data为空数据时，默认全选按钮会选中的问题

### DIFF
--- a/src/table/hooks/useRowSelect.tsx
+++ b/src/table/hooks/useRowSelect.tsx
@@ -65,12 +65,14 @@ export default function useRowSelect(props: TdPrimaryTableProps) {
 
   // eslint-disable-next-line
   function getSelectedHeader(h: CreateElement) {
+    const isIndeterminate = intersectionKeys.value.length > 0 && intersectionKeys.value.length < canSelectedRows.value.length;
+    const isChecked = intersectionKeys.value.length !== 0
+      && canSelectedRows.value.length !== 0
+      && intersectionKeys.value.length === canSelectedRows.value.length;
     return () => (
       <Checkbox
-        checked={intersectionKeys.value.length === canSelectedRows.value.length}
-        indeterminate={
-          intersectionKeys.value.length > 0 && intersectionKeys.value.length < canSelectedRows.value.length
-        }
+        checked={isChecked}
+        indeterminate={isIndeterminate}
         disabled={!canSelectedRows.value.length}
         {...{ on: { change: handleSelectAll } }}
       />


### PR DESCRIPTION
修复可选中行table组件，data为空数据时，默认全选按钮会选中的问题

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#1143 
### 💡 需求背景和解决方案
<img width="840" alt="image" src="https://user-images.githubusercontent.com/32627250/178149849-dda88ed0-a91c-4b20-a270-0852cad63c74.png">
修复后
<img width="849" alt="image" src="https://user-images.githubusercontent.com/32627250/178149672-95d8aefe-deb3-4c08-bbfc-87681a244bfd.png">
原因
对空数据没进行判断
解决方案
对空数据做处理
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 修复可选中行table组件，data为空数据时，默认全选按钮会选中的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
