### PR TITLE
【修复】表格列宽拖拽到最大或最小时，有可能无法二次拖拽

### DIFF
--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -56,9 +56,9 @@ export default function useColumnResize(tableContentRef: Ref<HTMLDivElement>, re
     const tableBoundRect = tableContentRef.value?.getBoundingClientRect();
     const resizeLinePos = targetBoundRect.right - tableBoundRect.left;
     const colLeft = targetBoundRect.left - tableBoundRect.left;
-    const minColLen = col.resize?.minWidth || DEFAULT_MIN_WIDTH;
+    const minColWidth = col.resize?.minWidth || DEFAULT_MIN_WIDTH;
     const maxColWidth = col.resize?.maxWidth || DEFAULT_MAX_WIDTH;
-    const minResizeLineLeft = colLeft + minColLen;
+    const minResizeLineLeft = colLeft + minColWidth;
     const maxResizeLineLeft = colLeft + maxColWidth;
 
     // 开始拖拽，记录下鼠标起始位置
@@ -78,10 +78,15 @@ export default function useColumnResize(tableContentRef: Ref<HTMLDivElement>, re
     const onDragEnd = () => {
       if (resizeLineParams.isDragging) {
         // 结束拖拽，更新列宽
-        const width = parseInt(resizeLineStyle.left, 10) - colLeft;
-
+        let width = Math.ceil(parseInt(resizeLineStyle.left, 10) - colLeft) || 0;
+        // 为了避免精度问题，导致 width 宽度超出 [minColWidth, maxColWidth] 的范围，需要对比目标宽度和最小/最大宽度
+        if (width <= minColWidth) {
+          width = minColWidth;
+        } else if (width >= maxColWidth) {
+          width = maxColWidth;
+        }
         // eslint-disable-next-line
-        col.width = `${Math.floor(width)}px`;
+        col.width = `${width}px`;
 
         // 恢复设置
         resizeLineParams.isDragging = false;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/1067


### 💡 需求背景和解决方案

解决问题：由于计算精度问题，导致拖拽的宽度和minWidth/maxWidth有一点偏差，无法出发二次拖拽事件

### 📝 更新日志

- fix(table): 表格列宽拖拽到最大或最小时，有可能无法二次拖拽


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
