### PR TITLE
fix:  不区分是否受控，如果 value 发生变更，以 value 为准

### DIFF
--- a/src/hooks/useDefaultValue.ts
+++ b/src/hooks/useDefaultValue.ts
@@ -17,10 +17,8 @@ export default function useDefaultValue<T, P extends any[]>(
   const internalValue = ref();
   internalValue.value = typeof value.value !== 'undefined' ? value.value : defaultValue;
 
-  watch(value, () => {
-    if (value.value !== internalValue.value) {
-      internalValue.value = value.value;
-    }
+  watch(value, (newVal) => {
+    internalValue.value = newVal;
   });
 
   return [

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -16,10 +16,8 @@ export default function useVModel<T, P extends any[]>(
   const internalValue = ref<T>();
   internalValue.value = typeof value.value !== 'undefined' ? value.value : defaultValue;
 
-  watch(value, () => {
-    if (value.value !== internalValue.value) {
-      internalValue.value = value.value;
-    }
+  watch(value, (newVal) => {
+    internalValue.value = newVal;
   });
 
   return [


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/1178


### 💡 需求背景和解决方案
不区分组件是否受控，如果 value 发生变更，始终以 value 为准。

### 📝 更新日志
- fix: 修复 useDefaultValue、useVModel 无法动态设置 v-model 的问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
