### PR TITLE
Feature/button support href tag

### DIFF
--- a/examples/button/button.en-US.md
+++ b/examples/button/button.en-US.md
@@ -10,10 +10,12 @@ content | String / Slot / Function | - | button's children elements。Typescript
 default | String / Slot / Function | - | default slot。Typescript：`string | TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 disabled | Boolean | false | disable the button, make it can not be clicked | N
 ghost | Boolean | false | make background-color to be transparent | N
+href | String | - | address. When `href` exists, the button label is rendered by default using `< a >`; If `tag` is specified, the specified label is used for rendering | N
 icon | Slot / Function | - | use it to set left icon in button。Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 loading | Boolean | false | set button to be loading state | N
 shape | String | rectangle | button shape。options：rectangle/square/round/circle | N
 size | String | medium | a button has three size。options：small/medium/large。Typescript：`SizeEnum`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+tag | String | - | The element used to render the button. By default, ` < button > ` is used for rendering, and can be customized as `<a>` `<div>`. Completely transfer all HTML attributes, such as: `href/target/data-*`. ⚠️ The pop-up floating layer information cannot be displayed when the button is disabled `<button disabled>`. This problem can be solved by modifying `tag = div`. Optional: `button/a/div` | N
 theme | String | - | button theme。options：default/primary/danger/warning/success | N
 type | String | button | type of button element in html。options：submit/reset/button | N
 variant | String | base | variant of button。options：base/outline/dashed/text | N

--- a/examples/button/button.md
+++ b/examples/button/button.md
@@ -10,10 +10,12 @@ content | String / Slot / Function | - | 按钮内容。TS 类型：`string | TN
 default | String / Slot / Function | - | 按钮内容。TS 类型：`string | TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 disabled | Boolean | false | 是否禁用按钮 | N
 ghost | Boolean | false | 是否为幽灵按钮（镂空按钮） | N
+href | String | - | 跳转地址。href 存在时，按钮标签默认使用 `<a>` 渲染；如果指定了 `tag` 则使用指定的标签渲染 | N
 icon | Slot / Function | - | 按钮内部图标，可完全自定义。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 loading | Boolean | false | 是否显示为加载状态 | N
 shape | String | rectangle | 按钮形状，有 4 种：长方形、正方形、圆角长方形、圆形。可选项：rectangle/square/round/circle | N
 size | String | medium | 组件尺寸。可选项：small/medium/large。TS 类型：`SizeEnum`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+tag | String | - | 渲染按钮的 HTML 标签，默认使用标签 `<button>` 渲染，可以自定义为 `<a>` `<div>` 等。透传全部 HTML 属性，如：`href/target/data-*` 等。⚠️ 禁用按钮 `<button disabled>`无法显示 Popup 浮层信息，可通过修改 `tag=div` 解决这个问题。可选项：button/a/div | N
 theme | String | undefined | 组件风格，依次为默认色、品牌色、危险色、警告色、成功色。可选项：default/primary/danger/warning/success | N
 type | String | button | 按钮类型。可选项：submit/reset/button | N
 variant | String | base | 按钮形式，基础、线框、虚线、文字。可选项：base/outline/dashed/text | N

--- a/examples/button/demos/custom-element.vue
+++ b/examples/button/demos/custom-element.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="tdesign-demo-block-row">
+    <t-button tag="div">div</t-button>
+    <t-button tag="a">a</t-button>
+    <t-button href="#">a:href</t-button>
+  </div>
+</template>

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -8,12 +8,6 @@ import mixins from '../utils/mixins';
 
 const keepAnimationMixins = getKeepAnimationMixins();
 const classPrefixMixins = getClassPrefixMixins('button');
-export interface ButtonHTMLAttributes {
-  attrs?: {
-    disabled?: boolean;
-    type?: string;
-  };
-}
 
 export default mixins(keepAnimationMixins, classPrefixMixins).extend({
   name: 'TButton',
@@ -61,11 +55,10 @@ export default mixins(keepAnimationMixins, classPrefixMixins).extend({
       on.click = this.onClick;
     }
 
-    const buttonAttrs: ButtonHTMLAttributes = {
-      attrs: {
-        type: this.type,
-        disabled,
-      },
+    const buttonAttrs = {
+      type: this.type,
+      disabled,
+      href: this.href,
     };
 
     const renderTag = () => {

--- a/src/button/button.tsx
+++ b/src/button/button.tsx
@@ -1,4 +1,4 @@
-import { VNode } from 'vue';
+import { VNode, CreateElement } from 'vue';
 import TLoading from '../loading';
 import props from './props';
 import { renderContent, renderTNodeJSX } from '../utils/render-tnode';
@@ -22,10 +22,11 @@ export default mixins(keepAnimationMixins, classPrefixMixins).extend({
 
   directives: { ripple },
 
-  render(): VNode {
+  render(h: CreateElement): VNode {
     let buttonContent = renderContent(this, 'default', 'content');
     const icon = this.loading ? <TLoading inheritColor={true} /> : renderTNodeJSX(this, 'icon');
     const disabled = this.disabled || this.loading;
+
     let { theme } = this;
 
     if (!this.theme) {
@@ -67,10 +68,20 @@ export default mixins(keepAnimationMixins, classPrefixMixins).extend({
       },
     };
 
-    return (
-      <button v-ripple={this.keepAnimation.ripple} class={buttonClass} {...buttonAttrs} {...{ on }}>
-        {buttonContent}
-      </button>
+    const renderTag = () => {
+      if (!this.tag && this.href) return 'a';
+      return this.tag || 'button';
+    };
+
+    return h(
+      renderTag(),
+      {
+        class: buttonClass,
+        attrs: buttonAttrs,
+        on,
+        directives: [{ name: 'ripple', value: this.keepAnimation.ripple }],
+      },
+      [buttonContent],
     );
   },
 });

--- a/src/button/props.ts
+++ b/src/button/props.ts
@@ -21,6 +21,8 @@ export default {
   },
   /** 是否禁用按钮 */
   disabled: Boolean,
+  /** 跳转地址 */
+  href: String,
   /** 是否为幽灵按钮（镂空按钮） */
   ghost: Boolean,
   /** 按钮内部图标，可完全自定义 */
@@ -43,6 +45,14 @@ export default {
     default: 'medium' as TdButtonProps['size'],
     validator(val: TdButtonProps['size']): boolean {
       return ['small', 'medium', 'large'].includes(val);
+    },
+  },
+  /**渲染按钮的 HTML 标签*/
+  tag: {
+    type: String as PropType<TdButtonProps['tag']>,
+    default: undefined as TdButtonProps['tag'],
+    validator(val: TdButtonProps['tag']): boolean {
+      return ['button', 'a', 'div'].includes(val);
     },
   },
   /** 组件风格，依次为默认色、品牌色、危险色、警告色、成功色 */

--- a/src/button/type.ts
+++ b/src/button/type.ts
@@ -32,6 +32,11 @@ export interface TdButtonProps {
    */
   ghost?: boolean;
   /**
+   * 跳转地址。href 存在时，按钮标签默认使用 `<a>` 渲染；如果指定了 `tag` 则使用指定的标签渲染
+   * @default ''
+   */
+  href?: string;
+  /**
    * 按钮内部图标，可完全自定义
    */
   icon?: TNode;
@@ -51,6 +56,10 @@ export interface TdButtonProps {
    */
   size?: SizeEnum;
   /**
+   * 渲染按钮的 HTML 标签，默认使用标签 `<button>` 渲染，可以自定义为 `<a>` `<div>` 等。透传全部 HTML 属性，如：`href/target/data-*` 等。⚠️ 禁用按钮 `<button disabled>`无法显示 Popup 浮层信息，可通过修改 `tag=div` 解决这个问题
+   */
+  tag?: 'button' | 'a' | 'div';
+  /**
    * 组件风格，依次为默认色、品牌色、危险色、警告色、成功色
    */
   theme?: 'default' | 'primary' | 'danger' | 'warning' | 'success';
@@ -68,4 +77,4 @@ export interface TdButtonProps {
    * 点击时触发
    */
   onClick?: (e: MouseEvent) => void;
-};
+}

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -686,6 +686,12 @@ exports[`ssr snapshot test renders ./examples/button/demos/block.vue correctly 1
 </div>
 `;
 
+exports[`ssr snapshot test renders ./examples/button/demos/custom-element.vue correctly 1`] = `
+<div class="tdesign-demo-block-row">
+  <div type="button" class="t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">div</span></div> <a type="button" class="t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">a</span></a> <a type="button" href="#" class="t-button t-size-m t-button--variant-base t-button--theme-primary"><span class="t-button__text">a:href</span></a>
+</div>
+`;
+
 exports[`ssr snapshot test renders ./examples/button/demos/ghost.vue correctly 1`] = `
 <div class="tdesign-demo-block-column">
   <div class="tdesign-demo-block-row"><button type="button" class="t-button t-size-m t-button--variant-outline t-button--theme-default t-button--ghost"><span class="t-button__text">幽灵按钮</span></button> <button type="button" class="t-button t-size-m t-button--variant-dashed t-button--theme-default t-button--ghost"><span class="t-button__text">幽灵按钮</span></button> <button type="button" class="t-button t-size-m t-button--variant-text t-button--theme-default t-button--ghost"><span class="t-button__text">幽灵按钮</span></button></div>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 新特性提交

### 🔗 相关 Issue

[Button] 支持 href 和 tag 属性：https://github.com/Tencent/tdesign-vue/issues/1279

### 💡 需求背景和解决方案

根据 tag 渲染 button 的根元素。
> 其中 href 存在时，按钮标签默认使用 <a> 渲染；如果指定了 tag 则使用指定的标签渲染

### 📝 更新日志

- feat(Button): 支持 href 和 tag （自定义渲染元素）https://github.com/Tencent/tdesign-vue/issues/1279

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
