### PR TITLE
feat: support close popup when double click input area

### DIFF
--- a/examples/select-input/usage/props.json
+++ b/examples/select-input/usage/props.json
@@ -69,11 +69,5 @@
         "value": "error"
       }
     ]
-  },
-  {
-    "name": "value",
-    "type": "Boolean",
-    "defaultValue": false,
-    "options": []
   }
 ]

--- a/src/select-input/select-input.tsx
+++ b/src/select-input/select-input.tsx
@@ -60,7 +60,6 @@ export default defineComponent({
 
   render(h) {
     // 浮层显示的受控与非受控
-    // 浮层显示的受控与非受控
     const visibleProps = { visible: this.popupVisible ?? this.innerPopupVisible };
 
     const mainContent = (

--- a/src/select-input/useOverlayStyle.ts
+++ b/src/select-input/useOverlayStyle.ts
@@ -39,11 +39,9 @@ export default function useOverlayStyle(props: overlayStyleProps) {
 
   const onInnerPopupVisibleChange = (visible: boolean, context: PopupVisibleChangeContext) => {
     if (props.disabled || props.readonly) return;
-    // 如果点击触发元素（输入框），则永久显示下拉框
-    const newVisible = context.trigger === 'trigger-element-click' ? true : visible;
-    innerPopupVisible.value = newVisible;
-    props.onPopupVisibleChange?.(newVisible, context);
-    instance.emit('popup-visible-change', newVisible, context);
+    innerPopupVisible.value = visible;
+    props.onPopupVisibleChange?.(visible, context);
+    instance.emit('popup-visible-change', visible, context);
   };
 
   const tOverlayStyle = computed(() => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-react/issues/919

react 对应修改：https://github.com/Tencent/tdesign-react/pull/1174
vue-next 对应修改：https://github.com/Tencent/tdesign-vue-next/pull/1299

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(SelectInput): SelectInput 及相关的 Select/Cascader/TreeSelect 组件交互调整，再次点击输入框时也可以收起下拉框。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
