### PR TITLE
fix(popup): 修复popup在ie9-10点击报错问题

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -158,7 +158,7 @@ export default mixins(classPrefixMixins).extend({
           this.handleToggle({ e, trigger: 'trigger-element-click' });
           // ie9-10 trigger propagation
           if (getIEVersion() < 11) {
-            this.handleDocumentClick();
+            this.handleDocumentClick(e);
           }
         });
       } else if (hasTrigger['context-menu']) {


### PR DESCRIPTION
修复popup在ie9-10点击报错问题

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

问题： ie9-10调用handleDocumentClick方法时没有传递参数
解决方案：加上需要传递的参数。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): 修复popup在ie9-10点击时，控制台报错问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
