### PR TITLE
fix(table): 列宽度和小于表宽的情况下，调整列宽的结果与预期不符

### DIFF
--- a/examples/table/demos/affix.vue
+++ b/examples/table/demos/affix.vue
@@ -24,7 +24,7 @@
         horizontalScrollAffixedBottom ? { offsetBottom: paginationAffixedBottom ? 61 : 0, zIndex: 1000 } : false
       "
       :paginationAffixedBottom="paginationAffixedBottom"
-      tableLayout="auto"
+      table-ayout="fixed"
       dragSort="col"
       bordered
       resizable

--- a/examples/table/demos/filter-controlled.vue
+++ b/examples/table/demos/filter-controlled.vue
@@ -37,6 +37,7 @@
       :filter-value="filterValue"
       :bordered="bordered"
       resizable
+      table-layout="fixed"
       @filter-change="onFilterChange"
       @change="onChange"
     />

--- a/examples/table/demos/merge-cells.vue
+++ b/examples/table/demos/merge-cells.vue
@@ -6,6 +6,7 @@
     :columns="columns"
     :size="size"
     :rowspanAndColspan="rowspanAndColspan"
+    table-layout="fixed"
     resizable
   >
   </t-table>

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -81,7 +81,8 @@ export default defineComponent({
       emitScrollEvent,
       setUseFixedTableElmRef,
       updateColumnFixedShadow,
-      setThWidthListByColumnDrag,
+      getThWidthList,
+      setThWidthList,
     } = useFixed(props, context, finalColumns);
 
     // 1. 表头吸顶；2. 表尾吸底；3. 底部滚动条吸底；4. 分页器吸底
@@ -101,7 +102,7 @@ export default defineComponent({
     const { dataSource, isPaginateData, renderPagination } = usePagination(props, context);
 
     // 列宽拖拽逻辑
-    const columnResizeParams = useColumnResize(tableContentRef, refreshTable, setThWidthListByColumnDrag);
+    const columnResizeParams = useColumnResize(tableContentRef, refreshTable, getThWidthList, setThWidthList);
     const { resizeLineRef, resizeLineStyle } = columnResizeParams;
 
     const dynamicBaseTableClasses = computed(() => [

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -296,7 +296,7 @@ export default defineComponent({
     }
     const columnResizable = this.allowResizeColumnWidth === undefined ? this.resizable : this.allowResizeColumnWidth;
     const defaultColWidth = this.tableLayout === 'fixed' && this.isWidthOverflow ? '100px' : undefined;
-    if (this.resizable) {
+    if (columnResizable) {
       this.recalculateColWidth(columns);
     }
     const colgroup = (

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -82,7 +82,6 @@ export default defineComponent({
       setUseFixedTableElmRef,
       updateColumnFixedShadow,
       setThWidthListByColumnDrag,
-      recalculateColWidth,
     } = useFixed(props, context, finalColumns);
 
     // 1. 表头吸顶；2. 表尾吸底；3. 底部滚动条吸底；4. 分页器吸底
@@ -281,7 +280,6 @@ export default defineComponent({
       updateAffixHeaderOrFooter,
       refreshTable,
       onInnerVirtualScroll,
-      recalculateColWidth,
     };
   },
 

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -82,7 +82,8 @@ export default defineComponent({
       setUseFixedTableElmRef,
       updateColumnFixedShadow,
       getThWidthList,
-      setThWidthList,
+      updateThWidthList,
+      setRecalculateColWidthFuncRef,
     } = useFixed(props, context, finalColumns);
 
     // 1. 表头吸顶；2. 表尾吸底；3. 底部滚动条吸底；4. 分页器吸底
@@ -102,8 +103,9 @@ export default defineComponent({
     const { dataSource, isPaginateData, renderPagination } = usePagination(props, context);
 
     // 列宽拖拽逻辑
-    const columnResizeParams = useColumnResize(tableContentRef, refreshTable, getThWidthList, setThWidthList);
-    const { resizeLineRef, resizeLineStyle } = columnResizeParams;
+    const columnResizeParams = useColumnResize(tableContentRef, refreshTable, getThWidthList, updateThWidthList);
+    const { resizeLineRef, resizeLineStyle, recalculateColWidth } = columnResizeParams;
+    setRecalculateColWidthFuncRef(recalculateColWidth);
 
     const dynamicBaseTableClasses = computed(() => [
       tableClasses.value,

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -61,6 +61,8 @@ export default defineComponent({
     // 表格基础样式类
     const { tableClasses, tableContentStyles, tableElementStyles } = useStyle(props);
     const { global } = useConfig('table');
+    const { isMultipleHeader, spansAndLeafNodes, thList } = useTableHeader(props);
+    const finalColumns = computed(() => spansAndLeafNodes.value?.leafColumns || props.columns);
 
     // 固定表头和固定列逻辑
     const {
@@ -81,7 +83,7 @@ export default defineComponent({
       updateColumnFixedShadow,
       setThWidthListByColumnDrag,
       recalculateColWidth,
-    } = useFixed(props, context);
+    } = useFixed(props, context, finalColumns);
 
     // 1. 表头吸顶；2. 表尾吸底；3. 底部滚动条吸底；4. 分页器吸底
     const {
@@ -97,7 +99,6 @@ export default defineComponent({
       setTableContentRef,
     } = useAffix(props);
 
-    const { isMultipleHeader, spansAndLeafNodes, thList } = useTableHeader(props);
     const { dataSource, isPaginateData, renderPagination } = usePagination(props, context);
 
     // 列宽拖拽逻辑
@@ -297,9 +298,6 @@ export default defineComponent({
       log.warn('Table', 'table-layout can not be `auto` for resizable column table, set `table-layout: fixed` please.');
     }
     const defaultColWidth = this.tableLayout === 'fixed' && this.isWidthOverflow ? '100px' : undefined;
-    if (columnResizable) {
-      this.recalculateColWidth(columns);
-    }
     const colgroup = (
       <colgroup>
         {columns.map((col) => (

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -293,6 +293,9 @@ export default defineComponent({
       log.warn('Table', 'allowResizeColumnWidth is going to be deprecated, please use resizable instead.');
     }
     const columnResizable = this.allowResizeColumnWidth === undefined ? this.resizable : this.allowResizeColumnWidth;
+    if (columnResizable && this.tableLayout === 'auto') {
+      log.warn('Table', 'table-layout can not be `auto` for resizable column table, set `table-layout: fixed` please.');
+    }
     const defaultColWidth = this.tableLayout === 'fixed' && this.isWidthOverflow ? '100px' : undefined;
     if (columnResizable) {
       this.recalculateColWidth(columns);
@@ -446,6 +449,7 @@ export default defineComponent({
             bordered={this.bordered}
             spansAndLeafNodes={this.spansAndLeafNodes}
             thList={this.thList}
+            thWidthList={this.thWidthList}
             resizable={columnResizable}
             columnResizeParams={this.columnResizeParams}
           />

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -11,7 +11,6 @@ import {
   onMounted,
 } from '@vue/composition-api';
 import pick from 'lodash/pick';
-import { isNumber } from 'lodash';
 import props from './base-table-props';
 import useTableHeader from './hooks/useTableHeader';
 import useColumnResize from './hooks/useColumnResize';
@@ -33,7 +32,6 @@ import TFoot from './tfoot';
 import log from '../_common/js/log';
 import { getIEVersion } from '../_common/js/utils/helper';
 import { getAffixProps } from './utils';
-import { BaseTableCol, TableRowData } from './type';
 
 export const BASE_TABLE_EVENTS = ['page-change', 'cell-click', 'scroll', 'scrollX', 'scrollY'];
 export const BASE_TABLE_ALL_EVENTS = ROW_LISTENERS.map((t) => `row-${t}`).concat(BASE_TABLE_EVENTS);

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -31,7 +31,7 @@ export default function useColumnResize(
 
   // 表格列宽拖拽事件
   // 只在表头显示拖拽图标
-  const onColumnMouseover = (e: MouseEvent, col: BaseTableCol<TableRowData>) => {
+  const onColumnMouseover = (e: MouseEvent) => {
     if (!resizeLineRef.value) return;
 
     const target = (e.target as HTMLElement).closest('th');

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -88,8 +88,6 @@ export default function useColumnResize(
         } else if (width >= maxColWidth) {
           width = maxColWidth;
         }
-        // eslint-disable-next-line
-        // col.width = `${width}px`;
         setThWidthListByColumnDrag(col, width, nearCol, nearCol.resize?.minWidth || DEFAULT_MIN_WIDTH);
 
         // 恢复设置

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -4,7 +4,16 @@ import { BaseTableCol, TableRowData } from '../type';
 const DEFAULT_MIN_WIDTH = 80;
 const DEFAULT_MAX_WIDTH = 600;
 
-export default function useColumnResize(tableContentRef: Ref<HTMLDivElement>, refreshTable: () => void) {
+export default function useColumnResize(
+  tableContentRef: Ref<HTMLDivElement>,
+  refreshTable: () => void,
+  setThWidthListByColumnDrag: (
+    dragCol: BaseTableCol<TableRowData>,
+    dragWidth: number,
+    nearCol: BaseTableCol<TableRowData>,
+    minWidth: number,
+  ) => void,
+) {
   const resizeLineRef = ref<HTMLDivElement>();
 
   const resizeLineParams = {
@@ -32,11 +41,7 @@ export default function useColumnResize(tableContentRef: Ref<HTMLDivElement>, re
       const maxWidth = col.resize?.maxWidth || DEFAULT_MAX_WIDTH;
       // 当离右边框的距离不超过 8 时，显示拖拽图标
       const distance = 8;
-      if (
-        targetBoundRect.width >= minWidth
-        && targetBoundRect.width <= maxWidth
-        && targetBoundRect.right - e.pageX <= distance
-      ) {
+      if (targetBoundRect.right - e.pageX <= distance) {
         target.style.cursor = 'col-resize';
         resizeLineParams.draggingCol = target;
       } else {
@@ -47,7 +52,7 @@ export default function useColumnResize(tableContentRef: Ref<HTMLDivElement>, re
   };
 
   // 调整表格列宽
-  const onColumnMousedown = (e: MouseEvent, col: BaseTableCol<TableRowData>) => {
+  const onColumnMousedown = (e: MouseEvent, col: BaseTableCol<TableRowData>, nearCol: BaseTableCol<TableRowData>) => {
     // 非 resize 的点击，不做处理
     if (!resizeLineParams.draggingCol) return;
 
@@ -86,7 +91,8 @@ export default function useColumnResize(tableContentRef: Ref<HTMLDivElement>, re
           width = maxColWidth;
         }
         // eslint-disable-next-line
-        col.width = `${width}px`;
+        // col.width = `${width}px`;
+        setThWidthListByColumnDrag(col, width, nearCol, nearCol.resize?.minWidth || DEFAULT_MIN_WIDTH);
 
         // 恢复设置
         resizeLineParams.isDragging = false;

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -37,8 +37,6 @@ export default function useColumnResize(
     const target = (e.target as HTMLElement).closest('th');
     const targetBoundRect = target.getBoundingClientRect();
     if (!resizeLineParams.isDragging) {
-      const minWidth = col.resize?.minWidth || DEFAULT_MIN_WIDTH;
-      const maxWidth = col.resize?.maxWidth || DEFAULT_MAX_WIDTH;
       // 当离右边框的距离不超过 8 时，显示拖拽图标
       const distance = 8;
       if (targetBoundRect.right - e.pageX <= distance) {

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -1,5 +1,6 @@
 import { ref, Ref, reactive } from '@vue/composition-api';
 import isNumber from 'lodash/isNumber';
+import { RecalculateColumnWidthFunc } from '../interface';
 import { BaseTableCol, TableRowData } from '../type';
 
 const DEFAULT_MIN_WIDTH = 80;
@@ -144,12 +145,12 @@ export default function useColumnResize(
     document.ondragstart = () => false;
   };
 
-  const recalculateColWidth = (
+  const recalculateColWidth: RecalculateColumnWidthFunc = (
     columns: BaseTableCol<TableRowData>[],
     thWidthList: { [colKey: string]: number },
     tableLayout: string,
     tableElmWidth: number,
-  ) => {
+  ): void => {
     let actualWidth = 0;
     const missingWidthCols: BaseTableCol<TableRowData>[] = [];
     const thMap: { [colKey: string]: number } = {};

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -2,7 +2,7 @@ import {
   ref, reactive, watch, toRefs, SetupContext, onMounted, computed, onBeforeMount,
 } from '@vue/composition-api';
 import get from 'lodash/get';
-import { isNumber } from 'lodash';
+import isNumber from 'lodash/isNumber';
 import log from '../../_common/js/log';
 import { ClassName, Styles } from '../../common';
 import { BaseTableCol, TableRowData, TdBaseTableProps } from '../type';

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -16,7 +16,11 @@ import { BaseTableCol, TableRowData, TdBaseTableProps } from '../type';
 import getScrollbarWidth from '../../_common/js/utils/getScrollbarWidth';
 import { on, off } from '../../utils/dom';
 import {
-  FixedColumnInfo, TableRowFixedClasses, RowAndColFixedPosition, TableColFixedClasses,
+  FixedColumnInfo,
+  TableRowFixedClasses,
+  RowAndColFixedPosition,
+  TableColFixedClasses,
+  RecalculateColumnWidthFunc,
 } from '../interface';
 
 // 固定列相关类名处理
@@ -128,27 +132,13 @@ export default function useFixed(
     ),
   );
 
-  const recalculateColWidth = ref<(
-    columns: BaseTableCol<TableRowData>[],
-    thWidthList: { [colKey: string]: number },
-    tableLayout: string,
-    tableElmWidth: number,
-  ) => void
-    >(() => {},
-    );
+  const recalculateColWidth = ref<RecalculateColumnWidthFunc>(() => {});
 
   function setUseFixedTableElmRef(val: HTMLTableElement) {
     tableElmRef.value = val;
   }
 
-  function setRecalculateColWidthFuncRef(
-    val: (
-      columns: BaseTableCol<TableRowData>[],
-      thWidthList: { [colKey: string]: number },
-      tableLayout: string,
-      tableElmWidth: number,
-    ) => void,
-  ) {
+  function setRecalculateColWidthFuncRef(val: RecalculateColumnWidthFunc) {
     recalculateColWidth.value = val;
   }
 

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -103,7 +103,7 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
   const isFixedRightColumn = ref(false);
   const isFixedLeftColumn = ref(false);
 
-  const dragingCols = ref<string[]>([]);
+  const draggingCols = ref<string[]>([]);
 
   // 没有表头吸顶，没有虚拟滚动，则不需要表头宽度计算
   const notNeedThWidthList = computed(
@@ -403,7 +403,7 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
 
     thWidthList.value[dragCol.colKey] = dragWidth;
     thWidthList.value[nearCol.colKey] = Math.max(minWidth, oldWidth + oldNearWidth - dragWidth);
-    dragingCols.value = [dragCol.colKey, nearCol.colKey];
+    draggingCols.value = [dragCol.colKey, nearCol.colKey];
   };
 
   const recalculateColWidth = (columns: BaseTableCol<TableRowData>[]) => {
@@ -430,16 +430,16 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
           thWidthList.value[col.colKey] = avgWidth;
         });
       } else {
-        if (dragingCols.value.length) {
+        if (draggingCols.value.length) {
           let sum = 0;
-          dragingCols.value.forEach((colKey) => {
+          draggingCols.value.forEach((colKey) => {
             sum += thWidthList.value[colKey];
           });
           actualWidth -= sum;
           tableElmWidth.value -= sum;
         }
         columns.forEach((col) => {
-          if (dragingCols.value.includes(col.colKey)) return;
+          if (draggingCols.value.includes(col.colKey)) return;
           thWidthList.value[col.colKey] = (thWidthList.value[col.colKey] / actualWidth) * tableElmWidth.value;
         });
       }
@@ -450,7 +450,7 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
       });
     }
 
-    dragingCols.value = [];
+    draggingCols.value = [];
   };
 
   watch(

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -405,24 +405,28 @@ export default function useFixed(
     context.emit('scroll', { e });
   };
 
-  const setThWidthListByColumnDrag = (
-    dragCol: BaseTableCol<TableRowData>,
-    dragWidth: number,
-    nearCol: BaseTableCol<TableRowData>,
-    minWidth: number,
-  ) => {
+  const getThWidthList = () => {
+    if (!thWidthList.value) {
+      thWidthList.value = {};
+    }
+    return thWidthList.value;
+  };
+
+  const setDraggingCols = (colKeys: string[]) => {
+    draggingCols.value = colKeys;
+  };
+
+  const setThWidthList = (data: { [colKey: string]: number }) => {
     if (!thWidthList.value) {
       thWidthList.value = {};
     }
 
-    const propColWidth = isNumber(dragCol.width) ? dragCol.width : parseFloat(dragCol.width);
-    const propNearColWidth = isNumber(nearCol.width) ? nearCol.width : parseFloat(nearCol.width);
-    const oldWidth = thWidthList.value[dragCol.colKey] || propColWidth;
-    const oldNearWidth = thWidthList.value[nearCol.colKey] || propNearColWidth;
-
-    thWidthList.value[dragCol.colKey] = dragWidth;
-    thWidthList.value[nearCol.colKey] = Math.max(minWidth, oldWidth + oldNearWidth - dragWidth);
-    draggingCols.value = [dragCol.colKey, nearCol.colKey];
+    const draggingCols: string[] = [];
+    Object.entries(data).forEach(([colKey, width]) => {
+      thWidthList.value[colKey] = width;
+      draggingCols.push(colKey);
+    });
+    setDraggingCols(draggingCols);
   };
 
   const recalculateColWidth = (columns: BaseTableCol<TableRowData>[]) => {
@@ -621,6 +625,7 @@ export default function useFixed(
     updateThWidthListHandler,
     updateColumnFixedShadow,
     setUseFixedTableElmRef,
-    setThWidthListByColumnDrag,
+    getThWidthList,
+    setThWidthList,
   };
 }

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -79,6 +79,8 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
     headerAffixedTop,
     footerAffixedBottom,
     bordered,
+    resizable,
+    allowResizeColumnWidth,
   } = toRefs(props);
   const data = ref<TableRowData[]>([]);
   const tableContentRef = ref<HTMLDivElement>();
@@ -351,6 +353,8 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
   };
 
   const updateThWidthList = (trList: HTMLCollection) => {
+    const columnResizable = resizable.value || allowResizeColumnWidth.value || false;
+    if (columnResizable) return;
     const widthMap: { [colKey: string]: number } = {};
     for (let i = 0, len = trList.length; i < len; i++) {
       const thList = trList[i].children;
@@ -422,13 +426,33 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
       }
     });
 
-    if (tableElmWidth.value > 0 && actualWidth < tableElmWidth.value) {
+    let tableWidth = tableElmWidth.value;
+    let needUpdate = false;
+    if (tableWidth > 0) {
       if (missingWidthCols.length) {
-        const widthDiff = tableElmWidth.value - actualWidth;
-        const avgWidth = widthDiff / missingWidthCols.length;
-        missingWidthCols.forEach((col) => {
-          thWidthList.value[col.colKey] = avgWidth;
-        });
+        if (actualWidth < tableWidth) {
+          const widthDiff = tableWidth - actualWidth;
+          const avgWidth = widthDiff / missingWidthCols.length;
+          missingWidthCols.forEach((col) => {
+            thWidthList.value[col.colKey] = avgWidth;
+          });
+        } else if (tableLayout.value === 'fixed') {
+          missingWidthCols.forEach((col) => {
+            const originWidth = thWidthList.value[col.colKey] || 100;
+            thWidthList.value[col.colKey] = isNumber(originWidth) ? originWidth : parseFloat(originWidth);
+          });
+        } else {
+          const extraWidth = missingWidthCols.length * 100;
+          const totalWidth = extraWidth + actualWidth;
+          columns.forEach((col) => {
+            if (!thWidthList.value[col.colKey]) {
+              thWidthList.value[col.colKey] = (100 / totalWidth) * tableWidth;
+            } else {
+              thWidthList.value[col.colKey] = (thWidthList.value[col.colKey] / totalWidth) * tableWidth;
+            }
+          });
+        }
+        needUpdate = true;
       } else {
         if (draggingCols.value.length) {
           let sum = 0;
@@ -436,21 +460,45 @@ export default function useFixed(props: TdBaseTableProps, context: SetupContext)
             sum += thWidthList.value[colKey];
           });
           actualWidth -= sum;
-          tableElmWidth.value -= sum;
+          tableWidth -= sum;
         }
-        columns.forEach((col) => {
-          if (draggingCols.value.includes(col.colKey)) return;
-          thWidthList.value[col.colKey] = (thWidthList.value[col.colKey] / actualWidth) * tableElmWidth.value;
-        });
+
+        if (actualWidth !== tableWidth || draggingCols.value.length) {
+          columns.forEach((col) => {
+            if (draggingCols.value.includes(col.colKey)) return;
+            thWidthList.value[col.colKey] = (thWidthList.value[col.colKey] / actualWidth) * tableWidth;
+          });
+          needUpdate = true;
+        }
       }
     } else {
       missingWidthCols.forEach((col) => {
-        const originWidth = thWidthList.value[col.colKey] || col.width || 100;
+        const originWidth = thWidthList.value[col.colKey] || 100;
         thWidthList.value[col.colKey] = isNumber(originWidth) ? originWidth : parseFloat(originWidth);
       });
+
+      needUpdate = true;
     }
 
-    draggingCols.value = [];
+    // 列宽转为整数
+    if (needUpdate) {
+      let addon = 0;
+      Object.keys(thWidthList.value).forEach((key) => {
+        const width = thWidthList.value[key];
+        addon += width - Math.floor(width);
+        thWidthList.value[key] = Math.floor(width) + (addon > 1 ? 1 : 0);
+        if (addon > 1) {
+          addon -= 1;
+        }
+      });
+      if (addon > 0.5) {
+        thWidthList.value[columns[0].colKey] += 1;
+      }
+    }
+
+    if (draggingCols.value.length) {
+      draggingCols.value = [];
+    }
   };
 
   watch(

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -622,6 +622,5 @@ export default function useFixed(
     updateColumnFixedShadow,
     setUseFixedTableElmRef,
     setThWidthListByColumnDrag,
-    recalculateColWidth,
   };
 }

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -10,7 +10,6 @@ import {
   ComputedRef,
 } from '@vue/composition-api';
 import get from 'lodash/get';
-import isNumber from 'lodash/isNumber';
 import log from '../../_common/js/log';
 import { ClassName, Styles } from '../../common';
 import { BaseTableCol, TableRowData, TdBaseTableProps } from '../type';

--- a/src/table/interface.ts
+++ b/src/table/interface.ts
@@ -69,7 +69,7 @@ export interface FixedColumnInfo {
 // 固定表头和固定列 具体的固定位置（left/top/right/bottom）
 export type RowAndColFixedPosition = Map<string | number, FixedColumnInfo>;
 
-// 允许修改行宽时重新计算各列宽度
+// 允许修改列宽时，重新计算各列宽度的函数声明
 export interface RecalculateColumnWidthFunc {
   (
     columns: BaseTableCol<TableRowData>[],

--- a/src/table/interface.ts
+++ b/src/table/interface.ts
@@ -68,3 +68,13 @@ export interface FixedColumnInfo {
 
 // 固定表头和固定列 具体的固定位置（left/top/right/bottom）
 export type RowAndColFixedPosition = Map<string | number, FixedColumnInfo>;
+
+// 允许修改行宽时重新计算各列宽度
+export interface RecalculateColumnWidthFunc {
+  (
+    columns: BaseTableCol<TableRowData>[],
+    thWidthList: { [colKey: string]: number },
+    tableLayout: string,
+    tableElmWidth: number,
+  ): void;
+}

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -29,7 +29,7 @@ export interface TheadProps {
     resizeLineRef: HTMLDivElement;
     resizeLineStyle: Object;
     onColumnMouseover: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
-    onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
+    onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>, nearCol: BaseTableCol<TableRowData>) => void;
   };
   resizable: Boolean;
 }
@@ -114,7 +114,11 @@ export default defineComponent({
           const innerTh = renderTitle(h, this.slots, col, index);
           const resizeColumnListener = this.resizable
             ? {
-              mousedown: (e: MouseEvent) => this.columnResizeParams?.onColumnMousedown?.(e, col),
+              mousedown: (e: MouseEvent) => this.columnResizeParams?.onColumnMousedown?.(
+                e,
+                col,
+                index < row.length - 1 ? row[index + 1] : row[index - 1],
+              ),
               mousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e, col),
             }
             : {};

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -28,7 +28,7 @@ export interface TheadProps {
   columnResizeParams: {
     resizeLineRef: HTMLDivElement;
     resizeLineStyle: Object;
-    onColumnMouseover: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
+    onColumnMouseover: (e: MouseEvent) => void;
     onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>, nearCol: BaseTableCol<TableRowData>) => void;
   };
   resizable: Boolean;
@@ -119,7 +119,7 @@ export default defineComponent({
                 col,
                 index < row.length - 1 ? row[index + 1] : row[index - 1],
               ),
-              mousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e, col),
+              mousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e),
             }
             : {};
           const content = isFunction(col.ellipsisTitle) ? col.ellipsisTitle(h, { col, colIndex: index }) : undefined;

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -13945,15 +13945,15 @@ exports[`ssr snapshot test renders ./examples/table/demos/affix.vue correctly 1`
     <div class="t-table__content">
       <table class="t-table--layout-auto" style="width:;">
         <colgroup>
-          <col>
-          <col>
-          <col>
-          <col>
-          <col>
-          <col>
-          <col>
-          <col>
-          <col>
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
           <col style="width:80px;">
         </colgroup>
         <thead class="t-table__header">
@@ -14211,9 +14211,9 @@ exports[`ssr snapshot test renders ./examples/table/demos/base.vue correctly 1`]
         <colgroup>
           <col style="width:100px;">
           <col style="width:100px;">
-          <col>
-          <col>
-          <col>
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
           <col style="width:200px;">
         </colgroup>
         <thead class="t-table__header">
@@ -15831,10 +15831,10 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
     <div class="t-table__content">
       <table class="t-table--layout-fixed" style="width:;">
         <colgroup>
-          <col>
-          <col>
-          <col>
-          <col>
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
+          <col style="width:100px;">
         </colgroup>
         <thead class="t-table__header">
           <tr>
@@ -15962,7 +15962,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/fixed-column.vue corre
           <col style="width:80px;">
           <col style="width:100px;">
           <col style="width:150px;">
-          <col>
+          <col style="width:100px;">
           <col style="width:100px;">
           <col style="width:150px;">
           <col style="width:100px;">

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -13936,14 +13936,14 @@ exports[`ssr snapshot test renders ./examples/switch/demos/status.vue correctly 
 exports[`ssr snapshot test renders ./examples/table/demos/affix.vue correctly 1`] = `
 <div class="tdesign-demo-block-column-large tdesign-demo__table-affix" style="width:100%;">
   <div><label class="t-checkbox t-is-checked"><input type="checkbox" checked="checked" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">表头吸顶</span></label> <label class="t-checkbox t-is-checked" style="margin-left:32px;"><input type="checkbox" checked="checked" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">表尾吸底</span></label> <label class="t-checkbox" style="margin-left:32px;"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">滚动条吸底</span></label> <label class="t-checkbox" style="margin-left:32px;"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">分页器吸底</span></label> <label class="t-checkbox t-is-checked" style="margin-left:32px;"><input type="checkbox" checked="checked" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">固定左侧列</span></label> <label class="t-checkbox t-is-checked" style="margin-left:32px;"><input type="checkbox" checked="checked" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">固定右侧列</span></label></div>
-  <div class="t-table t-table--bordered t-table--affixed-header t-table--footer-affixed t-table--column-fixed t-table--column-resizable t-table--col-draggable" style="position:relative;">
+  <div table-ayout="fixed" class="t-table t-table--bordered t-table--affixed-header t-table--footer-affixed t-table--column-fixed t-table--column-resizable t-table--col-draggable" style="position:relative;">
     <div offsetTop="0">
       <div>
         <div class="t-table__affixed-header-elm-wrap" style="width:0px;height:0px;opacity:1;margin-top:0;"></div>
       </div>
     </div>
     <div class="t-table__content">
-      <table class="t-table--layout-auto" style="width:;">
+      <table class="t-table--layout-fixed" style="width:;">
         <colgroup>
           <col style="width:100px;">
           <col style="width:100px;">
@@ -13958,36 +13958,36 @@ exports[`ssr snapshot test renders ./examples/table/demos/affix.vue correctly 1`
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="row t-table__th-index t-align-center">
+            <th data-colkey="index" class="row t-table__th-index t-align-center" style="width:100px;">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform">
+            <th data-colkey="platform" class="t-table__th-platform" style="width:100px;">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type">
+            <th data-colkey="type" class="t-table__th-type" style="width:100px;">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="expo" class="t-table__th-expo">
+            <th data-colkey="expo" class="t-table__th-expo" style="width:100px;">
               <div class="t-table__th-cell-inner">曝光</div>
             </th>
-            <th data-colkey="click" class="t-table__th-click">
+            <th data-colkey="click" class="t-table__th-click" style="width:100px;">
               <div class="t-table__th-cell-inner">点击</div>
             </th>
-            <th data-colkey="ctr" class="t-table__th-ctr">
+            <th data-colkey="ctr" class="t-table__th-ctr" style="width:100px;">
               <div class="t-table__th-cell-inner">点击率</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default">
+            <th data-colkey="default" class="t-table__th-default" style="width:100px;">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="required" class="t-table__th-required">
+            <th data-colkey="required" class="t-table__th-required" style="width:100px;">
               <div class="t-table__th-cell-inner">是否必传</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position">
+            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:100px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis">详情信息</div>
               </div>
             </th>
-            <th data-colkey="operation" class="t-table__th-operation">
+            <th data-colkey="operation" class="t-table__th-operation" style="width:80px;">
               <div class="t-table__th-cell-inner">操作</div>
             </th>
           </tr>
@@ -14218,22 +14218,22 @@ exports[`ssr snapshot test renders ./examples/table/demos/base.vue correctly 1`]
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="custom-column-class-name t-table__th-index t-align-center">
+            <th data-colkey="index" class="custom-column-class-name t-table__th-index t-align-center" style="width:100px;">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform">
+            <th data-colkey="platform" class="t-table__th-platform" style="width:100px;">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type">
+            <th data-colkey="type" class="t-table__th-type" style="width:100px;">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default">
+            <th data-colkey="default" class="t-table__th-default" style="width:100px;">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="needed" class="t-table__th-needed">
+            <th data-colkey="needed" class="t-table__th-needed" style="width:100px;">
               <div class="t-table__th-cell-inner">是否必传</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position">
+            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:200px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis">详情信息</div>
               </div>
@@ -15838,7 +15838,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="firstName" class="t-table__th-firstName">
+            <th data-colkey="firstName" class="t-table__th-firstName" style="width:100px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15852,7 +15852,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                 </div>
               </div>
             </th>
-            <th data-colkey="lastName" class="t-table__th-lastName">
+            <th data-colkey="lastName" class="t-table__th-lastName" style="width:100px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--sortable t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15867,7 +15867,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                 </div>
               </div>
             </th>
-            <th data-colkey="email" class="t-table__th-email">
+            <th data-colkey="email" class="t-table__th-email" style="width:100px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15881,7 +15881,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                 </div>
               </div>
             </th>
-            <th data-colkey="createTime" class="t-table__th-createTime">
+            <th data-colkey="createTime" class="t-table__th-createTime" style="width:100px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15970,28 +15970,28 @@ exports[`ssr snapshot test renders ./examples/table/demos/fixed-column.vue corre
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="t-table__th-index t-align-center">
+            <th data-colkey="index" class="t-table__th-index t-align-center" style="width:80px;">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform">
+            <th data-colkey="platform" class="t-table__th-platform" style="width:100px;">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type">
+            <th data-colkey="type" class="t-table__th-type" style="width:150px;">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default">
+            <th data-colkey="default" class="t-table__th-default" style="width:100px;">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="description" class="t-table__th-description">
+            <th data-colkey="description" class="t-table__th-description" style="width:100px;">
               <div class="t-table__th-cell-inner">说明</div>
             </th>
-            <th data-colkey="needed" class="t-table__th-needed">
+            <th data-colkey="needed" class="t-table__th-needed" style="width:150px;">
               <div class="t-table__th-cell-inner">是否必传</div>
             </th>
-            <th data-colkey="operation" class="t-table__th-operation">
+            <th data-colkey="operation" class="t-table__th-operation" style="width:100px;">
               <div class="t-table__th-cell-inner">操作</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position">
+            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:120px;">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis">详情信息</div>
               </div>
@@ -16355,28 +16355,28 @@ exports[`ssr snapshot test renders ./examples/table/demos/fixed-header-col.vue c
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="t-table__th-index t-align-center">
+            <th data-colkey="index" class="t-table__th-index t-align-center" style="width:100px;">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform">
+            <th data-colkey="platform" class="t-table__th-platform" style="width:120px;">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type">
+            <th data-colkey="type" class="t-table__th-type" style="width:120px;">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default">
+            <th data-colkey="default" class="t-table__th-default" style="width:150px;">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position">
+            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:250px;">
               <div class="t-table__th-cell-inner">详情信息</div>
             </th>
-            <th data-colkey="description" class="t-table__th-description">
+            <th data-colkey="description" class="t-table__th-description" style="width:120px;">
               <div class="t-table__th-cell-inner">说明</div>
             </th>
-            <th data-colkey="needed" class="t-table__th-needed">
+            <th data-colkey="needed" class="t-table__th-needed" style="width:120px;">
               <div class="t-table__th-cell-inner">必传</div>
             </th>
-            <th data-colkey="operation" class="t-table__th-operation">
+            <th data-colkey="operation" class="t-table__th-operation" style="width:100px;">
               <div class="t-table__th-cell-inner">操作</div>
             </th>
           </tr>
@@ -16736,19 +16736,19 @@ exports[`ssr snapshot test renders ./examples/table/demos/merge-cells.vue correc
       </colgroup>
       <thead class="t-table__header">
         <tr>
-          <th data-colkey="platform" class="test t-table__th-platform">
+          <th data-colkey="platform" class="test t-table__th-platform" style="width:100px;">
             <div class="t-table__th-cell-inner">平台</div>
           </th>
-          <th data-colkey="type" class="row t-table__th-type">
+          <th data-colkey="type" class="row t-table__th-type" style="width:100px;">
             <div class="t-table__th-cell-inner">类型</div>
           </th>
-          <th data-colkey="default" class="test4 t-table__th-default">
+          <th data-colkey="default" class="test4 t-table__th-default" style="width:100px;">
             <div class="t-table__th-cell-inner">默认值</div>
           </th>
-          <th data-colkey="needed" class="test3 t-table__th-needed">
+          <th data-colkey="needed" class="test3 t-table__th-needed" style="width:100px;">
             <div class="t-table__th-cell-inner">是否必传</div>
           </th>
-          <th data-colkey="description" class="row t-table__th-description">
+          <th data-colkey="description" class="row t-table__th-description" style="width:100px;">
             <div class="t-table__th-cell-inner">说明</div>
           </th>
         </tr>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -13945,49 +13945,49 @@ exports[`ssr snapshot test renders ./examples/table/demos/affix.vue correctly 1`
     <div class="t-table__content">
       <table class="t-table--layout-fixed" style="width:;">
         <colgroup>
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
+          <col>
           <col style="width:80px;">
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="row t-table__th-index t-align-center" style="width:100px;">
+            <th data-colkey="index" class="row t-table__th-index t-align-center">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform" style="width:100px;">
+            <th data-colkey="platform" class="t-table__th-platform">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type" style="width:100px;">
+            <th data-colkey="type" class="t-table__th-type">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="expo" class="t-table__th-expo" style="width:100px;">
+            <th data-colkey="expo" class="t-table__th-expo">
               <div class="t-table__th-cell-inner">曝光</div>
             </th>
-            <th data-colkey="click" class="t-table__th-click" style="width:100px;">
+            <th data-colkey="click" class="t-table__th-click">
               <div class="t-table__th-cell-inner">点击</div>
             </th>
-            <th data-colkey="ctr" class="t-table__th-ctr" style="width:100px;">
+            <th data-colkey="ctr" class="t-table__th-ctr">
               <div class="t-table__th-cell-inner">点击率</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default" style="width:100px;">
+            <th data-colkey="default" class="t-table__th-default">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="required" class="t-table__th-required" style="width:100px;">
+            <th data-colkey="required" class="t-table__th-required">
               <div class="t-table__th-cell-inner">是否必传</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:100px;">
+            <th data-colkey="detail.position" class="t-table__th-detail.position">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis">详情信息</div>
               </div>
             </th>
-            <th data-colkey="operation" class="t-table__th-operation" style="width:80px;">
+            <th data-colkey="operation" class="t-table__th-operation">
               <div class="t-table__th-cell-inner">操作</div>
             </th>
           </tr>
@@ -14211,29 +14211,29 @@ exports[`ssr snapshot test renders ./examples/table/demos/base.vue correctly 1`]
         <colgroup>
           <col style="width:100px;">
           <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
+          <col>
+          <col>
+          <col>
           <col style="width:200px;">
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="custom-column-class-name t-table__th-index t-align-center" style="width:100px;">
+            <th data-colkey="index" class="custom-column-class-name t-table__th-index t-align-center">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform" style="width:100px;">
+            <th data-colkey="platform" class="t-table__th-platform">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type" style="width:100px;">
+            <th data-colkey="type" class="t-table__th-type">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default" style="width:100px;">
+            <th data-colkey="default" class="t-table__th-default">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="needed" class="t-table__th-needed" style="width:100px;">
+            <th data-colkey="needed" class="t-table__th-needed">
               <div class="t-table__th-cell-inner">是否必传</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:200px;">
+            <th data-colkey="detail.position" class="t-table__th-detail.position">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis">详情信息</div>
               </div>
@@ -15831,14 +15831,14 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
     <div class="t-table__content">
       <table class="t-table--layout-fixed" style="width:;">
         <colgroup>
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
-          <col style="width:100px;">
+          <col>
+          <col>
+          <col>
+          <col>
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="firstName" class="t-table__th-firstName" style="width:100px;">
+            <th data-colkey="firstName" class="t-table__th-firstName">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15852,7 +15852,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                 </div>
               </div>
             </th>
-            <th data-colkey="lastName" class="t-table__th-lastName" style="width:100px;">
+            <th data-colkey="lastName" class="t-table__th-lastName">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--sortable t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15867,7 +15867,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                 </div>
               </div>
             </th>
-            <th data-colkey="email" class="t-table__th-email" style="width:100px;">
+            <th data-colkey="email" class="t-table__th-email">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15881,7 +15881,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/filter-controlled.vue 
                 </div>
               </div>
             </th>
-            <th data-colkey="createTime" class="t-table__th-createTime" style="width:100px;">
+            <th data-colkey="createTime" class="t-table__th-createTime">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__cell--filterable">
                   <div class="t-table__cell--title">
@@ -15962,7 +15962,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/fixed-column.vue corre
           <col style="width:80px;">
           <col style="width:100px;">
           <col style="width:150px;">
-          <col style="width:100px;">
+          <col>
           <col style="width:100px;">
           <col style="width:150px;">
           <col style="width:100px;">
@@ -15970,28 +15970,28 @@ exports[`ssr snapshot test renders ./examples/table/demos/fixed-column.vue corre
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="t-table__th-index t-align-center" style="width:80px;">
+            <th data-colkey="index" class="t-table__th-index t-align-center">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform" style="width:100px;">
+            <th data-colkey="platform" class="t-table__th-platform">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type" style="width:150px;">
+            <th data-colkey="type" class="t-table__th-type">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default" style="width:100px;">
+            <th data-colkey="default" class="t-table__th-default">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="description" class="t-table__th-description" style="width:100px;">
+            <th data-colkey="description" class="t-table__th-description">
               <div class="t-table__th-cell-inner">说明</div>
             </th>
-            <th data-colkey="needed" class="t-table__th-needed" style="width:150px;">
+            <th data-colkey="needed" class="t-table__th-needed">
               <div class="t-table__th-cell-inner">是否必传</div>
             </th>
-            <th data-colkey="operation" class="t-table__th-operation" style="width:100px;">
+            <th data-colkey="operation" class="t-table__th-operation">
               <div class="t-table__th-cell-inner">操作</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:120px;">
+            <th data-colkey="detail.position" class="t-table__th-detail.position">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis">详情信息</div>
               </div>
@@ -16355,28 +16355,28 @@ exports[`ssr snapshot test renders ./examples/table/demos/fixed-header-col.vue c
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="index" class="t-table__th-index t-align-center" style="width:100px;">
+            <th data-colkey="index" class="t-table__th-index t-align-center">
               <div class="t-table__th-cell-inner">序号</div>
             </th>
-            <th data-colkey="platform" class="t-table__th-platform" style="width:120px;">
+            <th data-colkey="platform" class="t-table__th-platform">
               <div class="t-table__th-cell-inner">平台</div>
             </th>
-            <th data-colkey="type" class="t-table__th-type" style="width:120px;">
+            <th data-colkey="type" class="t-table__th-type">
               <div class="t-table__th-cell-inner">类型</div>
             </th>
-            <th data-colkey="default" class="t-table__th-default" style="width:150px;">
+            <th data-colkey="default" class="t-table__th-default">
               <div class="t-table__th-cell-inner">默认值</div>
             </th>
-            <th data-colkey="detail.position" class="t-table__th-detail.position" style="width:250px;">
+            <th data-colkey="detail.position" class="t-table__th-detail.position">
               <div class="t-table__th-cell-inner">详情信息</div>
             </th>
-            <th data-colkey="description" class="t-table__th-description" style="width:120px;">
+            <th data-colkey="description" class="t-table__th-description">
               <div class="t-table__th-cell-inner">说明</div>
             </th>
-            <th data-colkey="needed" class="t-table__th-needed" style="width:120px;">
+            <th data-colkey="needed" class="t-table__th-needed">
               <div class="t-table__th-cell-inner">必传</div>
             </th>
-            <th data-colkey="operation" class="t-table__th-operation" style="width:100px;">
+            <th data-colkey="operation" class="t-table__th-operation">
               <div class="t-table__th-cell-inner">操作</div>
             </th>
           </tr>
@@ -16736,19 +16736,19 @@ exports[`ssr snapshot test renders ./examples/table/demos/merge-cells.vue correc
       </colgroup>
       <thead class="t-table__header">
         <tr>
-          <th data-colkey="platform" class="test t-table__th-platform" style="width:100px;">
+          <th data-colkey="platform" class="test t-table__th-platform">
             <div class="t-table__th-cell-inner">平台</div>
           </th>
-          <th data-colkey="type" class="row t-table__th-type" style="width:100px;">
+          <th data-colkey="type" class="row t-table__th-type">
             <div class="t-table__th-cell-inner">类型</div>
           </th>
-          <th data-colkey="default" class="test4 t-table__th-default" style="width:100px;">
+          <th data-colkey="default" class="test4 t-table__th-default">
             <div class="t-table__th-cell-inner">默认值</div>
           </th>
-          <th data-colkey="needed" class="test3 t-table__th-needed" style="width:100px;">
+          <th data-colkey="needed" class="test3 t-table__th-needed">
             <div class="t-table__th-cell-inner">是否必传</div>
           </th>
-          <th data-colkey="description" class="row t-table__th-description" style="width:100px;">
+          <th data-colkey="description" class="row t-table__th-description">
             <div class="t-table__th-cell-inner">说明</div>
           </th>
         </tr>

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -141,15 +141,33 @@ exports[`Table Table affixVue demo works fine 1`] = `
         class="t-table--layout-auto"
       >
         <colgroup>
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
-          <col />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
           <col
             style="width: 80px;"
           />
@@ -1231,9 +1249,15 @@ exports[`Table Table baseVue demo works fine 1`] = `
           <col
             style="width: 100px;"
           />
-          <col />
-          <col />
-          <col />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
           <col
             style="width: 200px;"
           />
@@ -5734,10 +5758,18 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
         class="t-table--layout-fixed"
       >
         <colgroup>
-          <col />
-          <col />
-          <col />
-          <col />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
+          <col
+            style="width: 100px;"
+          />
         </colgroup>
         <thead
           class="t-table__header"
@@ -6273,7 +6305,9 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
           <col
             style="width: 150px;"
           />
-          <col />
+          <col
+            style="width: 100px;"
+          />
           <col
             style="width: 100px;"
           />

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -123,6 +123,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
   <div
     class="t-table t-table--bordered t-table--affixed-header t-table--footer-affixed t-table--column-fixed t-table--column-resizable t-table--col-draggable"
     style="position: relative;"
+    table-ayout="fixed"
   >
     <div
       offsettop="0"
@@ -138,7 +139,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
       class="t-table__content"
     >
       <table
-        class="t-table--layout-auto"
+        class="t-table--layout-fixed"
       >
         <colgroup>
           <col
@@ -179,6 +180,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="row t-table__th-index t-align-center"
               data-colkey="index"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -189,6 +191,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -199,6 +202,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -209,6 +213,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-expo"
               data-colkey="expo"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -219,6 +224,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-click"
               data-colkey="click"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -229,6 +235,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-ctr"
               data-colkey="ctr"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -239,6 +246,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -249,6 +257,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-required"
               data-colkey="required"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -259,6 +268,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -273,6 +283,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-operation"
               data-colkey="operation"
+              style="width: 80px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1269,6 +1280,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="custom-column-class-name t-table__th-index t-align-center"
               data-colkey="index"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1279,6 +1291,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1289,6 +1302,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1299,6 +1313,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1309,6 +1324,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-needed"
               data-colkey="needed"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1319,6 +1335,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
+              style="width: 200px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5778,6 +5795,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-firstName"
               data-colkey="firstName"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5819,6 +5837,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-lastName"
               data-colkey="lastName"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5898,6 +5917,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-email"
               data-colkey="email"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5939,6 +5959,7 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-createTime"
               data-colkey="createTime"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6328,6 +6349,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-index t-align-center"
               data-colkey="index"
+              style="width: 80px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6338,6 +6360,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6348,6 +6371,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
+              style="width: 150px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6358,6 +6382,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6368,6 +6393,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-description"
               data-colkey="description"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6378,6 +6404,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-needed"
               data-colkey="needed"
+              style="width: 150px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6388,6 +6415,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-operation"
               data-colkey="operation"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6398,6 +6426,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
+              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6824,6 +6853,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-index t-align-center"
               data-colkey="index"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6834,6 +6864,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
+              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6844,6 +6875,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
+              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6854,6 +6886,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
+              style="width: 150px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6864,6 +6897,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
+              style="width: 250px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6874,6 +6908,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-description"
               data-colkey="description"
+              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6884,6 +6919,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-needed"
               data-colkey="needed"
+              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6894,6 +6930,7 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-operation"
               data-colkey="operation"
+              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -16233,6 +16270,7 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="test t-table__th-platform"
             data-colkey="platform"
+            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16243,6 +16281,7 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="row t-table__th-type"
             data-colkey="type"
+            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16253,6 +16292,7 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="test4 t-table__th-default"
             data-colkey="default"
+            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16263,6 +16303,7 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="test3 t-table__th-needed"
             data-colkey="needed"
+            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16273,6 +16314,7 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="row t-table__th-description"
             data-colkey="description"
+            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -142,33 +142,15 @@ exports[`Table Table affixVue demo works fine 1`] = `
         class="t-table--layout-fixed"
       >
         <colgroup>
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
+          <col />
           <col
             style="width: 80px;"
           />
@@ -180,7 +162,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="row t-table__th-index t-align-center"
               data-colkey="index"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -191,7 +172,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -202,7 +182,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -213,7 +192,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-expo"
               data-colkey="expo"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -224,7 +202,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-click"
               data-colkey="click"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -235,7 +212,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-ctr"
               data-colkey="ctr"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -246,7 +222,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -257,7 +232,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-required"
               data-colkey="required"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -268,7 +242,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -283,7 +256,6 @@ exports[`Table Table affixVue demo works fine 1`] = `
             <th
               class="t-table__th-operation"
               data-colkey="operation"
-              style="width: 80px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1260,15 +1232,9 @@ exports[`Table Table baseVue demo works fine 1`] = `
           <col
             style="width: 100px;"
           />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
+          <col />
+          <col />
+          <col />
           <col
             style="width: 200px;"
           />
@@ -1280,7 +1246,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="custom-column-class-name t-table__th-index t-align-center"
               data-colkey="index"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1291,7 +1256,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1302,7 +1266,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1313,7 +1276,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1324,7 +1286,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-needed"
               data-colkey="needed"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -1335,7 +1296,6 @@ exports[`Table Table baseVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
-              style="width: 200px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5775,18 +5735,10 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
         class="t-table--layout-fixed"
       >
         <colgroup>
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
-          <col
-            style="width: 100px;"
-          />
+          <col />
+          <col />
+          <col />
+          <col />
         </colgroup>
         <thead
           class="t-table__header"
@@ -5795,7 +5747,6 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-firstName"
               data-colkey="firstName"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5837,7 +5788,6 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-lastName"
               data-colkey="lastName"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5917,7 +5867,6 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-email"
               data-colkey="email"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -5959,7 +5908,6 @@ exports[`Table Table filterControlledVue demo works fine 1`] = `
             <th
               class="t-table__th-createTime"
               data-colkey="createTime"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6326,9 +6274,7 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
           <col
             style="width: 150px;"
           />
-          <col
-            style="width: 100px;"
-          />
+          <col />
           <col
             style="width: 100px;"
           />
@@ -6349,7 +6295,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-index t-align-center"
               data-colkey="index"
-              style="width: 80px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6360,7 +6305,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6371,7 +6315,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
-              style="width: 150px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6382,7 +6325,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6393,7 +6335,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-description"
               data-colkey="description"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6404,7 +6345,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-needed"
               data-colkey="needed"
-              style="width: 150px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6415,7 +6355,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-operation"
               data-colkey="operation"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6426,7 +6365,6 @@ exports[`Table Table fixedColumnVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
-              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6853,7 +6791,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-index t-align-center"
               data-colkey="index"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6864,7 +6801,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-platform"
               data-colkey="platform"
-              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6875,7 +6811,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-type"
               data-colkey="type"
-              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6886,7 +6821,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-default"
               data-colkey="default"
-              style="width: 150px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6897,7 +6831,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-detail.position"
               data-colkey="detail.position"
-              style="width: 250px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6908,7 +6841,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-description"
               data-colkey="description"
-              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6919,7 +6851,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-needed"
               data-colkey="needed"
-              style="width: 120px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -6930,7 +6861,6 @@ exports[`Table Table fixedHeaderColVue demo works fine 1`] = `
             <th
               class="t-table__th-operation"
               data-colkey="operation"
-              style="width: 100px;"
             >
               <div
                 class="t-table__th-cell-inner"
@@ -16270,7 +16200,6 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="test t-table__th-platform"
             data-colkey="platform"
-            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16281,7 +16210,6 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="row t-table__th-type"
             data-colkey="type"
-            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16292,7 +16220,6 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="test4 t-table__th-default"
             data-colkey="default"
-            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16303,7 +16230,6 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="test3 t-table__th-needed"
             data-colkey="needed"
-            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"
@@ -16314,7 +16240,6 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           <th
             class="row t-table__th-description"
             data-colkey="description"
-            style="width: 100px;"
           >
             <div
               class="t-table__th-cell-inner"


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#1067 

### 💡 需求背景和解决方案

1. 使用thWidthList记录拖动后的实际列宽
2. 根据拖动结果重新计算其余各列的宽度，使之能够确保列宽总和大于等于表宽

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 列宽度和小于表宽的情况下，调整列宽的结果与预期不符

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
