### PR TITLE
fix: vModel invalid when initial

### DIFF
--- a/src/hooks/useDefaultValue.ts
+++ b/src/hooks/useDefaultValue.ts
@@ -10,13 +10,13 @@ export default function useDefaultValue<T, P extends any[]>(
   propsName: string,
   eventName: string,
 ): [Ref<T>, ChangeHandler<T, P>] {
-  const { emit } = getCurrentInstance();
+  const { emit, vnode } = getCurrentInstance();
 
   const internalValue = ref();
   internalValue.value = defaultValue;
 
   // 受控模式
-  if (typeof value.value !== 'undefined') {
+  if (Object.prototype.hasOwnProperty.call(vnode.componentOptions.propsData, propsName)) {
     return [
       value,
       (newValue, ...args) => {

--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -9,11 +9,12 @@ export default function useVModel<T, P extends any[]>(
   // eventName 不是 input 时，需要单独传入 eventName 用于事件输出
   eventName?: string,
 ): [Ref<T>, ChangeHandler<T, P>] {
-  const { emit } = getCurrentInstance();
+  const { emit, vnode } = getCurrentInstance();
   const internalValue = ref<T>();
   internalValue.value = defaultValue;
+
   // 受控模式
-  if (typeof value.value !== 'undefined') {
+  if (Object.prototype.hasOwnProperty.call(vnode.componentOptions.propsData, 'value')) {
     return [
       value,
       (newValue, ...args) => {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复


### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/1178

### 💡 需求背景和解决方案

useModel无法兼容导致v-model初始值为undefined进入非受控状态无法切换

### 📝 更新日志

- fix(useModel):  兼容因 `v-model` 初始值为 `undefined`  导致 `useModel` 的失效

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
