### PR TITLE
fix(table): 列拖动后，选择行导致拖动后的距离被重置

### DIFF
--- a/src/table/hooks/useRowSelect.tsx
+++ b/src/table/hooks/useRowSelect.tsx
@@ -67,12 +67,14 @@ export default function useRowSelect(
 
   // eslint-disable-next-line
   function getSelectedHeader(h: CreateElement) {
-    const isChecked = intersectionKeys.value.length !== 0
-      && canSelectedRows.value.length !== 0
-      && intersectionKeys.value.length === canSelectedRows.value.length;
+    // 判断条件直接写在jsx中，防止变量被computed捕获，选中行重新计算了columns
     return () => (
       <Checkbox
-        checked={isChecked}
+        checked={
+          intersectionKeys.value.length !== 0
+          && canSelectedRows.value.length !== 0
+          && intersectionKeys.value.length === canSelectedRows.value.length
+        }
         indeterminate={
           intersectionKeys.value.length > 0 && intersectionKeys.value.length < canSelectedRows.value.length
         }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

列拖动后，选择行导致拖动后的距离被重置问题
https://github.com/Tencent/tdesign-vue/issues/859#issuecomment-1123176523

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 列拖动后，选择行导致拖动后的距离被重置

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
