### PR TITLE
fix(select): 修复过滤掉数据后上下键仍可以选择过滤外的数据问题

### DIFF
--- a/src/select/instance.ts
+++ b/src/select/instance.ts
@@ -1,5 +1,7 @@
 import Select from './select';
 import Option from './option';
+import SelectPanel from './select-panel';
 
 export type SelectInstance = InstanceType<typeof Select>;
 export type OptionInstance = InstanceType<typeof Option>;
+export type SelectPanelInstance = InstanceType<typeof SelectPanel>;

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -91,21 +91,28 @@ export default defineComponent({
         return option.label?.indexOf(`${props.inputValue}`) > -1;
       };
 
-      const res: SelectOption[] = [];
+      const res: Array<SelectOption & { index?: number }> = [];
+      let groupIndex = 0;
       props.options.forEach((option) => {
         if ((option as SelectOptionGroup).group && (option as SelectOptionGroup).children) {
           res.push({
             ...option,
-            children: (option as SelectOptionGroup).children.filter(filterMethods),
+            // 处理index使其在过滤后的分组中能正确触发上下移动键的hover效果
+            children: (option as SelectOptionGroup).children.filter(filterMethods).reduce((pre, cur) => {
+              pre.push({ ...cur, index: groupIndex });
+              groupIndex += 1;
+              return pre;
+            }, []),
           });
         }
         if (filterMethods(option)) {
-          res.push(option);
+          res.push({ ...option, index: res.length });
         }
       });
 
       return res;
     });
+    const getDisplayOptions = () => displayOptions.value;
 
     const isCreateOptionShown = computed(() => props.creatable && props.filterable && props.inputValue);
     const isEmpty = computed(() => !(displayOptions.value.length > 0));
@@ -179,6 +186,7 @@ export default defineComponent({
       bufferSize,
       threshold,
       displayOptions,
+      getDisplayOptions,
       componentName: COMPONENT_NAME,
     };
   },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[#1433 ](https://github.com/Tencent/tdesign-vue/issues/1433)
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
keydownEvent()的数据来源是useSelectOption的optionsList，而不是filter之后的displayOptions，所以会出现可以选择过滤之外的数据的问题。
为了能使上下键移动时正确触发hover，需要单独处理一下displayOptions里的index属性，使其根据过滤后的数组大小依次递增，而不是在useSelectOption里处理的值。
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(select): 修复过滤掉数据后上下键仍可以选择过滤外的数据问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
