### PR TITLE
fix: 兼容IE滚动条高度计算覆盖不全问题

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -30,6 +30,7 @@ import { ROW_LISTENERS } from './tr';
 import THead from './thead';
 import TFoot from './tfoot';
 import log from '../_common/js/log';
+import { getIEVersion } from '../_common/js/utils/helper';
 import { getAffixProps } from './utils';
 
 export const BASE_TABLE_EVENTS = ['page-change', 'cell-click', 'scroll', 'scrollX', 'scrollY'];
@@ -308,7 +309,8 @@ export default defineComponent({
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
     const affixHeaderWrapHeightStyle = {
       width: `${this.tableWidth}px`,
-      height: `${barWidth === 12 ? affixHeaderWrapHeight - 4 : affixHeaderWrapHeight}px`,
+      // IE浏览器需要遮挡header吸顶滚动条，要减去getBoundingClientRect.height的滚动条高度4像素
+      height: `${getIEVersion() <= 11 ? affixHeaderWrapHeight - 4 : affixHeaderWrapHeight}px`,
       opacity: headerOpacity,
       marginTop: onlyVirtualScrollBordered ? `${borderWidth}px` : 0,
     };

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -306,12 +306,13 @@ export default defineComponent({
     const barWidth = this.isWidthOverflow ? this.scrollbarWidth : 0;
     // IE浏览器需要遮挡header吸顶滚动条，要减去getBoundingClientRect.height的滚动条高度4像素
     const IEHeaderWrap = getIEVersion() <= 11 ? 4 : 0;
-    const affixHeaderWrapHeight = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - barWidth - borderWidth;
+    const affixHeaderHeight = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - IEHeaderWrap;
+    const affixHeaderWrapHeight = affixHeaderHeight - barWidth - borderWidth;
     // 两类场景：1. 虚拟滚动，永久显示表头，直到表头消失在可视区域； 2. 表头吸顶，根据滚动情况判断是否显示吸顶表头
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
     const affixHeaderWrapHeightStyle = {
       width: `${this.tableWidth}px`,
-      height: `${affixHeaderWrapHeight - IEHeaderWrap}px`,
+      height: `${affixHeaderWrapHeight}px`,
       opacity: headerOpacity,
       marginTop: onlyVirtualScrollBordered ? `${borderWidth}px` : 0,
     };

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -304,14 +304,14 @@ export default defineComponent({
     const onlyVirtualScrollBordered = !!(this.isVirtual && !this.headerAffixedTop && this.bordered) && /Chrome/.test(navigator?.userAgent);
     const borderWidth = this.bordered && onlyVirtualScrollBordered ? 1 : 0;
     const barWidth = this.isWidthOverflow ? this.scrollbarWidth : 0;
+    // IE浏览器需要遮挡header吸顶滚动条，要减去getBoundingClientRect.height的滚动条高度4像素
+    const IEHeaderWrap = getIEVersion() <= 11 ? 4 : 0;
     const affixHeaderWrapHeight = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - barWidth - borderWidth;
     // 两类场景：1. 虚拟滚动，永久显示表头，直到表头消失在可视区域； 2. 表头吸顶，根据滚动情况判断是否显示吸顶表头
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
-    // IE浏览器需要遮挡header吸顶滚动条，要减去getBoundingClientRect.height的滚动条高度4像素
-    const IEHeaderWrap = 4;
     const affixHeaderWrapHeightStyle = {
       width: `${this.tableWidth}px`,
-      height: `${getIEVersion() <= 11 ? affixHeaderWrapHeight - IEHeaderWrap : affixHeaderWrapHeight}px`,
+      height: `${affixHeaderWrapHeight - IEHeaderWrap}px`,
       opacity: headerOpacity,
       marginTop: onlyVirtualScrollBordered ? `${borderWidth}px` : 0,
     };

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -307,10 +307,11 @@ export default defineComponent({
     const affixHeaderWrapHeight = (this.affixHeaderRef?.getBoundingClientRect().height || 0) - barWidth - borderWidth;
     // 两类场景：1. 虚拟滚动，永久显示表头，直到表头消失在可视区域； 2. 表头吸顶，根据滚动情况判断是否显示吸顶表头
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
+    // IE浏览器需要遮挡header吸顶滚动条，要减去getBoundingClientRect.height的滚动条高度4像素
+    const IEHeaderWrap = 4;
     const affixHeaderWrapHeightStyle = {
       width: `${this.tableWidth}px`,
-      // IE浏览器需要遮挡header吸顶滚动条，要减去getBoundingClientRect.height的滚动条高度4像素
-      height: `${getIEVersion() <= 11 ? affixHeaderWrapHeight - 4 : affixHeaderWrapHeight}px`,
+      height: `${getIEVersion() <= 11 ? affixHeaderWrapHeight - IEHeaderWrap : affixHeaderWrapHeight}px`,
       opacity: headerOpacity,
       marginTop: onlyVirtualScrollBordered ? `${borderWidth}px` : 0,
     };

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -308,7 +308,7 @@ export default defineComponent({
     const headerOpacity = props.headerAffixedTop ? Number(this.showAffixHeader) : 1;
     const affixHeaderWrapHeightStyle = {
       width: `${this.tableWidth}px`,
-      height: `${affixHeaderWrapHeight}px`,
+      height: `${barWidth === 12 ? affixHeaderWrapHeight - 4 : affixHeaderWrapHeight}px`,
       opacity: headerOpacity,
       marginTop: onlyVirtualScrollBordered ? `${borderWidth}px` : 0,
     };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 💡 需求背景和解决方案
IE 下，滚动条高度计算相差4像素，导致吸顶header不能盖住滚动条
![image](https://user-images.githubusercontent.com/766999/178752700-9f4b7e37-408a-4a47-97c3-4390e402dfed.png)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 兼容IE滚动条高度计算覆盖不全问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
