### PR TITLE
fix: umd version usage

### DIFF
--- a/.github/workflows/typos-config.toml
+++ b/.github/workflows/typos-config.toml
@@ -1,3 +1,4 @@
 [default.extend-words]
 actived = "actived"
 ba = "ba"
+thead = "thead"

--- a/script/rollup.config.js
+++ b/script/rollup.config.js
@@ -183,7 +183,7 @@ const cjsConfig = {
 /** @type {import('rollup').RollupOptions} */
 const umdConfig = {
   input,
-  external: externalPeerDeps,
+  external: externalPeerDeps.concat([/@vue\/composition-api/]),
   plugins: getPlugins({
     env: 'development',
     extractOneCss: true,
@@ -202,7 +202,7 @@ const umdConfig = {
 /** @type {import('rollup').RollupOptions} */
 const umdMinConfig = {
   input,
-  external: externalPeerDeps,
+  external: externalPeerDeps.concat([/@vue\/composition-api/]),
   plugins: getPlugins({
     isProd: true,
     extractOneCss: true,

--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -23,11 +23,14 @@ npm i tdesign-vue
 
 #### 浏览器引入
 
-目前可以通过 [unpkg.com/tdesign-vue](https://unpkg.com/tdesign-vue) 获取到最新版本的资源，在页面上引入 js 和 css 文件即可开始使用。
+目前可以通过 [unpkg.com/tdesign-vue](https://unpkg.com/tdesign-vue) 获取到最新版本的资源，在页面上引入 js 和 css 文件即可开始使用。由于部分组件依赖了`@vue/composition-api`，除了像其他 vue2 版本的组件库一样需要引入`vue`，还需要额外手动引入`@vue/composition-api`。
 
 ```html
 <link rel="stylesheet" href="https://unpkg.com/tdesign-vue/dist/tdesign.min.css" />
+<script src="https://cdn.jsdelivr.net/npm/vue@2.6/dist/vue.js"></script>
+<script src="https://unpkg.com/@vue/composition-api@1.7.0/dist/vue-composition-api.prod.js"></script>
 <script src="https://unpkg.com/tdesign-vue/dist/tdesign.min.js"></script>
+
 ```
 
 ### 基础使用


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

当前打包版本会将`@vue/composition-api`打入umd的包中 当用户自身项目也使用`@vue/composition-api` Vue无法判断注册过了一次 会出现2次注册的情况 导致项目报错 
<img width="508" alt="image" src="https://user-images.githubusercontent.com/26377630/184610478-5229857b-7f71-4a76-ba69-0bb1a8817e1a.png">

将umd版本改为不打包`@vue/composition-api`  由用户手动引入 

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(umd): 修复umd版本的使用问题，具体使用方式请参考`浏览器引入`相关文档说明

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
