### PR TITLE
fix(tree): checkable and expandOnClickNode conflict

### DIFF
--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -22,7 +22,8 @@ export default mixins(classPrefixMixins, Vue as VueConstructor<CheckboxInstance>
 
   inheritAttrs: false,
 
-  props: { ...checkboxProps },
+  props: { ...checkboxProps, stopLabelTrigger: Boolean },
+
   inject: {
     checkboxGroup: { default: undefined },
   },
@@ -81,14 +82,21 @@ export default mixins(classPrefixMixins, Vue as VueConstructor<CheckboxInstance>
           checked={this.checked$}
           onChange={this.handleChange}
         ></input>
+
         <span class={`${this.componentName}__input`}></span>
-        <span class={`${this.componentName}__label`}>{renderContent(this, 'default', 'label')}</span>
+        <span class={`${this.componentName}__label`} onClick={this.handleLabelClick}>
+          {renderContent(this, 'default', 'label')}
+        </span>
       </label>
     );
   },
 
   methods: {
-    handleChange(e: Event): void {
+    handleLabelClick(e: Event) {
+      // 在tree等组件中使用  阻止label触发checked 与expand冲突
+      if (this.stopLabelTrigger) e.preventDefault();
+    },
+    handleChange(e: Event) {
       const value = !this.checked$;
       emitEvent<Parameters<TdCheckboxProps['onChange']>>(this, 'change', value, { e });
       e.stopPropagation();

--- a/src/tree/td-tree.tsx
+++ b/src/tree/td-tree.tsx
@@ -121,7 +121,9 @@ export default mixins(getConfigReceiverMixins<TypeTreeInstance, TreeConfig>('tre
   methods: {
     // 创建单个 tree 节点
     renderItem(node: TreeNode) {
-      const { nested, treeScope, $proxyScope } = this;
+      const {
+        nested, treeScope, $proxyScope, expandOnClickNode,
+      } = this;
       const treeItem = (
         <TreeItem
           key={node.value}
@@ -131,6 +133,7 @@ export default mixins(getConfigReceiverMixins<TypeTreeInstance, TreeConfig>('tre
           proxyScope={$proxyScope}
           onClick={this.handleClick}
           onChange={this.handleChange}
+          expandOnClickNode={expandOnClickNode}
         />
       );
       return treeItem;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
由于checkbox的整个区域都支持点击选中 在tree组件中 与expandOnClickNode存在冲突 即表现为点击checkbox的label 会同时 
触发树的展开 和checkbox的选中 实际项目中 配置expandOnClickNode的用户需要的只是展开节点 而非同时选中 
调整为expandOnClickNode时 叶子节点保持原有交互 非叶子节点点击label只展开 点击输入框为选中
修复前

https://user-images.githubusercontent.com/26377630/184812350-aad2b037-6644-4800-91c7-6f04bad0bbf5.mp4


修复后


https://user-images.githubusercontent.com/26377630/184811964-b4f33af1-5427-4f5a-b9d2-ed3c0e2bd334.mp4


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): 修复`expandOnClickNode`点击展开与checkbox点击选中的冲突问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
