### PR TITLE
fix: 修复时间面板展示错误 & 区间选择器结束时间默认展示当天最后一秒

### DIFF
--- a/src/date-picker/DateRangePicker.tsx
+++ b/src/date-picker/DateRangePicker.tsx
@@ -87,7 +87,11 @@ export default defineComponent({
     });
 
     // 日期 hover
-    function onCellMouseEnter(date: Date) {
+    function onCellMouseEnter(nextDate: Date) {
+      const date = nextDate;
+      // 不开启时间选择时 结束时间默认重置为 23:59:59
+      if (activeIndex.value && !props.enableTimePicker) date.setHours(23, 59, 59);
+
       isHoverCell.value = true;
       const nextValue = [...(inputValue.value as string[])];
       nextValue[activeIndex.value] = formatDate(date, {
@@ -104,7 +108,11 @@ export default defineComponent({
     }
 
     // 日期点击
-    function onCellClick(date: Date, { e, partial }: { e: MouseEvent; partial: DateRangePickerPartial }) {
+    function onCellClick(nextDate: Date, { e, partial }: { e: MouseEvent; partial: DateRangePickerPartial }) {
+      const date = nextDate;
+      // 不开启时间选择时 结束时间默认重置为 23:59:59
+      if (activeIndex.value && !props.enableTimePicker) date.setHours(23, 59, 59);
+
       props.onPick?.(date, { e, partial });
       emit('pick', date, { e, partial });
 

--- a/src/date-picker/panel/PanelContent.tsx
+++ b/src/date-picker/panel/PanelContent.tsx
@@ -1,5 +1,4 @@
-import { defineComponent, PropType, computed } from '@vue/composition-api';
-import dayjs from 'dayjs';
+import { defineComponent, PropType } from '@vue/composition-api';
 import { usePrefixClass } from '../../hooks/useConfig';
 import type { TdDatePickerProps } from '../type';
 
@@ -43,7 +42,7 @@ export default defineComponent({
       enableTimePicker: props.enableTimePicker,
     });
 
-    const defaultTimeValue = computed(() => dayjs().format(timeFormat));
+    const defaultTimeValue = '00:00:00';
 
     return { COMPONENT_NAME, defaultTimeValue, timeFormat };
   },
@@ -91,7 +90,7 @@ export default defineComponent({
                 key: this.partial,
                 props: {
                   format: timeFormat,
-                  value: this.time,
+                  value: this.time || defaultTimeValue,
                   onChange: this.onTimePickerChange,
                   isShowPanel: this.popupVisible,
                   ...this.timePickerProps,

--- a/src/date-picker/panel/RangePanel.tsx
+++ b/src/date-picker/panel/RangePanel.tsx
@@ -172,7 +172,7 @@ export default defineComponent({
                 key="startPanel"
                 {...{
                   props: {
-                    partial: 'start',
+                    partial: this.activeIndex ? 'end' : 'start',
                     year: this.year[0],
                     month: this.month[0],
                     time: this.time[0],
@@ -186,7 +186,7 @@ export default defineComponent({
                 key="endPanel"
                 {...{
                   props: {
-                    partial: 'end',
+                    partial: this.activeIndex ? 'end' : 'start',
                     year: this.year[1],
                     month: this.month[1],
                     time: this.time[1],


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Datepicker): 修复时间面板展示错误
- feat(Datepicker): 区间选择器结束时间调整为默认展示当天最后一秒

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
