### PR TITLE
fix(select): 统一处理options和t-option传入的选项；精简t-option逻辑

### DIFF
--- a/examples/select/demos/creatable.vue
+++ b/examples/select/demos/creatable.vue
@@ -4,9 +4,19 @@
       v-model="value"
       creatable
       filterable
-      placeholder="支持自定义创建"
+      placeholder="单选支持自定义创建"
       :options="options"
-      style="width: 200px;"
+      style="width: 200px; display: inline-block; margin: 0 20px 20px 0"
+      @create="createOptions"
+    />
+    <t-select
+      v-model="value2"
+      creatable
+      filterable
+      multiple
+      placeholder="多选支持自定义创建"
+      :options="options"
+      style="width: 400px; display: inline-block"
       @create="createOptions"
     />
   </div>
@@ -22,6 +32,7 @@ export default {
         { label: '选项三', value: '3' },
       ],
       value: '',
+      value2: [],
     };
   },
   methods: {

--- a/examples/select/demos/custom-options.vue
+++ b/examples/select/demos/custom-options.vue
@@ -1,6 +1,5 @@
 <template>
-  <div class='tdesign-demo-select-options'>
-
+  <div class="tdesign-demo-select-options">
     <!-- 方式一：使用 options 自定义下拉选项内容 -->
     <t-select
       v-model="value1"
@@ -8,7 +7,7 @@
       :popupProps="{ overlayClassName: 'tdesign-demo-select__overlay-option' }"
       placeholder="请选择"
     />
-    <br/><br/>
+    <br /><br />
 
     <!-- 方式二：使用插槽自定义下拉选项内容 -->
     <t-select
@@ -16,12 +15,7 @@
       placeholder="请选择"
       :popupProps="{ overlayClassName: 'tdesign-demo-select__overlay-option' }"
     >
-      <t-option
-        v-for="item in options"
-        :value="item.value"
-        :label="item.label"
-        :key="item.value"
-      >
+      <t-option v-for="item in options" :value="item.value" :label="item.label" :key="item.value">
         <div class="tdesign-demo__user-option">
           <img src="https://tdesign.gtimg.com/site/avatar.jpg" />
           <div class="tdesign-demo__user-option-info">
@@ -38,8 +32,8 @@
 export default {
   data() {
     return {
-      value1: [],
-      value2: [],
+      value1: '',
+      value2: '',
       options: [
         { label: '用户一', value: '1', description: '这是一段用户描述信息，可自定义内容' },
         { label: '用户二', value: '2', description: '这是一段用户描述信息，可自定义内容' },
@@ -79,7 +73,6 @@ export default {
 </script>
 
 <style>
-
 .tdesign-demo__user-option {
   display: flex;
 }
@@ -101,5 +94,4 @@ export default {
 .tdesign-demo-select__overlay-option .t-select-option {
   height: 60px;
 }
-
 </style>

--- a/examples/select/demos/custom-selected.vue
+++ b/examples/select/demos/custom-selected.vue
@@ -14,7 +14,17 @@
     <!-- 自定义选中项内容，valueDisplay 为 插槽(slot) -->
     <t-select v-model="value2" :options="options" placeholder="请选择" multiple clearable>
       <template #valueDisplay="{ value, onClose }">
-        <t-tag v-for="(item, index) in value" :key="index" :closable="true" :onClose="() => onClose(index)">
+        <t-tag
+          v-for="(item, index) in value"
+          :key="index"
+          :closable="true"
+          :onClose="
+            (context) => {
+              context.e && context.e.stopPropagation();
+              onClose(index);
+            }
+          "
+        >
           {{ item.label }}({{ item.value[0].toUpperCase() }})
         </t-tag>
       </template>
@@ -45,7 +55,14 @@ export default {
     valueDisplay(h, { value, onClose }) {
       if (!(value instanceof Array)) return;
       return value.map((item, index) => (
-        <t-tag key={index} closable={true} onClose={() => onClose(index)}>
+        <t-tag
+          key={index}
+          closable={true}
+          onClose={(context) => {
+            context.e && context.e.stopPropagation();
+            onClose(index);
+          }}
+        >
           {item.label}({item.value[0].toUpperCase()})
         </t-tag>
       ));

--- a/examples/select/demos/group.vue
+++ b/examples/select/demos/group.vue
@@ -28,7 +28,10 @@ export default {
       options: [
         {
           group: '分组一',
-          children: [],
+          children: [
+            { label: '选项一', value: 1 },
+            { label: '选项二', value: 2 },
+          ],
         },
         {
           group: '分组二',

--- a/examples/select/usage/props.json
+++ b/examples/select/usage/props.json
@@ -54,12 +54,6 @@
     "options": []
   },
   {
-    "name": "popupVisible",
-    "type": "Boolean",
-    "defaultValue": false,
-    "options": []
-  },
-  {
     "name": "readonly",
     "type": "Boolean",
     "defaultValue": false,

--- a/src/select/hooks.ts
+++ b/src/select/hooks.ts
@@ -1,0 +1,120 @@
+import {
+  ref, Ref, SetupContext, computed, onBeforeUpdate,
+} from '@vue/composition-api';
+import { VNode } from 'vue';
+import get from 'lodash/get';
+import isArray from 'lodash/isArray';
+import {
+  TdSelectProps, SelectKeysType, TdOptionProps, SelectOptionGroup, SelectValue,
+} from './type';
+
+type UniOption = (TdOptionProps | SelectOptionGroup) & {
+  index?: number;
+  slots?: () => VNode;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const useSelectOptions = (props: TdSelectProps, context: SetupContext, keys: Ref<SelectKeysType>) => {
+  const options = ref<UniOption[]>([]);
+
+  const getOptions = () => {
+    let dynamicIndex = 0;
+
+    // 解析 props 中 options 字段的配置，以此初始化 innerOptions
+    const innerOptions: UniOption[] = props.options.map((option) => {
+      const getFormatOption = (option: TdOptionProps) => {
+        const { value, label } = keys.value;
+        const res = {
+          ...option,
+          index: dynamicIndex,
+          label: get(option, label),
+          value: get(option, value),
+        };
+        dynamicIndex += 1;
+        return res;
+      };
+      if ((option as SelectOptionGroup).group && (option as SelectOptionGroup).children) {
+        return {
+          ...option,
+          children: (option as SelectOptionGroup).children.map((child) => getFormatOption(child)),
+        };
+      }
+      return getFormatOption(option);
+    });
+
+    // 处理 slots 中 t-option 与 t-option-group
+    const currentSlots = context.parent.$slots.default || [];
+    const optionsSlots = currentSlots.filter((item) => item.tag.endsWith('TOption'));
+    const groupSlots = currentSlots.filter((item) => item.tag.endsWith('TOptionGroup'));
+    if (isArray(groupSlots)) {
+      groupSlots.forEach((group) => {
+        const groupOption = {
+          group: (group.componentOptions.propsData as TdOptionProps)?.label,
+          ...group.componentOptions.propsData,
+          children: [] as TdOptionProps[],
+        };
+
+        const res = group.componentOptions.children;
+        if (isArray(res)) {
+          res.forEach((child) => {
+            groupOption.children.push({
+              ...child.componentOptions.propsData,
+              slots: () => child.componentOptions.children,
+              index: dynamicIndex,
+            } as TdOptionProps);
+            dynamicIndex += 1;
+          });
+        }
+
+        innerOptions.push(groupOption);
+      });
+    }
+
+    if (isArray(optionsSlots)) {
+      optionsSlots.forEach((child) => {
+        innerOptions.push({
+          ...child.componentOptions.propsData,
+          slots: () => child.componentOptions.children,
+          index: dynamicIndex,
+        } as TdOptionProps);
+        dynamicIndex += 1;
+      });
+    }
+
+    options.value = innerOptions;
+  };
+
+  const optionsMap = computed(() => {
+    const res = new Map<SelectValue, TdOptionProps>();
+    optionsList.value.forEach((option: TdOptionProps) => {
+      res.set(option.value, option);
+    });
+    return res;
+  });
+
+  const optionsList = computed(() => {
+    const res: TdOptionProps[] = [];
+    const getOptionsList = (options: TdOptionProps[]) => {
+      options.forEach((option) => {
+        if ((option as SelectOptionGroup).group) {
+          getOptionsList((option as SelectOptionGroup).children);
+        } else {
+          res.push(option);
+        }
+      });
+    };
+    getOptionsList(options.value);
+    return res;
+  });
+
+  getOptions();
+  onBeforeUpdate(() => {
+    getOptions();
+  });
+
+  return {
+    options,
+    optionsMap,
+    optionsList,
+  };
+};

--- a/src/select/hooks.ts
+++ b/src/select/hooks.ts
@@ -44,8 +44,8 @@ export const useSelectOptions = (props: TdSelectProps, context: SetupContext, ke
 
     // 处理 slots 中 t-option 与 t-option-group
     const currentSlots = context.parent.$slots.default || [];
-    const optionsSlots = currentSlots.filter((item) => item.tag.endsWith('TOption'));
-    const groupSlots = currentSlots.filter((item) => item.tag.endsWith('TOptionGroup'));
+    const optionsSlots = currentSlots.filter((item) => item.tag?.endsWith('TOption'));
+    const groupSlots = currentSlots.filter((item) => item.tag?.endsWith('TOptionGroup'));
     if (isArray(groupSlots)) {
       groupSlots.forEach((group) => {
         const groupOption = {

--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -72,6 +72,10 @@ export default function useSelectOptions(props: TdSelectProps, context: SetupCon
     if (isArray(optionsSlots)) {
       optionsSlots.forEach((child) => {
         innerOptions.push({
+          // 单独处理 style 和 class 参数的透传
+          class: child.data.staticClass,
+          style: child.data.staticStyle,
+          // 透传其他常规参数
           ...child.componentOptions.propsData,
           slots: () => child.componentOptions.children,
           index: dynamicIndex,

--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -6,15 +6,14 @@ import get from 'lodash/get';
 import isArray from 'lodash/isArray';
 import {
   TdSelectProps, SelectKeysType, TdOptionProps, SelectOptionGroup, SelectValue,
-} from './type';
+} from '../type';
 
 type UniOption = (TdOptionProps | SelectOptionGroup) & {
   index?: number;
   slots?: () => VNode;
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export const useSelectOptions = (props: TdSelectProps, context: SetupContext, keys: Ref<SelectKeysType>) => {
+export default function useSelectOptions(props: TdSelectProps, context: SetupContext, keys: Ref<SelectKeysType>) {
   const options = ref<UniOption[]>([]);
 
   const getOptions = () => {
@@ -117,4 +116,4 @@ export const useSelectOptions = (props: TdSelectProps, context: SetupContext, ke
     optionsMap,
     optionsList,
   };
-};
+}

--- a/src/select/option.tsx
+++ b/src/select/option.tsx
@@ -3,7 +3,6 @@ import {
   ref,
   SetupContext,
   toRefs,
-  watch,
   onMounted,
   inject,
   onBeforeUnmount,
@@ -13,21 +12,19 @@ import {
 import Vue, { PropType } from 'vue';
 
 import { ScopedSlotReturnValue } from 'vue/types/vnode';
-import get from 'lodash/get';
 import { renderContent } from '../utils/render-tnode';
-import { scrollSelectedIntoView } from '../utils/dom';
 import { prefix } from '../config';
 import CLASSNAMES from '../utils/classnames';
 import Ripple from '../utils/ripple';
 import { getKeepAnimationMixins } from '../config-provider/config-receiver';
 import props from './option-props';
-import { TdOptionProps } from './type';
+import { SelectValue, TdOptionProps } from './type';
 import Checkbox from '../checkbox/index';
 import { SelectInstance } from './instance';
 import useLazyLoad from '../hooks/useLazyLoad';
 import { TScroll } from '../common';
+import { getNewMultipleValue } from './util';
 
-const selectName = `${prefix}-select`;
 const keepAnimationMixins = getKeepAnimationMixins();
 export interface OptionInstance extends Vue {
   tSelect: SelectInstance;
@@ -41,17 +38,23 @@ export interface OptionProps extends TdOptionProps {
   scrollType?: 'lazy' | 'virtual';
   isVirtual: boolean;
   bufferSize: number;
+  multiple: Boolean;
+  isCreatedOption: Boolean;
+  index: Number;
 }
 
 export default defineComponent({
   name: 'TOption',
   props: {
     ...props,
+    isCreatedOption: Boolean,
+    multiple: Boolean,
     rowIndex: Number,
     trs: Map as PropType<OptionProps['trs']>,
     scrollType: String,
     isVirtual: Boolean,
     bufferSize: Number,
+    index: Number,
   },
   components: {
     TCheckbox: Checkbox,
@@ -59,102 +62,64 @@ export default defineComponent({
   mixins: [keepAnimationMixins],
   directives: { Ripple },
   setup(props: OptionProps, context: SetupContext) {
+    const selectProvider: any = inject('tSelect');
     const optionNode = ref(null);
-    const isHover = ref(false);
-    const formDisabled = ref(undefined);
 
     const {
-      value, label, disabled, panelElement, scrollType, bufferSize,
+      value, label, disabled, panelElement, scrollType, bufferSize, index, multiple, isCreatedOption,
     } = toRefs(props);
-
-    const tSelect: any = inject('tSelect');
 
     const { hasLazyLoadHolder = null, tRowHeight = null } = useLazyLoad(
       panelElement,
       optionNode,
       reactive({ type: scrollType, bufferSize, rowIndex: props.rowIndex }),
     );
-    watch(value, () => {
-      tSelect && tSelect.getOptions({ ...context, ...props });
-    });
 
-    const tDisabled = computed(() => formDisabled.value || disabled.value);
-    const hovering = computed(
-      () => tSelect
-        && tSelect.visible.value
-        && tSelect.hoverOptions.value[tSelect.hoverIndex.value]
-        && tSelect.hoverOptions.value[tSelect.hoverIndex.value][tSelect.realValue.value] === value.value,
-    );
-    watch(hovering, (val) => {
-      if (val) {
-        const timer = setTimeout(() => {
-          scrollSelectedIntoView(tSelect.getOverlayElm(), optionNode.value as HTMLElement);
-          clearTimeout(timer);
-        }, tSelect.popupOpenTime.value); // 待popup弹出后再滚动到对应位置
-      }
-    });
-    const classes = computed(() => [
-      `${prefix}-select-option`,
-      {
-        [CLASSNAMES.STATUS.disabled]: tDisabled.value || tSelect.reachMaxLimit.value,
-        [CLASSNAMES.STATUS.selected]: selected.value,
-        [CLASSNAMES.SIZE[tSelect && tSelect.size.value]]: tSelect && tSelect.value,
-        [`${prefix}-select-option__hover`]: hovering.value,
-      },
-    ]);
-    const isCreatedOption = computed(() => tSelect.creatable.value && value.value === tSelect.tInputValue.value);
-    const show = computed(() => {
-      /**
-       * 此属性主要用于slots生成options时显示控制，直传options由select进行显示控制
-       * create的option，始终显示
-       * canFilter只显示待匹配的选项
-       */
-      if (!tSelect) return false;
-      if (isCreatedOption.value) return true;
-      if (tSelect.canFilter.value && tSelect.tInputValue.value !== '') {
-        return tSelect.filterOptions.value.some(
-          (option: TdOptionProps) => get(option, tSelect.realValue.value) === value.value,
-        );
-      }
-      return true;
-    });
-    const labelText = computed(() => label.value || value.value);
-    const selected = computed(() => {
-      let flag = false;
-      if (!tSelect) return false;
-      if (tSelect.value.value instanceof Array) {
-        if (tSelect.labelInValue.value) {
-          flag = tSelect.value.value.map((item: any) => get(item, tSelect.realValue.value)).indexOf(value.value) !== -1;
-        } else {
-          flag = tSelect.value.value.indexOf(value.value) !== -1;
-        }
-      } else if (typeof tSelect.value.value === 'object') {
-        flag = get(tSelect.value.value, tSelect.realValue.value) === value.value;
-      } else {
-        flag = tSelect.value.value === value.value;
-      }
-      return flag;
-    });
-    const select = (e: MouseEvent | KeyboardEvent) => {
-      e.stopPropagation();
-      if (tDisabled.value || (!selected.value && tSelect.reachMaxLimit.value)) {
-        return false;
-      }
-      const parent = context.refs.optionNode as HTMLLIElement;
-      if (parent && parent.className.indexOf(`${selectName}__create-option`) !== -1) {
-        tSelect && tSelect.createOption(value.value.toString());
-      }
-      tSelect && tSelect.onOptionClick(value.value, e);
-    };
+    const isHover = ref(false);
+    const formDisabled = ref(undefined);
+    const isDisabled = computed(() => formDisabled.value || disabled.value || selectProvider.isReachMaxLimit.value);
+    const isSelected = computed(() => multiple.value
+      ? (selectProvider.selectValue.value as SelectValue[]).includes(props.value)
+      : selectProvider.selectValue.value === props.value);
     const mouseEvent = (v: boolean) => {
       isHover.value = v;
     };
-    onMounted(() => {
-      tSelect && tSelect.getOptions({ ...context, ...props });
-    });
-    onBeforeUnmount(() => {
-      tSelect && tSelect.hasSlotOptions.value && tSelect.destroyOptions({ ...props });
-    });
+
+    const labelText = computed(() => label.value || value.value);
+    const classes = computed(() => [
+      `${prefix}-select-option`,
+      CLASSNAMES.SIZE[selectProvider && selectProvider.size.value],
+      {
+        [CLASSNAMES.STATUS.disabled]: isDisabled.value,
+        [CLASSNAMES.STATUS.selected]: isSelected.value,
+        [`${prefix}-select-option__hover`]:
+          (isHover.value || selectProvider.hoverIndex.value === index.value) && !isDisabled.value && !isSelected.value,
+      },
+    ]);
+
+    const handleClick = (e: MouseEvent | KeyboardEvent) => {
+      if (multiple.value || isDisabled.value) return;
+      e.stopPropagation();
+
+      if (isCreatedOption.value) {
+        selectProvider.handleCreate?.(value.value);
+        if (selectProvider.multiple.value) {
+          const newValue = getNewMultipleValue(selectProvider.selectValue.value as SelectValue[], value.value);
+          selectProvider.handleValueChange(newValue.value, { e, trigger: 'check' });
+          return;
+        }
+      }
+      selectProvider.handleValueChange(value.value, { e, trigger: 'check' });
+      selectProvider.handlePopupVisibleChange(false, { e });
+    };
+
+    const handleCheckboxClick = (val: boolean, context: { e: MouseEvent | KeyboardEvent }) => {
+      const newValue = getNewMultipleValue(selectProvider.selectValue.value as SelectValue[], value.value);
+      selectProvider.handleValueChange(newValue.value, { e: context.e, trigger: val ? 'check' : 'uncheck' });
+      if (!selectProvider.reserveKeyword.value) {
+        selectProvider.handlerInputChange('');
+      }
+    };
 
     // 处理虚拟滚动节点挂载
     onMounted(() => {
@@ -179,22 +144,23 @@ export default defineComponent({
     });
 
     return {
-      selected,
-      show,
+      isHover,
+      isSelected,
       mouseEvent,
-      select,
       classes,
-      tSelect,
+      selectProvider,
       labelText,
       optionNode,
       tRowHeight,
       hasLazyLoadHolder,
+      handleClick,
+      handleCheckboxClick,
     };
   },
 
   render() {
     const {
-      classes, labelText, selected, disabled, show, tSelect,
+      classes, multiple, labelText, isSelected, disabled, selectProvider, handleCheckboxClick, mouseEvent,
     } = this;
     const children: ScopedSlotReturnValue = renderContent(this, 'default', 'content');
     const optionChild = children || labelText;
@@ -202,11 +168,10 @@ export default defineComponent({
       return (
         <li
           ref="optionNode"
-          v-show={show}
           class={classes}
-          onMouseenter={this.mouseEvent.bind(true)}
-          onMouseleave={this.mouseEvent.bind(false)}
-          onClick={this.select}
+          onMouseenter={() => mouseEvent(true)}
+          onMouseleave={() => mouseEvent(false)}
+          onClick={this.handleClick}
           v-ripple={(this.keepAnimation as any).ripple}
         >
           {<span style={{ height: `${this.tRowHeight}px`, border: 'none' }}></span>}
@@ -217,20 +182,17 @@ export default defineComponent({
     return (
       <li
         ref="optionNode"
-        v-show={show}
         class={classes}
-        onMouseenter={this.mouseEvent.bind(true)}
-        onMouseleave={this.mouseEvent.bind(false)}
-        onClick={this.select}
+        onMouseenter={() => mouseEvent(true)}
+        onMouseleave={() => mouseEvent(false)}
+        onClick={this.handleClick}
         v-ripple={(this.keepAnimation as any).ripple}
       >
-        {tSelect && tSelect.multiple.value ? (
+        {multiple ? (
           <t-checkbox
-            checked={selected}
-            disabled={disabled || (!selected && tSelect.reachMaxLimit.value)}
-            nativeOnClick={(e: MouseEvent) => {
-              e.preventDefault();
-            }}
+            checked={isSelected}
+            disabled={disabled || (!isSelected && selectProvider.isReachMaxLimit.value)}
+            onChange={handleCheckboxClick}
           >
             {optionChild}
           </t-checkbox>

--- a/src/select/option.tsx
+++ b/src/select/option.tsx
@@ -163,7 +163,7 @@ export default defineComponent({
       classes, multiple, labelText, isSelected, disabled, selectProvider, handleCheckboxClick, mouseEvent,
     } = this;
     const children: ScopedSlotReturnValue = renderContent(this, 'default', 'content');
-    const optionChild = children || labelText;
+    const optionChild = children || <span>{labelText}</span>;
     if (this.hasLazyLoadHolder) {
       return (
         <li
@@ -197,7 +197,7 @@ export default defineComponent({
             {optionChild}
           </t-checkbox>
         ) : (
-          <span>{optionChild}</span>
+          optionChild
         )}
       </li>
     );

--- a/src/select/optionGroup.tsx
+++ b/src/select/optionGroup.tsx
@@ -7,7 +7,7 @@ import { prefix } from '../config';
 import CLASSNAMES from '../utils/classnames';
 import props from './option-group-props';
 import { ClassName } from '../common';
-import { TdOptionProps, TdOptionGroupProps } from './type';
+import { TdOptionGroupProps } from './type';
 import { useTNodeJSX } from '../hooks/tnode';
 
 const name = `${prefix}-select-option-group`;
@@ -15,7 +15,6 @@ const name = `${prefix}-select-option-group`;
 export interface Select extends Vue {
   tSelect: {
     size: string;
-    displayOptions: Array<TdOptionProps>;
   };
 }
 

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -234,35 +234,51 @@ export default defineComponent({
 
       return (
         <ul class={`${name}__list`}>
-          {options.map((item: SelectOptionGroup & TdOptionProps & { slots: VNode } & OptionsType, index) => {
-            if (item.group) {
-              return (
-                <t-option-group label={item.group} divider={item.divider}>
-                  {this.renderOptionsContent(item.children)}
-                </t-option-group>
-              );
-            }
-
-            const scrollProps = isVirtual
-              ? {
-                rowIndex: item.$index,
-                trs,
-                scrollType,
-                isVirtual,
-                bufferSize,
+          {options.map(
+            (
+              item: SelectOptionGroup &
+                TdOptionProps & {
+                  slots: VNode;
+                  class: string | undefined;
+                  style: { [key: string]: string } | undefined;
+                } & OptionsType,
+              index,
+            ) => {
+              if (item.group) {
+                return (
+                  <t-option-group label={item.group} divider={item.divider}>
+                    {this.renderOptionsContent(item.children)}
+                  </t-option-group>
+                );
               }
-              : { key: index };
-            // replace `scopedSlots` of `v-slots` in Vue3
-            return (
-              <t-option
-                {...{ props: { ...item, ...scrollProps } }}
-                multiple={multiple}
-                scopedSlots={{ default: item.slots }}
-                key={`${item.$index || ''}_${index}`}
-                on={on}
-              />
-            );
-          })}
+
+              const scrollProps = isVirtual
+                ? {
+                  rowIndex: item.$index,
+                  trs,
+                  scrollType,
+                  isVirtual,
+                  bufferSize,
+                }
+                : { key: index };
+              // replace `scopedSlots` of `v-slots` in Vue3
+              return (
+                <t-option
+                  // 透传 class
+                  class={item.class}
+                  // 透传 style
+                  style={item.style}
+                  // 透传其余参数
+                  {...{ props: { ...item, ...scrollProps } }}
+                  // t-option 自身逻辑所需属性
+                  multiple={multiple}
+                  scopedSlots={{ default: item.slots }}
+                  key={`${item.$index || ''}_${index}`}
+                  on={on}
+                />
+              );
+            },
+          )}
         </ul>
       );
     },

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -19,7 +19,6 @@ export interface OptionsType extends TdOptionProps {
 
 type SelectPanelProps = Pick<
   TdSelectProps,
-  | 'value'
   | 'size'
   | 'multiple'
   | 'empty'
@@ -61,7 +60,6 @@ export default defineComponent({
     'loading',
     'loadingText',
     'multiple',
-    'value',
     'scroll',
     'creatable',
     'filterable',

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -1,12 +1,13 @@
 import {
   computed, defineComponent, toRefs, inject, onMounted, onBeforeUnmount,
 } from '@vue/composition-api';
-import { get } from 'lodash';
+import isFunction from 'lodash/isFunction';
+import { VNode } from 'vue';
 import { useTNodeJSX } from '../hooks/tnode';
-import { renderTNodeJSX } from '../utils/render-tnode';
+import { renderTNodeJSXDefault } from '../utils/render-tnode';
 import { useConfig } from '../config-provider/useConfig';
 import {
-  SelectValue, TdOptionProps, SelectOptionGroup, TdSelectProps,
+  TdOptionProps, SelectOptionGroup, TdSelectProps, SelectOption,
 } from './type';
 import { name } from './select';
 import Option from './option';
@@ -16,38 +17,25 @@ export interface OptionsType extends TdOptionProps {
   $index?: number;
 }
 
-interface SelectPanelProps
-  extends Pick<
-    TdSelectProps,
-    | 'value'
-    | 'size'
-    | 'multiple'
-    | 'empty'
-    | 'options'
-    | 'max'
-    | 'loadingText'
-    | 'loading'
-    | 'valueType'
-    | 'keys'
-    | 'panelTopContent'
-    | 'panelBottomContent'
-    | 'inputValue'
-    | 'scroll'
-  > {
-  onChange?: (value: SelectValue, context?: { label?: string | number; restData?: Record<string, any> }) => void;
-  /**
-   * 是否展示popup
-   */
-  showPopup: boolean;
-  /**
-   * 控制popup展示的函数
-   */
-  setShowPopup: (show: boolean) => void;
-  /**
-   * 是否支持创建自定义option
-   */
-  showCreateOption: boolean;
-}
+type SelectPanelProps = Pick<
+  TdSelectProps,
+  | 'value'
+  | 'size'
+  | 'multiple'
+  | 'empty'
+  | 'options'
+  | 'loadingText'
+  | 'loading'
+  | 'valueType'
+  | 'keys'
+  | 'panelTopContent'
+  | 'panelBottomContent'
+  | 'inputValue'
+  | 'scroll'
+  | 'creatable'
+  | 'filterable'
+  | 'filter'
+>;
 
 const sizeClassMap = {
   small: 's',
@@ -69,25 +57,23 @@ export default defineComponent({
     'size',
     'options',
     'empty',
-    'showCreateOption',
+    'filter',
     'loading',
     'loadingText',
     'multiple',
-    'max',
     'value',
-    'realValue',
-    'realLabel',
     'scroll',
+    'creatable',
+    'filterable',
   ],
 
   setup(props: SelectPanelProps) {
-    const { options, showCreateOption } = toRefs(props);
+    const { options, inputValue } = toRefs(props);
     const renderTNode = useTNodeJSX();
     const { t, global } = useConfig('select');
-    const tSelect: any = inject('tSelect');
+    const selectProvider: any = inject('tSelect');
 
-    const isEmpty = computed(() => !options.value.length && !showCreateOption.value);
-    const panelContentRef = computed(() => tSelect.getOverlayElm());
+    const panelContentRef = computed(() => selectProvider.getOverlayElm());
 
     const {
       type,
@@ -96,6 +82,38 @@ export default defineComponent({
       isFixedRowHeight = false,
       threshold = 100,
     } = props.scroll || {};
+
+    const displayOptions = computed(() => {
+      if (!inputValue.value || props.creatable || !(props.filterable || isFunction(props.filter))) return options.value;
+
+      const filterMethods = (option: SelectOption) => {
+        if (isFunction(props.filter)) {
+          return props.filter(`${props.inputValue}`, option);
+        }
+        return option.label?.indexOf(`${props.inputValue}`) > -1;
+      };
+
+      const res: SelectOption[] = [];
+      props.options.forEach((option) => {
+        if ((option as SelectOptionGroup).group && (option as SelectOptionGroup).children) {
+          res.push({
+            ...option,
+            children: (option as SelectOptionGroup).children.filter(filterMethods),
+          });
+        }
+        if (filterMethods(option)) {
+          res.push(option);
+        }
+      });
+
+      return res;
+    });
+
+    const isCreateOptionShown = computed(() => props.creatable && props.filterable && props.inputValue);
+    const isEmpty = computed(() => !displayOptions.value.length);
+    const isVirtual = computed(
+      () => props.scroll?.type === 'virtual' && props.options?.length > (props.scroll?.threshold || 100),
+    );
 
     const {
       trs = null,
@@ -107,18 +125,13 @@ export default defineComponent({
     } = type === 'virtual'
       ? useVirtualScroll({
         container: panelContentRef,
-        data: options,
+        data: displayOptions,
         fixedHeight: isFixedRowHeight,
         lineHeight: rowHeight,
         bufferSize,
         threshold,
       })
       : {};
-
-    const isVirtual = computed(
-      () => props.scroll?.type === 'virtual' && props.options?.length > (props.scroll?.threshold || 100),
-    );
-
     let lastScrollY = -1;
     const onInnerVirtualScroll = (e: WheelEvent) => {
       if (!isVirtual.value) {
@@ -138,14 +151,14 @@ export default defineComponent({
     // 监听popup滚动 处理虚拟滚动时的virtualData变化
     onMounted(() => {
       if (props.scroll?.type === 'virtual') {
-        tSelect.getOverlayElm().addEventListener('scroll', onInnerVirtualScroll);
+        selectProvider.getOverlayElm().addEventListener('scroll', onInnerVirtualScroll);
       }
     });
 
     // 卸载时取消监听
     onBeforeUnmount(() => {
       if (props.scroll?.type === 'virtual') {
-        tSelect.getOverlayElm().removeEventListener('scroll', onInnerVirtualScroll);
+        selectProvider.getOverlayElm().removeEventListener('scroll', onInnerVirtualScroll);
       }
     });
 
@@ -154,7 +167,8 @@ export default defineComponent({
       global,
       isEmpty,
       renderTNode,
-      tSelect,
+      selectProvider,
+      isCreateOptionShown,
       // 虚拟滚动相关
       trs,
       isVirtual,
@@ -166,35 +180,39 @@ export default defineComponent({
       handleRowMounted,
       bufferSize,
       threshold,
+      displayOptions,
     };
   },
 
   methods: {
     renderEmptyContent() {
       const { empty, t, global } = this;
-      const useLocale = !empty && !this.$slots.empty;
-      if (useLocale) {
-        return <div class={`${name}__loading-tips`}>{t(global.empty)}</div>;
+      if (empty && typeof empty === 'string') {
+        return <div class={`${name}__empty`}>{empty}</div>;
       }
-      return renderTNodeJSX(this, 'empty');
+      return renderTNodeJSXDefault(this, 'empty', <div class={`${name}__empty`}>{t(global.empty)}</div>);
     },
     renderLoadingContent() {
       const { loadingText, t, global } = this;
-      const useLocale = !loadingText && !this.$slots.loadingText;
-      if (useLocale) {
-        return <div class={`${name}__loading-tips`}>{t(global.loadingText)}</div>;
+      if (loadingText && typeof loadingText === 'string') {
+        return <div class={`${name}__loading-tips`}>{loadingText}</div>;
       }
-      return renderTNodeJSX(this, 'loadingText');
+      return renderTNodeJSXDefault(
+        this,
+        'loadingText',
+        <div class={`${name}__loading-tips`}>{t(global.loadingText)}</div>,
+      );
     },
     renderCreateOption() {
       const {
-        showCreateOption, inputValue, trs, scrollType, isVirtual, handleRowMounted, bufferSize,
+        inputValue, trs, scrollType, isVirtual, handleRowMounted, bufferSize,
       } = this;
       const on = isVirtual ? { onRowMounted: handleRowMounted } : {};
 
       return (
-        <ul v-show={showCreateOption} class={[`${name}__create-option`, `${name}__list`]}>
+        <ul class={[`${name}__create-option`, `${name}__list`]}>
           <t-option
+            isCreatedOption={true}
             value={inputValue}
             label={inputValue}
             class={`${name}__create-option--special`}
@@ -207,117 +225,102 @@ export default defineComponent({
         </ul>
       );
     },
-    renderSingleOption(options: OptionsType[] = []) {
+
+    // 递归render options
+    renderOptionsContent(options: SelectOption[]) {
       const {
-        realValue, realLabel, trs, scrollType, isVirtual, handleRowMounted, bufferSize,
+        multiple, trs, scrollType, isVirtual, handleRowMounted, bufferSize,
       } = this;
 
       const on = isVirtual ? { onRowMounted: handleRowMounted } : {};
-      return options.map((item, index) => (
-        <t-option
-          value={get(item, realValue as string)}
-          label={get(item, realLabel as string)}
-          content={item.content}
-          disabled={item.disabled}
-          key={`${item.$index}_${index}`}
-          rowIndex={item.$index}
-          trs={trs}
-          scrollType={scrollType}
-          isVirtual={isVirtual}
-          bufferSize={bufferSize}
-          on={on}
-        ></t-option>
-      ));
+
+      return (
+        <ul class={`${name}__list`}>
+          {options.map((item: SelectOptionGroup & TdOptionProps & { slots: VNode } & OptionsType, index) => {
+            if (item.group) {
+              return (
+                <t-option-group label={item.group} divider={item.divider}>
+                  {this.renderOptionsContent(item.children)}
+                </t-option-group>
+              );
+            }
+
+            const scrollProps = isVirtual
+              ? {
+                rowIndex: item.$index,
+                trs,
+                scrollType,
+                isVirtual,
+                bufferSize,
+              }
+              : { key: index };
+            // replace `scopedSlots` of `v-slots` in Vue3
+            return (
+              <t-option
+                {...{ props: { ...item, ...scrollProps } }}
+                multiple={multiple}
+                scopedSlots={{ default: item.slots }}
+                key={`${item.$index || ''}_${index}`}
+                on={on}
+              />
+            );
+          })}
+        </ul>
+      );
     },
-    renderOptionsContent() {
+
+    renderPanelContent(innerStyle = {}) {
       const {
-        tSelect, options, visibleData, isVirtual,
+        renderTNode, isEmpty, isCreateOptionShown, size, loading, isVirtual, visibleData, displayOptions,
       } = this;
-      const children = renderTNodeJSX(this, 'default');
-      // 自定义输出
-      if (tSelect.hasSlotOptions.value) {
-        return (
-          <ul v-show={options.length} class={[`${name}__groups`, `${name}__list`]}>
-            {children}
-          </ul>
-        );
-      }
-      // 组件渲染
-      let optionsContent;
-      if (tSelect.isGroupOption.value) {
-        // 有分组
-        optionsContent = (isVirtual && visibleData ? visibleData : options).map((groupList: SelectOptionGroup) => {
-          const children = groupList.children.filter((item) => tSelect.displayOptionsMap.value.get(item));
-          return (
-            <t-option-group label={groupList.group} divider={groupList.divider}>
-              {this.renderSingleOption(children)}
-            </t-option-group>
-          );
-        });
-      } else {
-        // 无分组
-        optionsContent = this.renderSingleOption(isVirtual && visibleData ? visibleData : options);
-      }
-      return <ul class={`${name}__list`}>{optionsContent}</ul>;
+      return (
+        <div
+          class={[`${name}__dropdown-inner`, `${name}__dropdown-inner--size-${sizeClassMap[size]}`]}
+          style={innerStyle}
+        >
+          {renderTNode('panelTopContent')}
+          {isEmpty && this.renderEmptyContent()}
+          {isCreateOptionShown && this.renderCreateOption()}
+          {!isEmpty && loading && this.renderLoadingContent()}
+          {!isEmpty && !loading && this.renderOptionsContent(isVirtual && visibleData ? visibleData : displayOptions)}
+          {renderTNode('panelBottomContent')}
+        </div>
+      );
     },
   },
 
   render() {
-    const {
-      size, renderTNode, loading, isEmpty, translateY, scrollHeight, isVirtual,
-    } = this;
-    const translate = `translate(0, ${translateY}px)`;
-    const virtualStyle = {
-      transform: translate,
-      '-ms-transform': translate,
-      '-moz-transform': translate,
-      '-webkit-transform': translate,
-    };
+    const { translateY, scrollHeight, isVirtual } = this;
 
-    const cursorTranslate = `translate(0, ${scrollHeight}px)`;
-    const cursorTranslateStyle = {
-      position: 'absolute',
-      width: '1px',
-      height: '1px',
-      transition: 'transform 0.2s',
-      transform: cursorTranslate,
-      '-ms-transform': cursorTranslate,
-      '-moz-transform': cursorTranslate,
-      '-webkit-transform': cursorTranslate,
-    };
-
-    // 虚拟滚动渲染
+    // 虚拟滚动渲染，popup 的 dom 结构有区别
     if (isVirtual) {
+      const cursorTranslate = `translate(0, ${scrollHeight}px)`;
+      const cursorTranslateStyle = {
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        transition: 'transform 0.2s',
+        transform: cursorTranslate,
+        '-ms-transform': cursorTranslate,
+        '-moz-transform': cursorTranslate,
+        '-webkit-transform': cursorTranslate,
+      };
+
+      const translate = `translate(0, ${translateY}px)`;
+      const virtualStyle = {
+        transform: translate,
+        '-ms-transform': translate,
+        '-moz-transform': translate,
+        '-webkit-transform': translate,
+      };
       return (
         <div>
           <div style={{ ...cursorTranslateStyle }}></div>
-          <div
-            class={[`${name}__dropdown-inner`, `${name}__dropdown-inner--size-${sizeClassMap[size]}`]}
-            style={virtualStyle}
-          >
-            {renderTNode('panelTopContent')}
-            {isEmpty && this.renderEmptyContent()}
-            {this.renderCreateOption()}
-            {!isEmpty && loading && this.renderLoadingContent()}
-            {!isEmpty && !loading && this.renderOptionsContent()}
-            {renderTNode('panelBottomContent')}
-          </div>
+          {this.renderPanelContent(virtualStyle)}
         </div>
       );
     }
 
-    return (
-      <div
-        class={[`${name}__dropdown-inner`, `${name}__dropdown-inner--size-${sizeClassMap[size]}`]}
-        style={virtualStyle}
-      >
-        {renderTNode('panelTopContent')}
-        {isEmpty && this.renderEmptyContent()}
-        {this.renderCreateOption()}
-        {!isEmpty && loading && this.renderLoadingContent()}
-        {!isEmpty && !loading && this.renderOptionsContent()}
-        {renderTNode('panelBottomContent')}
-      </div>
-    );
+    return (this.renderPanelContent as Function)();
   },
 });

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -34,7 +34,7 @@ import FakeArrow from '../common-components/fake-arrow';
 import Option from './option';
 import SelectPanel from './select-panel';
 import { getSingleContent, getMultipleContent, getNewMultipleValue } from './util';
-import { useSelectOptions } from './hooks';
+import useSelectOptions from './hooks/useSelectOptions';
 
 export type OptionInstance = InstanceType<typeof Option>;
 

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -462,80 +462,45 @@ export default defineComponent({
   },
 
   render() {
-    const {
-      valueDisplayParams,
-      placeholderText,
-      multiple,
-      keys,
-      autoWidth,
-      bordered,
-      readonly,
-      displayText,
-      clearable,
-      isDisabled,
-      borderless,
-      size,
-      isFilterable,
-      tInputValue,
-      isLoading,
-      loadingText,
-      tagInputProps,
-      tagProps,
-      inputProps,
-      minCollapsedNum,
-      popupProps,
-      selectInputProps,
-      value,
-      innerPopupVisible,
-      filter,
-      setInnerPopupVisible,
-      handleTInputValueChange,
-      renderTNode,
-      collapsedItemsParams,
-      updateScrollTop,
-      innerOptions,
-      creatable,
-      // 虚拟滚动参数
-      scroll,
-    } = this;
+    const { renderTNode } = this;
 
     const prefixIcon = () => renderTNode('prefixIcon');
-    const valueDisplay = () => renderTNode('valueDisplay', { params: valueDisplayParams });
-    const collapsedItems = () => renderTNode('collapsedItems', { params: collapsedItemsParams });
+    const valueDisplay = () => renderTNode('valueDisplay', { params: this.valueDisplayParams });
+    const collapsedItems = () => renderTNode('collapsedItems', { params: this.collapsedItemsParams });
 
-    const { overlayClassName, ...restPopupProps } = popupProps || {};
+    const { overlayClassName, ...restPopupProps } = this.popupProps || {};
 
     return (
       <div ref="select" class={`${name}__wrap`}>
         <SelectInput
           ref="selectInputRef"
           class={name}
-          autoWidth={autoWidth}
-          borderless={borderless || !bordered}
-          readonly={readonly}
-          allowInput={isFilterable}
-          multiple={multiple}
-          keys={keys}
-          value={displayText}
+          autoWidth={this.autoWidth}
+          borderless={this.borderless || !this.bordered}
+          readonly={this.readonly}
+          allowInput={this.isFilterable}
+          multiple={this.multiple}
+          keys={this.keys}
+          value={this.displayText}
           valueDisplay={valueDisplay}
-          clearable={clearable}
-          disabled={isDisabled}
+          clearable={this.clearable}
+          disabled={this.isDisabled}
           label={prefixIcon}
           suffixIcon={this.renderSuffixIcon}
-          placeholder={placeholderText}
-          inputValue={tInputValue}
+          placeholder={this.placeholderText}
+          inputValue={this.tInputValue}
           inputProps={{
-            size,
-            ...inputProps,
+            size: this.size,
+            ...this.inputProps,
           }}
           tagInputProps={{
             autoWidth: true,
-            ...tagInputProps,
+            ...this.tagInputProps,
           }}
-          tagProps={tagProps}
-          minCollapsedNum={minCollapsedNum}
+          tagProps={this.tagProps}
+          minCollapsedNum={this.minCollapsedNum}
           collapsedItems={collapsedItems}
-          popupVisible={innerPopupVisible}
+          popupVisible={this.innerPopupVisible}
           popupProps={{
             overlayClassName: [`${name}__dropdown`, ['narrow-scrollbar'], overlayClassName],
             ...restPopupProps,
@@ -545,30 +510,29 @@ export default defineComponent({
             blur: this.handleBlur,
             enter: this.handleEnter,
             clear: this.handleClear,
-            'input-change': handleTInputValueChange,
-            'popup-visible-change': setInnerPopupVisible,
+            'input-change': this.handleTInputValueChange,
+            'popup-visible-change': this.setInnerPopupVisible,
             'tag-change': this.handleTagChange,
           }}
-          {...selectInputProps}
-          updateScrollTop={updateScrollTop}
+          {...this.selectInputProps}
+          updateScrollTop={this.updateScrollTop}
         >
           <select-panel
             slot="panel"
             scopedSlots={this.$scopedSlots}
-            options={innerOptions}
-            value={value}
-            inputValue={tInputValue}
-            multiple={multiple}
-            filter={filter}
-            filterable={isFilterable}
-            size={size}
+            size={this.size}
+            options={this.innerOptions}
+            inputValue={this.tInputValue}
+            multiple={this.multiple}
             empty={this.empty}
-            loading={isLoading}
-            loadingText={loadingText}
-            scroll={scroll}
+            filter={this.filter}
+            filterable={this.isFilterable}
+            creatable={this.creatable}
+            scroll={this.scroll}
+            loading={this.isLoading}
+            loadingText={this.loadingText}
             panelTopContent={this.panelTopContent}
             panelBottomContent={this.panelBottomContent}
-            creatable={creatable}
           />
         </SelectInput>
       </div>

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -14,6 +14,7 @@ import debounce from 'lodash/debounce';
 import get from 'lodash/get';
 import { CloseCircleFilledIcon } from 'tdesign-icons-vue';
 import cloneDeep from 'lodash/cloneDeep';
+import isArray from 'lodash/isArray';
 import useDefaultValue from '../hooks/useDefaultValue';
 import { useTNodeJSX } from '../hooks/tnode';
 import { useConfig } from '../config-provider/useConfig';
@@ -366,6 +367,25 @@ export default defineComponent({
       }
     };
 
+    const checkValueInvalid = () => {
+      // 参数类型检测与修复
+      if (!multiple.value && isArray(value.value)) {
+        value.value = '';
+      }
+      if (multiple.value && !isArray(value.value)) {
+        value.value = [];
+      }
+    };
+
+    watch(
+      value,
+      () => {
+        checkValueInvalid();
+      },
+      {
+        immediate: true,
+      },
+    );
     // 为 eventListener 加单独的 sync watch，以防组件在卸载的时候未能正常清除监听 (https://github.com/Tencent/tdesign-vue/issues/1170)
     watch(
       innerPopupVisible,

--- a/src/select/util.ts
+++ b/src/select/util.ts
@@ -7,14 +7,15 @@ import {
 export const getSingleContent = (value: TdSelectProps['value'], options: SelectOption[]): string => {
   for (const option of options) {
     if ((option as TdOptionProps).value === value) {
-      return option?.label;
+      // 保底使用 value 作为显示
+      return option?.label || String((option as TdOptionProps).value);
     }
   }
   return value as string;
 };
 
 export const getMultipleContent = (value: SelectValue[], options: SelectOption[]) => {
-  const res = [];
+  const res: string[] = [];
   for (const iterator of value) {
     const resLabel = getSingleContent(iterator, options);
     if (resLabel) {

--- a/src/select/util.ts
+++ b/src/select/util.ts
@@ -1,24 +1,39 @@
-import { VNode } from 'vue';
-import { TdOptionProps } from './type';
+/* eslint-disable no-restricted-syntax */
+import cloneDeep from 'lodash/cloneDeep';
+import {
+  SelectOption, SelectValue, TdOptionProps, TdSelectProps,
+} from './type';
 
-// eslint-disable-next-line import/prefer-default-export
-export function parseOptions(vnodes: VNode[]): TdOptionProps[] {
-  if (!vnodes) return [];
-  return vnodes.reduce((options, vnode) => {
-    const { componentOptions } = vnode;
-    if (componentOptions?.tag === 't-option') {
-      const propsData = componentOptions.propsData as any;
-      return options.concat({
-        label: propsData.label,
-        value: propsData.value,
-        disabled: propsData.disabled,
-        content: componentOptions.children ? () => componentOptions.children : propsData.content,
-        default: propsData.default,
-      });
+export const getSingleContent = (value: TdSelectProps['value'], options: SelectOption[]): string => {
+  for (const option of options) {
+    if ((option as TdOptionProps).value === value) {
+      return option?.label;
     }
-    if (componentOptions?.tag === 't-option-group') {
-      return options.concat(parseOptions(componentOptions.children));
+  }
+  return value as string;
+};
+
+export const getMultipleContent = (value: SelectValue[], options: SelectOption[]) => {
+  const res = [];
+  for (const iterator of value) {
+    const resLabel = getSingleContent(iterator, options);
+    if (resLabel) {
+      res.push(resLabel);
     }
-    return options;
-  }, []);
-}
+  }
+  return res;
+};
+
+export const getNewMultipleValue = (innerValue: SelectValue[], optionValue: SelectValue) => {
+  const value = cloneDeep(innerValue) as SelectValue[];
+  const valueIndex = value.indexOf(optionValue);
+  if (valueIndex < 0) {
+    value.push(optionValue);
+  } else {
+    value.splice(valueIndex, 1);
+  }
+  return {
+    value,
+    isCheck: valueIndex < 0,
+  };
+};

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -238,28 +238,6 @@ export const isNodeOverflow = (ele: Vue | Element | (Vue | Element)[]): boolean 
   return scrollWidth > clientWidth;
 };
 
-// 将子元素selected滚动到父元素parentEle的可视范围内
-export const scrollSelectedIntoView = (parentEle: HTMLElement, selected: HTMLElement) => {
-  // 服务端不处理
-  if (Vue.prototype.$isServer) return;
-  // selected不存在或selected父元素不为parentEle则不处理
-  if (!selected || selected.offsetParent !== parentEle) {
-    parentEle.scrollTop = 0;
-    return;
-  }
-  const selectedTop = selected.offsetTop;
-  const selectedBottom = selectedTop + selected.offsetHeight;
-  const parentScrollTop = parentEle.scrollTop;
-  const parentViewBottom = parentScrollTop + parentEle.clientHeight;
-  if (selectedTop < parentScrollTop) {
-    // selected元素滚动过了，则将其向下滚动到可视范围顶部
-    parentEle.scrollTop = selectedTop;
-  } else if (selectedBottom > parentViewBottom) {
-    // selected元素未滚动到，则将其向上滚动到可视范围底部
-    parentEle.scrollTop = selectedBottom - parentEle.clientHeight;
-  }
-};
-
 export const removeDom = (el: HTMLElement) => {
   if (el.remove) {
     el.remove();

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -816,7 +816,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/base.vue correctly 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -825,7 +825,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/base.vue correctly 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -910,7 +910,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/card.vue correctly 
     <div class="demo-select-base t-select__wrap">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="card" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="卡片风格" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div> <button type="button" class="t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">今天（当前高亮日期）</span></button>
@@ -928,7 +928,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/card.vue correctly 
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -937,7 +937,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/card.vue correctly 
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1024,7 +1024,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/cell.vue correctly 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1033,7 +1033,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/cell.vue correctly 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1307,7 +1307,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/cell-append.vue cor
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1316,7 +1316,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/cell-append.vue cor
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1471,7 +1471,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/controller-config.v
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-s t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1480,7 +1480,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/controller-config.v
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-s t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1570,7 +1570,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/events.vue correctl
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1579,7 +1579,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/events.vue correctl
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1665,7 +1665,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/first-day-of-week.v
     <div class="demo-select-base t-select__wrap">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="3" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="周三" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -1678,7 +1678,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/first-day-of-week.v
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1687,7 +1687,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/first-day-of-week.v
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1780,7 +1780,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/head.vue correctly 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1789,7 +1789,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/head.vue correctly 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1874,7 +1874,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/mode.vue correctly 
     <div class="demo-select-base t-select__wrap">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="year" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="月历" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -1887,7 +1887,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/mode.vue correctly 
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -1937,7 +1937,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/range.vue correctly
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -1946,7 +1946,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/range.vue correctly
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -2036,7 +2036,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/slot-props-api.vue 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021" class="t-input__inner"><span class="t-input__input-pre">2021</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="2021 年" class="t-input__inner"><span class="t-input__input-pre">2021 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -2045,7 +2045,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/slot-props-api.vue 
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12 月" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -2300,7 +2300,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/value.vue correctly
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="1998" class="t-input__inner"><span class="t-input__input-pre">1998</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="1998 年" class="t-input__inner"><span class="t-input__input-pre">1998 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -2309,7 +2309,7 @@ exports[`ssr snapshot test renders ./examples/calendar/demos/value.vue correctly
           <div class="t-select__wrap">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="11" class="t-input__inner"><span class="t-input__input-pre">11</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="11 月" class="t-input__inner"><span class="t-input__input-pre">11 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -4646,7 +4646,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/calendar.vue
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-s t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="12" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="December" class="t-input__inner"><span class="t-input__input-pre">December</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -4854,21 +4854,21 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/others.vue c
   <div class="t-select__wrap" style="width:400px;">
     <div class="t-input__wrap t-select-input--empty t-select">
       <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="see clear icon, it is configurable" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="see clear icon, it is configurable" type="text" unselectable="on" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div> <br><br>
   <div class="t-select__wrap" style="width:400px;">
     <div class="t-input__wrap t-select-input--empty t-select">
       <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="select without data in Select" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="select without data in Select" type="text" unselectable="on" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div> <br><br>
   <div class="t-select__wrap" style="width:400px;">
     <div class="t-input__wrap t-select-input--empty t-select">
       <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="see loading text in Select" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading"><foreignObject x="1" y="1" width="12" height="12"><div class="t-loading__gradient-conic"></div></foreignObject></svg></div></span>
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="see loading text in Select" type="text" unselectable="on" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><div class="t-loading--center t-size-s t-loading t-select__right-icon t-select__active-icon"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading"><foreignObject x="1" y="1" width="12" height="12"><div class="t-loading__gradient-conic"></div></foreignObject></svg></div></span>
       </div>
     </div>
   </div> <br><br>
@@ -4995,7 +4995,7 @@ exports[`ssr snapshot test renders ./examples/config-provider/demos/pagination.v
   <div class="t-select__wrap t-pagination__select">
     <div class="t-input__wrap t-select">
       <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10" class="t-input__inner"><span class="t-input__input-pre">10</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10 / page" class="t-input__inner"><span class="t-input__input-pre">10 / page</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div>
@@ -7562,7 +7562,7 @@ exports[`ssr snapshot test renders ./examples/icon/demos/enhanced.vue correctly 
 
 exports[`ssr snapshot test renders ./examples/icon/demos/icon-select.vue correctly 1`] = `
 <div class="t-select__wrap" style="width:400px;">
-  <div class="t-input__wrap t-select">
+  <div class="t-input__wrap t-select-input--empty t-select">
     <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
       <div class="t-input__prefix">
         <div><svg class="t-icon t-icon-edit-1" style="margin-right:8px;">
@@ -10512,7 +10512,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/base.vue correctl
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10538,7 +10538,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/base.vue correctl
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10" class="t-input__inner"><span class="t-input__input-pre">10</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10 条/页" class="t-input__inner"><span class="t-input__input-pre">10 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10571,7 +10571,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/customizable.vue 
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="20" class="t-input__inner"><span class="t-input__input-pre">20</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="20 条/页" class="t-input__inner"><span class="t-input__input-pre">20 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10609,7 +10609,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/disabled.vue corr
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input disabled="disabled" readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input disabled="disabled" readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10646,7 +10646,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/few.vue correctly
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10" class="t-input__inner"><span class="t-input__input-pre">10</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10 条/页" class="t-input__inner"><span class="t-input__input-pre">10 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10674,7 +10674,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/jump.vue correctl
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="20" class="t-input__inner"><span class="t-input__input-pre">20</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="20 条/页" class="t-input__inner"><span class="t-input__input-pre">20 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10708,7 +10708,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/mini.vue correctl
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-s t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10740,7 +10740,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/more.vue correctl
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10771,7 +10771,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/more.vue correctl
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10799,7 +10799,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/page-num.vue corr
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="30" class="t-input__inner"><span class="t-input__input-pre">30</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="每页 30 条" class="t-input__inner"><span class="t-input__input-pre">每页 30 条</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10831,7 +10831,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/simple.vue correc
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -10858,7 +10858,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/simple-mini.vue c
   <div class="t-select__wrap t-pagination__select">
     <div class="t-input__wrap t-select">
       <div class="t-input t-size-s t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div>
@@ -10885,7 +10885,7 @@ exports[`ssr snapshot test renders ./examples/pagination/demos/total.vue correct
     <div class="t-select__wrap t-pagination__select">
       <div class="t-input__wrap t-select">
         <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10" class="t-input__inner"><span class="t-input__input-pre">10</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+          <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10 条/页" class="t-input__inner"><span class="t-input__input-pre">10 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
         </div>
       </div>
     </div>
@@ -11751,10 +11751,17 @@ exports[`ssr snapshot test renders ./examples/select/demos/collapsed.vue correct
 
 exports[`ssr snapshot test renders ./examples/select/demos/creatable.vue correctly 1`] = `
 <div>
-  <div class="t-select__wrap" style="width:200px;">
+  <div class="t-select__wrap" style="width:200px;display:inline-block;margin:0 20px 20px 0;">
     <div class="t-input__wrap t-select-input--empty t-select">
       <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input autocomplete="" placeholder="支持自定义创建" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+        <div class="t-input__prefix"></div><input autocomplete="" placeholder="单选支持自定义创建" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
+    </div>
+  </div>
+  <div class="t-select__wrap" style="width:400px;display:inline-block;">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-select">
+      <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input autocomplete="" placeholder="多选支持自定义创建" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div>
@@ -11811,8 +11818,8 @@ exports[`ssr snapshot test renders ./examples/select/demos/disabled.vue correctl
 <div>
   <div class="t-select__wrap" style="width:200px;display:inline-block;margin-right:20px;">
     <div class="t-input__wrap t-select-input--empty t-select">
-      <div class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"></div><input disabled="disabled" readonly="readonly" autocomplete="" placeholder="-请选择-" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      <div class="t-input t-size-m t-is-disabled t-is-default t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input disabled="disabled" autocomplete="" placeholder="-请选择-" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div>
@@ -11907,7 +11914,7 @@ exports[`ssr snapshot test renders ./examples/select/demos/multiple.vue correctl
   <div class="t-select__wrap">
     <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select">
       <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">1<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">2<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">3<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">4<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">5<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">6<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">云服务器<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">云数据库<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">域名注册<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">网站备案<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">对象存储<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">低代码平台<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
       </div>
     </div>
   </div> <br><br>
@@ -14151,7 +14158,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/affix.vue correctly 1`
           <div class="t-select__wrap t-pagination__select">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -14364,7 +14371,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/base.vue correctly 1`]
           <div class="t-select__wrap t-pagination__select">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -14550,7 +14557,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/custom-col.vue correct
           <div class="t-select__wrap t-pagination__select">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -14689,7 +14696,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/custom-col-button.vue 
           <div class="t-select__wrap t-pagination__select">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -17202,7 +17209,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination.vue correct
           <div class="t-select__wrap t-pagination__select">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5" class="t-input__inner"><span class="t-input__input-pre">5</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="5 条/页" class="t-input__inner"><span class="t-input__input-pre">5 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>
@@ -17282,7 +17289,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/pagination-ajax.vue co
         <div class="t-select__wrap t-pagination__select">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10" class="t-input__inner"><span class="t-input__input-pre">10</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10 条/页" class="t-input__inner"><span class="t-input__input-pre">10 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -17868,7 +17875,7 @@ exports[`ssr snapshot test renders ./examples/table/demos/tree.vue correctly 1`]
           <div class="t-select__wrap t-pagination__select">
             <div class="t-input__wrap t-select">
               <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10" class="t-input__inner"><span class="t-input__input-pre">10</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+                <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="10 条/页" class="t-input__inner"><span class="t-input__input-pre">10 条/页</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
               </div>
             </div>
           </div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -7562,7 +7562,7 @@ exports[`ssr snapshot test renders ./examples/icon/demos/enhanced.vue correctly 
 
 exports[`ssr snapshot test renders ./examples/icon/demos/icon-select.vue correctly 1`] = `
 <div class="t-select__wrap" style="width:400px;">
-  <div class="t-input__wrap t-select-input--empty t-select">
+  <div class="t-input__wrap t-select">
     <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
       <div class="t-input__prefix">
         <div><svg class="t-icon t-icon-edit-1" style="margin-right:8px;">

--- a/test/unit/calendar/__snapshots__/demo.test.js.snap
+++ b/test/unit/calendar/__snapshots__/demo.test.js.snap
@@ -39,7 +39,7 @@ exports[`Calendar Calendar baseVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                2020
+                2020 年
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -90,7 +90,7 @@ exports[`Calendar Calendar baseVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                12 月
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -890,7 +890,7 @@ exports[`Calendar Calendar cardVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  2020
+                  2020 年
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -941,7 +941,7 @@ exports[`Calendar Calendar cardVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  12
+                  12 月
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -1639,7 +1639,7 @@ exports[`Calendar Calendar cellAppendVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                2020
+                2020 年
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -1690,7 +1690,7 @@ exports[`Calendar Calendar cellAppendVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                12 月
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -2420,7 +2420,7 @@ exports[`Calendar Calendar cellVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                2020
+                2020 年
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -2471,7 +2471,7 @@ exports[`Calendar Calendar cellVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                12 月
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -3506,7 +3506,7 @@ exports[`Calendar Calendar controllerConfigVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  2020
+                  2020 年
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -3557,7 +3557,7 @@ exports[`Calendar Calendar controllerConfigVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  12
+                  12 月
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -4282,7 +4282,7 @@ exports[`Calendar Calendar eventsVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  2020
+                  2020 年
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -4333,7 +4333,7 @@ exports[`Calendar Calendar eventsVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  12
+                  12 月
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -5106,7 +5106,7 @@ exports[`Calendar Calendar firstDayOfWeekVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  2020
+                  2020 年
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -5157,7 +5157,7 @@ exports[`Calendar Calendar firstDayOfWeekVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  12
+                  12 月
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -5986,7 +5986,7 @@ exports[`Calendar Calendar headVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                2020
+                2020 年
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -6037,7 +6037,7 @@ exports[`Calendar Calendar headVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                12 月
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -6809,7 +6809,7 @@ exports[`Calendar Calendar modeVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  2020
+                  2020 年
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -7134,7 +7134,7 @@ exports[`Calendar Calendar rangeVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                2020
+                2020 年
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -7185,7 +7185,7 @@ exports[`Calendar Calendar rangeVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                12 月
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -7909,7 +7909,7 @@ exports[`Calendar Calendar slotPropsApiVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                2020
+                2020 年
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -7960,7 +7960,7 @@ exports[`Calendar Calendar slotPropsApiVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                12 月
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -8761,7 +8761,7 @@ exports[`Calendar Calendar valueVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  1998
+                  1998 年
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -8812,7 +8812,7 @@ exports[`Calendar Calendar valueVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  11
+                  11 月
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -9645,7 +9645,7 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                   <span
                     class="t-input__input-pre"
                   >
-                    2020
+                    2020 年
                   </span>
                   <span
                     class="t-input__suffix t-input__suffix-icon"
@@ -9696,7 +9696,7 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                   <span
                     class="t-input__input-pre"
                   >
-                    12
+                    12 月
                   </span>
                   <span
                     class="t-input__suffix t-input__suffix-icon"
@@ -10422,7 +10422,7 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                   <span
                     class="t-input__input-pre"
                   >
-                    2020
+                    2020 年
                   </span>
                   <span
                     class="t-input__suffix t-input__suffix-icon"
@@ -10473,7 +10473,7 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                   <span
                     class="t-input__input-pre"
                   >
-                    12
+                    12 月
                   </span>
                   <span
                     class="t-input__suffix t-input__suffix-icon"
@@ -11185,7 +11185,7 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                   <span
                     class="t-input__input-pre"
                   >
-                    2020
+                    2020 年
                   </span>
                   <span
                     class="t-input__suffix t-input__suffix-icon"
@@ -11236,7 +11236,7 @@ exports[`Calendar Calendar weekVue demo works fine 1`] = `
                   <span
                     class="t-input__input-pre"
                   >
-                    12
+                    12 月
                   </span>
                   <span
                     class="t-input__suffix t-input__suffix-icon"

--- a/test/unit/calendar/__snapshots__/index.test.js.snap
+++ b/test/unit/calendar/__snapshots__/index.test.js.snap
@@ -9,7 +9,7 @@ exports[`Calendar :props :firstDayOfWeek 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -18,7 +18,7 @@ exports[`Calendar :props :firstDayOfWeek 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -115,7 +115,7 @@ exports[`Calendar :props :isShowWeekendDefault 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -124,7 +124,7 @@ exports[`Calendar :props :isShowWeekendDefault 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -200,7 +200,7 @@ exports[`Calendar :props :mode 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -249,7 +249,7 @@ exports[`Calendar :props :range 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -258,7 +258,7 @@ exports[`Calendar :props :range 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -346,7 +346,7 @@ exports[`Calendar :props :theme 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -355,7 +355,7 @@ exports[`Calendar :props :theme 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -441,7 +441,7 @@ exports[`Calendar :props :value 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">2020 年</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>
@@ -450,7 +450,7 @@ exports[`Calendar :props :value 1`] = `
         <div class="t-select__wrap">
           <div class="t-input__wrap t-select">
             <div class="t-input t-size-m t-is-default t-is-readonly t-input--auto-width t-input--prefix t-input--suffix">
-              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+              <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" class="t-input__inner"><span class="t-input__input-pre">12 月</span><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-select__right-icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
             </div>
           </div>
         </div>

--- a/test/unit/config-provider/__snapshots__/demo.test.js.snap
+++ b/test/unit/config-provider/__snapshots__/demo.test.js.snap
@@ -91,7 +91,7 @@ exports[`ConfigProvider ConfigProvider calendarVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                12
+                December
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -3223,7 +3223,7 @@ exports[`ConfigProvider ConfigProvider paginationVue demo works fine 1`] = `
         <span
           class="t-input__input-pre"
         >
-          10
+          10 / page
         </span>
         <span
           class="t-input__suffix t-input__suffix-icon"

--- a/test/unit/pagination/__snapshots__/demo.test.js.snap
+++ b/test/unit/pagination/__snapshots__/demo.test.js.snap
@@ -33,7 +33,7 @@ exports[`Pagination Pagination baseVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            5
+            5 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -171,7 +171,7 @@ exports[`Pagination Pagination baseVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            10
+            10 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -325,7 +325,7 @@ exports[`Pagination Pagination customizableVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            20
+            20 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -503,7 +503,7 @@ exports[`Pagination Pagination disabledVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            5
+            5 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -677,7 +677,7 @@ exports[`Pagination Pagination fewVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            10
+            10 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -801,7 +801,7 @@ exports[`Pagination Pagination jumpVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            20
+            20 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -957,7 +957,7 @@ exports[`Pagination Pagination miniVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            5
+            5 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -1108,7 +1108,7 @@ exports[`Pagination Pagination moreVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            5
+            5 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -1276,7 +1276,7 @@ exports[`Pagination Pagination moreVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            5
+            5 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -1401,7 +1401,7 @@ exports[`Pagination Pagination pageNumVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            30
+            每页 30 条
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -1547,7 +1547,7 @@ exports[`Pagination Pagination simpleMiniVue demo works fine 1`] = `
         <span
           class="t-input__input-pre"
         >
-          5
+          5 条/页
         </span>
         <span
           class="t-input__suffix t-input__suffix-icon"
@@ -1689,7 +1689,7 @@ exports[`Pagination Pagination simpleVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            5
+            5 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"
@@ -1832,7 +1832,7 @@ exports[`Pagination Pagination totalVue demo works fine 1`] = `
           <span
             class="t-input__input-pre"
           >
-            10
+            10 条/页
           </span>
           <span
             class="t-input__suffix t-input__suffix-icon"

--- a/test/unit/select/__snapshots__/demo.test.js.snap
+++ b/test/unit/select/__snapshots__/demo.test.js.snap
@@ -286,7 +286,7 @@ exports[`Select Select creatableVue demo works fine 1`] = `
 <div>
   <div
     class="t-select__wrap"
-    style="width: 200px;"
+    style="width: 200px; display: inline-block; margin: 0px 20px 20px 0px;"
   >
     <div
       class="t-input__wrap t-select-input--empty t-select"
@@ -300,7 +300,50 @@ exports[`Select Select creatableVue demo works fine 1`] = `
         <input
           autocomplete=""
           class="t-input__inner"
-          placeholder="支持自定义创建"
+          placeholder="单选支持自定义创建"
+          type="text"
+          unselectable="off"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-select__right-icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="t-select__wrap"
+    style="width: 400px; display: inline-block;"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-select"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
+      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="多选支持自定义创建"
           type="text"
           unselectable="off"
         />
@@ -647,7 +690,7 @@ exports[`Select Select disabledVue demo works fine 1`] = `
       class="t-input__wrap t-select-input--empty t-select"
     >
       <div
-        class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix"
+        class="t-input t-size-m t-is-disabled t-is-default t-input--prefix t-input--suffix"
       >
         <div
           class="t-input__prefix"
@@ -657,9 +700,8 @@ exports[`Select Select disabledVue demo works fine 1`] = `
           class="t-input__inner"
           disabled="disabled"
           placeholder="-请选择-"
-          readonly="readonly"
           type="text"
-          unselectable="on"
+          unselectable="off"
         />
         <span
           class="t-input__suffix t-input__suffix-icon"
@@ -1158,7 +1200,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
           <span
             class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
           >
-            1
+            云服务器
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -1176,7 +1218,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
           <span
             class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
           >
-            2
+            云数据库
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -1194,7 +1236,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
           <span
             class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
           >
-            3
+            域名注册
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -1212,7 +1254,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
           <span
             class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
           >
-            4
+            网站备案
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -1230,7 +1272,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
           <span
             class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
           >
-            5
+            对象存储
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"
@@ -1248,7 +1290,7 @@ exports[`Select Select multipleVue demo works fine 1`] = `
           <span
             class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
           >
-            6
+            低代码平台
             <svg
               class="t-icon t-icon-close t-tag__icon-close"
               fill="none"

--- a/test/unit/table/__snapshots__/demo.test.js.snap
+++ b/test/unit/table/__snapshots__/demo.test.js.snap
@@ -666,7 +666,7 @@ exports[`Table Table affixVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  5
+                  5 条/页
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -1568,7 +1568,7 @@ exports[`Table Table baseVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  5
+                  5 条/页
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -2332,7 +2332,7 @@ exports[`Table Table customColButtonVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  5
+                  5 条/页
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -2792,7 +2792,7 @@ exports[`Table Table customColVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  5
+                  5 条/页
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -17526,7 +17526,7 @@ exports[`Table Table paginationAjaxVue demo works fine 1`] = `
               <span
                 class="t-input__input-pre"
               >
-                10
+                10 条/页
               </span>
               <span
                 class="t-input__suffix t-input__suffix-icon"
@@ -17961,7 +17961,7 @@ exports[`Table Table paginationVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  5
+                  5 条/页
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"
@@ -21532,7 +21532,7 @@ exports[`Table Table treeVue demo works fine 1`] = `
                 <span
                   class="t-input__input-pre"
                 >
-                  10
+                  10 条/页
                 </span>
                 <span
                   class="t-input__suffix t-input__suffix-icon"


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- #1039
- #1175
- #1213 
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

现有的 t-select （父组件）依赖 t-option 在页面渲染出 dom 节点后的生命周期钩子构建内部 options 记录数组。在远程搜索 / 筛选的场景下，可能导致用户传入的 t-option 因原数组为空而无法完成注册、记录异常的问题。
通过将 t-select 自身 slot 进行遍历并代理渲染 t-option 的方式，将父组件的 options 数组依赖自身的 slot 属性，从而解决 options 记录数组数据源冲突的问题，也能一并支持虚拟滚动的场景。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select): 修复开启虚拟滚动配合自定义面板使用卡顿的问题
- fix(select): 修复使用 t-opiton 自定义选项无法动态筛选问题
- fix(select): 修复 t-opiton 配合远程搜索使用异常的问题
- fix(select): 修复 `empty` 与 `loadingText` 在传参为 `string` 类型时，包裹元素消失的问题
- fix(select): 修复 `loadingText` slot 失效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
