### PR TITLE
feat(cascader-panel): 点击选项时派发 click 事件

### DIFF
--- a/src/cascader/_example/panel.vue
+++ b/src/cascader/_example/panel.vue
@@ -1,13 +1,7 @@
 <template>
   <div class="tdesign-demo-block-row">
     <div class="cascader-demo-panel-container">
-      <t-cascader-panel
-        v-model="value"
-        :options="options"
-        :onClick="clickHandle1"
-        @click="clickHandle"
-        @change="changeHandle"
-      />
+      <t-cascader-panel v-model="value" :options="options" />
     </div>
     <div class="cascader-demo-panel-container">
       <t-cascader-panel v-model="value2" :options="options" multiple />
@@ -55,17 +49,6 @@ export default {
       value: '',
       value2: [],
     };
-  },
-  methods: {
-    clickHandle(e, node) {
-      console.log('click trigger, args: ', e, node);
-    },
-    clickHandle1(e) {
-      console.log('click1 trigger, args: ', e);
-    },
-    changeHandle(e, ctx) {
-      console.log('change trigger, args: ', e, ctx);
-    },
   },
 };
 </script>

--- a/src/cascader/_example/panel.vue
+++ b/src/cascader/_example/panel.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="tdesign-demo-block-row">
     <div class="cascader-demo-panel-container">
-      <t-cascader-panel v-model="value" :options="options" />
+      <t-cascader-panel
+        v-model="value"
+        :options="options"
+        :onClick="clickHandle1"
+        @click="clickHandle"
+        @change="changeHandle"
+      />
     </div>
     <div class="cascader-demo-panel-container">
       <t-cascader-panel v-model="value2" :options="options" multiple />
@@ -49,6 +55,17 @@ export default {
       value: '',
       value2: [],
     };
+  },
+  methods: {
+    clickHandle(e, node) {
+      console.log('click trigger, args: ', e, node);
+    },
+    clickHandle1(e) {
+      console.log('click1 trigger, args: ', e);
+    },
+    changeHandle(e, ctx) {
+      console.log('change trigger, args: ', e, ctx);
+    },
   },
 };
 </script>

--- a/src/cascader/_tests_/index.test.js
+++ b/src/cascader/_tests_/index.test.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import Cascader from '@/src/cascader/index.ts';
+import Cascader, { CascaderPanel } from '@/src/cascader/index.ts';
 
 const options = [
   {
@@ -69,6 +69,24 @@ describe('Cascader', () => {
         },
       });
       expect(wrapper.find('.t-is-disabled').exists()).toBe(true);
+    });
+  });
+
+  describe('CascaderPanel', () => {
+    describe('@event', () => {
+      it('click', async () => {
+        const fn = jest.fn();
+        const wrapper = mount({
+          render() {
+            return <CascaderPanel options={options} onClick={fn} />;
+          },
+        }).findComponent(CascaderPanel);
+        const firstItem = wrapper.find('.t-cascader__item');
+        firstItem.trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(fn).toBeCalled();
+      });
     });
   });
 });

--- a/src/cascader/cascader-panel.tsx
+++ b/src/cascader/cascader-panel.tsx
@@ -3,18 +3,24 @@ import Panel from './components/Panel';
 import props from './props';
 
 import { useCascaderContext } from './hooks';
+import { TreeNode } from './interface';
 
 export default defineComponent({
   name: 'TCascaderPanel',
 
   props: { ...props },
 
-  setup(props, { slots }) {
+  setup(props, { slots, emit }) {
     const { cascaderContext } = useCascaderContext(props);
+
+    const onClick = (value: string, node: TreeNode) => {
+      emit('click', value, node);
+    };
 
     return {
       cascaderContext,
       slots,
+      onClick,
     };
   },
   render() {
@@ -24,6 +30,7 @@ export default defineComponent({
         trigger={this.trigger}
         cascaderContext={this.cascaderContext}
         scopedSlots={{ empty: this.slots.empty }}
+        onClick={this.onClick}
       />
     );
   },

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -19,7 +19,7 @@ export default defineComponent({
       type: Object as PropType<CascaderContextType>,
     },
   },
-  setup(props) {
+  setup(props, { emit }) {
     const renderTNodeJSXDefault = useTNodeDefault();
     const COMPONENT_NAME = usePrefixClass('cascader');
     const { global } = useConfig('cascader');
@@ -37,11 +37,12 @@ export default defineComponent({
       handleExpand,
       renderTNodeJSXDefault,
       COMPONENT_NAME,
+      emit,
     };
   },
   render() {
     const {
-      global, COMPONENT_NAME, handleExpand, renderTNodeJSXDefault, cascaderContext, panels,
+      global, COMPONENT_NAME, handleExpand, renderTNodeJSXDefault, cascaderContext, panels, emit,
     } = this;
 
     const renderItem = (node: TreeNode) => (
@@ -54,6 +55,7 @@ export default defineComponent({
             node,
             cascaderContext,
             onClick: () => {
+              emit('click', node.value, node);
               handleExpand(node, 'click');
             },
             onMouseenter: () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#1389 

### 💡 需求背景和解决方案
现有特性下，如果用户想要自定义 cascader 的表现，只能根据 cascader-panel 派发的 change 事件处理 panel 的显示和隐藏，但在单选模式下点击已选择项 change 事件是不会被触发的，此时用户没有一种方式能感知到操作已经发生，所以没办法比较方便地维护自定义组件的状态。

PR 通过点击 cascader-panel 选项时派发点击事件 `click`，实现用户对 panel 状态的感知

### 📝 更新日志
- feat(CascaderPanel): 点击选项时派发 `click` 事件

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
