### PR TITLE
fix: cascader loading text and demo space replace

### DIFF
--- a/src/cascader/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/cascader/__tests__/__snapshots__/demo.test.js.snap
@@ -21,30 +21,21 @@ exports[`Cascader Cascader baseVue demo works fine 1`] = `
     <span
       class="t-input__suffix t-input__suffix-icon"
     >
-      <div
-        class="t-loading--center t-size-s t-loading"
+      <svg
+        class="t-fake-arrow t-cascader__icon"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          class="t-loading__gradient t-icon-loading"
-          height="1em"
-          size="small"
-          version="1.1"
-          viewBox="0 0 14 14"
-          width="1em"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <foreignobject
-            height="12"
-            width="12"
-            x="1"
-            y="1"
-          >
-            <div
-              class="t-loading__gradient-conic"
-            />
-          </foreignobject>
-        </svg>
-      </div>
+        <path
+          d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+          stroke="black"
+          stroke-opacity="0.9"
+          stroke-width="1.3"
+        />
+      </svg>
     </span>
   </div>
 </div>

--- a/src/cascader/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/cascader/__tests__/__snapshots__/demo.test.js.snap
@@ -1,156 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Cascader Cascader baseVue demo works fine 1`] = `
-<div>
+<div
+  class="t-input__wrap t-cascader"
+>
   <div
-    class="t-input__wrap t-cascader"
+    class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__prefix"
+    />
+    <input
+      autocomplete=""
+      class="t-input__inner"
+      placeholder="请选择"
+      readonly="readonly"
+      type="text"
+      unselectable="on"
+    />
+    <span
+      class="t-input__suffix t-input__suffix-icon"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-loading--center t-size-s t-loading"
       >
         <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
+          class="t-loading__gradient t-icon-loading"
+          height="1em"
+          size="small"
+          version="1.1"
+          viewBox="0 0 14 14"
+          width="1em"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
+          <foreignobject
+            height="12"
+            width="12"
+            x="1"
+            y="1"
+          >
+            <div
+              class="t-loading__gradient-conic"
+            />
+          </foreignobject>
         </svg>
-      </span>
-    </div>
+      </div>
+    </span>
   </div>
 </div>
 `;
 
 exports[`Cascader Cascader checkStrictlyVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
         <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          class="t-input__suffix t-input__suffix-icon"
         >
-          1/1.1/1.1.2/1.1.2.1
           <svg
-            class="t-icon t-icon-close t-tag__icon-close"
+            class="t-fake-arrow t-cascader__icon"
             fill="none"
-            height="1em"
+            height="16"
             viewBox="0 0 16 16"
-            width="1em"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </span>
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
-        >
-          2
-          <svg
-            class="t-icon t-icon-close t-tag__icon-close"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
             />
           </svg>
         </span>
       </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            1/1.1/1.1.2/1.1.2.1
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            2
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -158,173 +173,184 @@ exports[`Cascader Cascader checkStrictlyVue demo works fine 1`] = `
 
 exports[`Cascader Cascader collapsedVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
     >
       <div
-        class="t-input__prefix"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+        <div
+          class="t-input__prefix"
         >
-          选项一/子选项一
-          <svg
-            class="t-icon t-icon-close t-tag__icon-close"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </span>
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark"
-        >
-          +2
-        </span>
-      </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
-      >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
-        >
-          选项一/子选项一
-          <svg
-            class="t-icon t-icon-close t-tag__icon-close"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </span>
-        <span
-          style="color: rgb(237, 123, 47);"
-        >
-          +2
-        </span>
-      </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
-      >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
-        >
-          选项一/子选项一
-          <svg
-            class="t-icon t-icon-close t-tag__icon-close"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </span>
-        <span>
-           
           <span
-            style="color: rgb(0, 168, 112);"
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            选项一/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark"
           >
             +2
           </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
         </span>
       </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            选项一/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <span
+            style="color: rgb(237, 123, 47);"
+          >
+            +2
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      >
+        <div
+          class="t-input__prefix"
+        >
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            选项一/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <span>
+             
+            <span
+              style="color: rgb(0, 168, 112);"
+            >
+              +2
+            </span>
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -332,84 +358,92 @@ exports[`Cascader Cascader collapsedVue demo works fine 1`] = `
 
 exports[`Cascader Cascader disabledVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        disabled="disabled"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon t-is-disabled"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
           disabled="disabled"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
         <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-is-disabled t-tag--disabled"
+          class="t-input__suffix t-input__suffix-icon"
         >
-          选项一/子选项一
+          <svg
+            class="t-fake-arrow t-cascader__icon t-is-disabled"
+            disabled="disabled"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
         </span>
       </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon t-is-disabled"
-          disabled="disabled"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-is-disabled t-tag--disabled"
+          >
+            选项一/子选项一
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon t-is-disabled"
+            disabled="disabled"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -417,94 +451,102 @@ exports[`Cascader Cascader disabledVue demo works fine 1`] = `
 
 exports[`Cascader Cascader ellipsisVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row t-cascader-demo"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
         <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          class="t-input__suffix t-input__suffix-icon"
         >
-          当选项一数据展示文本过长时/子选项一
           <svg
-            class="t-icon t-icon-close t-tag__icon-close"
+            class="t-fake-arrow t-cascader__icon"
             fill="none"
-            height="1em"
+            height="16"
             viewBox="0 0 16 16"
-            width="1em"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
             />
           </svg>
         </span>
       </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            当选项一数据展示文本过长时/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -512,138 +554,149 @@ exports[`Cascader Cascader ellipsisVue demo works fine 1`] = `
 
 exports[`Cascader Cascader filterableVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
+      class="t-input__wrap t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        type="text"
-        unselectable="off"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          type="text"
+          unselectable="off"
+        />
         <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          class="t-input__suffix t-input__suffix-icon"
         >
-          当选项一数据展示文本过长时/子选项一
           <svg
-            class="t-icon t-icon-close t-tag__icon-close"
+            class="t-fake-arrow t-cascader__icon"
             fill="none"
-            height="1em"
+            height="16"
             viewBox="0 0 16 16"
-            width="1em"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
             />
           </svg>
         </span>
       </div>
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder=""
-        type="text"
-        unselectable="off"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
-      >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        type="text"
-        unselectable="off"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            当选项一数据展示文本过长时/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+        </div>
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder=""
+          type="text"
+          unselectable="off"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-select-input--empty t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-input--prefix t-input--suffix"
+      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          type="text"
+          unselectable="off"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -651,396 +704,404 @@ exports[`Cascader Cascader filterableVue demo works fine 1`] = `
 
 exports[`Cascader Cascader keysVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-   
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
         <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          class="t-input__suffix t-input__suffix-icon"
         >
-          选项一/子选项一
           <svg
-            class="t-icon t-icon-close t-tag__icon-close"
+            class="t-fake-arrow t-cascader__icon"
             fill="none"
-            height="1em"
+            height="16"
             viewBox="0 0 16 16"
-            width="1em"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
             />
           </svg>
         </span>
       </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            选项一/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`Cascader Cascader loadVue demo works fine 1`] = `
-<div>
+<div
+  class="t-input__wrap t-select-input--empty t-cascader"
+>
   <div
-    class="t-input__wrap t-select-input--empty t-cascader"
+    class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__prefix"
+    />
+    <input
+      autocomplete=""
+      class="t-input__inner"
+      placeholder="请选择"
+      readonly="readonly"
+      type="text"
+      unselectable="on"
+    />
+    <span
+      class="t-input__suffix t-input__suffix-icon"
     >
-      <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+      <svg
+        class="t-fake-arrow t-cascader__icon"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
+        <path
+          d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+          stroke="black"
+          stroke-opacity="0.9"
+          stroke-width="1.3"
+        />
+      </svg>
+    </span>
   </div>
 </div>
 `;
 
 exports[`Cascader Cascader maxVue demo works fine 1`] = `
-<div>
+<div
+  class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
+>
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
+    class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__prefix"
+    />
+    <input
+      autocomplete=""
+      class="t-input__inner"
+      placeholder="请选择"
+      readonly="readonly"
+      type="text"
+      unselectable="on"
+    />
+    <span
+      class="t-input__suffix t-input__suffix-icon"
     >
-      <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+      <svg
+        class="t-fake-arrow t-cascader__icon"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
+        <path
+          d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+          stroke="black"
+          stroke-opacity="0.9"
+          stroke-width="1.3"
+        />
+      </svg>
+    </span>
   </div>
 </div>
 `;
 
 exports[`Cascader Cascader multipleVue demo works fine 1`] = `
 <div
-  class="t-cascader-demo"
+  class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
 >
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__prefix"
     >
-      <div
-        class="t-input__prefix"
-      >
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
-        >
-          选项一/子选项一
-          <svg
-            class="t-icon t-icon-close t-tag__icon-close"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </span>
-      </div>
       <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
       >
+        选项一/子选项一
         <svg
-          class="t-fake-arrow t-cascader__icon"
+          class="t-icon t-icon-close t-tag__icon-close"
           fill="none"
-          height="16"
+          height="1em"
           viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+          width="1em"
         >
           <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
+            d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+            fill="currentColor"
+            fill-opacity="0.9"
           />
         </svg>
       </span>
     </div>
+    <span
+      class="t-input__suffix t-input__suffix-icon"
+    >
+      <svg
+        class="t-fake-arrow t-cascader__icon"
+        fill="none"
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+          stroke="black"
+          stroke-opacity="0.9"
+          stroke-width="1.3"
+        />
+      </svg>
+    </span>
   </div>
 </div>
 `;
 
 exports[`Cascader Cascader panelVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="cascader-demo-panel-container"
+    class="t-space-item"
   >
     <div
-      class="t-cascader__panel t-cascader--normal"
+      class="cascader-demo-panel-container"
     >
-      <ul
-        class="t-cascader__menu narrow-scrollbar"
+      <div
+        class="t-cascader__panel t-cascader--normal"
       >
-        <li
-          cascadercontext="[object Object]"
-          class="t-cascader__item t-size-m t-cascader__item--with-icon"
-          node="[object Object]"
+        <ul
+          class="t-cascader__menu narrow-scrollbar"
         >
-          <span
-            class="t-cascader__item-label t-cascader__item-label--ellipsis"
-            role="label"
-            title="选项一"
+          <li
+            cascadercontext="[object Object]"
+            class="t-cascader__item t-size-m t-cascader__item--with-icon"
+            node="[object Object]"
           >
-            选项一
-          </span>
-          <svg
-            class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </li>
-        <li
-          cascadercontext="[object Object]"
-          class="t-cascader__item t-size-m t-cascader__item--with-icon"
-          node="[object Object]"
-        >
-          <span
-            class="t-cascader__item-label t-cascader__item-label--ellipsis"
-            role="label"
-            title="选项二"
-          >
-            选项二
-          </span>
-          <svg
-            class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </li>
-      </ul>
-    </div>
-  </div>
-   
-  <div
-    class="cascader-demo-panel-container"
-  >
-    <div
-      class="t-cascader__panel t-cascader--normal"
-    >
-      <ul
-        class="t-cascader__menu narrow-scrollbar"
-      >
-        <li
-          cascadercontext="[object Object]"
-          class="t-cascader__item t-size-m t-cascader__item--with-icon"
-          node="[object Object]"
-        >
-          <label
-            class="t-checkbox"
-            title="选项一"
-          >
-            <input
-              class="t-checkbox__former"
-              name="1"
-              type="checkbox"
-              value=""
-            />
             <span
-              class="t-checkbox__input"
-            />
-            <span
-              class="t-checkbox__label"
+              class="t-cascader__item-label t-cascader__item-label--ellipsis"
+              role="label"
+              title="选项一"
             >
               选项一
             </span>
-          </label>
-          <svg
-            class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
+            <svg
+              class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </li>
+          <li
+            cascadercontext="[object Object]"
+            class="t-cascader__item t-size-m t-cascader__item--with-icon"
+            node="[object Object]"
           >
-            <path
-              d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </li>
-        <li
-          cascadercontext="[object Object]"
-          class="t-cascader__item t-size-m t-cascader__item--with-icon"
-          node="[object Object]"
-        >
-          <label
-            class="t-checkbox"
-            title="选项二"
-          >
-            <input
-              class="t-checkbox__former"
-              name="2"
-              type="checkbox"
-              value=""
-            />
             <span
-              class="t-checkbox__input"
-            />
-            <span
-              class="t-checkbox__label"
+              class="t-cascader__item-label t-cascader__item-label--ellipsis"
+              role="label"
+              title="选项二"
             >
               选项二
             </span>
-          </label>
-          <svg
-            class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
+            <svg
+              class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="cascader-demo-panel-container"
+    >
+      <div
+        class="t-cascader__panel t-cascader--normal"
+      >
+        <ul
+          class="t-cascader__menu narrow-scrollbar"
+        >
+          <li
+            cascadercontext="[object Object]"
+            class="t-cascader__item t-size-m t-cascader__item--with-icon"
+            node="[object Object]"
           >
-            <path
-              d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </li>
-      </ul>
+            <label
+              class="t-checkbox"
+              title="选项一"
+            >
+              <input
+                class="t-checkbox__former"
+                name="1"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="t-checkbox__input"
+              />
+              <span
+                class="t-checkbox__label"
+              >
+                选项一
+              </span>
+            </label>
+            <svg
+              class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </li>
+          <li
+            cascadercontext="[object Object]"
+            class="t-cascader__item t-size-m t-cascader__item--with-icon"
+            node="[object Object]"
+          >
+            <label
+              class="t-checkbox"
+              title="选项二"
+            >
+              <input
+                class="t-checkbox__former"
+                name="2"
+                type="checkbox"
+                value=""
+              />
+              <span
+                class="t-checkbox__input"
+              />
+              <span
+                class="t-checkbox__label"
+              >
+                选项二
+              </span>
+            </label>
+            <svg
+              class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -1048,83 +1109,91 @@ exports[`Cascader Cascader panelVue demo works fine 1`] = `
 
 exports[`Cascader Cascader showAllLevelsVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -1132,122 +1201,133 @@ exports[`Cascader Cascader showAllLevelsVue demo works fine 1`] = `
 
 exports[`Cascader Cascader sizeVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-s t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-s t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-l t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-l t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -1255,83 +1335,91 @@ exports[`Cascader Cascader sizeVue demo works fine 1`] = `
 
 exports[`Cascader Cascader triggerVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -1339,122 +1427,133 @@ exports[`Cascader Cascader triggerVue demo works fine 1`] = `
 
 exports[`Cascader Cascader valueModeVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
-   
   <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
+        <span
+          class="t-input__suffix t-input__suffix-icon"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>
@@ -1462,129 +1561,120 @@ exports[`Cascader Cascader valueModeVue demo works fine 1`] = `
 
 exports[`Cascader Cascader valueTypeVue demo works fine 1`] = `
 <div
-  class="tdesign-demo-block-row"
+  class="t-space t-space-vertical"
+  style="gap: 16px;"
 >
-  
-  [
-  "1",
-  "1.1"
-]
-  
   <div
-    class="t-input__wrap t-cascader"
+    class="t-space-item"
   >
     <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
+      class="t-input__wrap t-cascader"
     >
       <div
-        class="t-input__prefix"
-      />
-      <input
-        autocomplete=""
-        class="t-input__inner"
-        placeholder="请选择"
-        readonly="readonly"
-        type="text"
-        unselectable="on"
-      />
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
-    </div>
-  </div>
-  
-  [
-  [
-    "1",
-    "1.1"
-  ],
-  [
-    "1",
-    "1.2"
-  ]
-]
-  
-  <div
-    class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
-  >
-    <div
-      class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
-    >
-      <div
-        class="t-input__prefix"
-      >
+        <div
+          class="t-input__prefix"
+        />
+        <input
+          autocomplete=""
+          class="t-input__inner"
+          placeholder="请选择"
+          readonly="readonly"
+          type="text"
+          unselectable="on"
+        />
         <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          class="t-input__suffix t-input__suffix-icon"
         >
-          选项一/子选项一
           <svg
-            class="t-icon t-icon-close t-tag__icon-close"
+            class="t-fake-arrow t-cascader__icon"
             fill="none"
-            height="1em"
+            height="16"
             viewBox="0 0 16 16"
-            width="1em"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
-            />
-          </svg>
-        </span>
-        <span
-          class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
-        >
-          选项一/子选项二
-          <svg
-            class="t-icon t-icon-close t-tag__icon-close"
-            fill="none"
-            height="1em"
-            viewBox="0 0 16 16"
-            width="1em"
-          >
-            <path
-              d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
-              fill="currentColor"
-              fill-opacity="0.9"
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
             />
           </svg>
         </span>
       </div>
-      <span
-        class="t-input__suffix t-input__suffix-icon"
+    </div>
+  </div>
+  <div
+    class="t-space-item"
+  >
+    <div
+      class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader"
+    >
+      <div
+        class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix"
       >
-        <svg
-          class="t-fake-arrow t-cascader__icon"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="t-input__prefix"
         >
-          <path
-            d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
-            stroke="black"
-            stroke-opacity="0.9"
-            stroke-width="1.3"
-          />
-        </svg>
-      </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            选项一/子选项一
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+          <span
+            class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close"
+          >
+            选项一/子选项二
+            <svg
+              class="t-icon t-icon-close t-tag__icon-close"
+              fill="none"
+              height="1em"
+              viewBox="0 0 16 16"
+              width="1em"
+            >
+              <path
+                d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z"
+                fill="currentColor"
+                fill-opacity="0.9"
+              />
+            </svg>
+          </span>
+        </div>
+        <span
+          class="t-input__suffix t-input__suffix-icon"
+        >
+          <svg
+            class="t-fake-arrow t-cascader__icon"
+            fill="none"
+            height="16"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921"
+              stroke="black"
+              stroke-opacity="0.9"
+              stroke-width="1.3"
+            />
+          </svg>
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/cascader/_example/base.vue
+++ b/src/cascader/_example/base.vue
@@ -1,7 +1,5 @@
 <template>
-  <div>
-    <t-cascader v-model="value" :options="options" clearable @change="onChange" />
-  </div>
+  <t-cascader v-model="value" :options="options" loading clearable @change="onChange" />
 </template>
 <script>
 export default {

--- a/src/cascader/_example/base.vue
+++ b/src/cascader/_example/base.vue
@@ -1,5 +1,5 @@
 <template>
-  <t-cascader v-model="value" :options="options" loading clearable @change="onChange" />
+  <t-cascader v-model="value" :options="options" clearable @change="onChange" />
 </template>
 <script>
 export default {

--- a/src/cascader/_example/check-strictly.vue
+++ b/src/cascader/_example/check-strictly.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value1" :options="options" check-strictly />
     <t-cascader v-model="value2" :options="options" check-strictly multiple />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/collapsed.vue
+++ b/src/cascader/_example/collapsed.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value" :options="options" :on-remove="handleBlur" multiple :min-collapsed-num="1" />
     <t-cascader v-model="value" :options="options" :collapsed-items="collapsedItems" multiple :min-collapsed-num="1" />
     <t-cascader v-model="value" :options="options" multiple clearable :min-collapsed-num="1">
@@ -14,7 +14,7 @@
         </t-popup>
       </template>
     </t-cascader>
-  </div>
+  </t-space>
 </template>
 <script lang="jsx">
 export default {

--- a/src/cascader/_example/disabled.vue
+++ b/src/cascader/_example/disabled.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value1" :options="options" disabled />
     <t-cascader v-model="value2" :options="options" disabled multiple />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/ellipsis.vue
+++ b/src/cascader/_example/ellipsis.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tdesign-demo-block-row t-cascader-demo">
+  <t-space direction="vertical">
     <t-cascader v-model="value1" :options="options" clearable placeholder="请选择" />
     <t-cascader v-model="value2" multiple :options="options" clearable placeholder="请选择" />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/filterable.vue
+++ b/src/cascader/_example/filterable.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value" :options="options" filterable clearable />
     <t-cascader v-model="value2" :options="options" filterable clearable multiple :min-collapsed-num="2" />
     <t-cascader v-model="value3" :filter="filterMethod" :options="options" clearable :min-collapsed-num="2" />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/keys.vue
+++ b/src/cascader/_example/keys.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader
       v-model="value"
       :keys="{ label: 'name', value: 'code', children: 'items' }"
@@ -10,10 +10,10 @@
       v-model="value2"
       :keys="{ label: 'name', value: 'code', children: 'items' }"
       :options="options"
-      multiple
       clearable
+      multiple
     />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/load.vue
+++ b/src/cascader/_example/load.vue
@@ -1,7 +1,5 @@
 <template>
-  <div>
-    <t-cascader v-model="value" :options="options" clearable :load="load" />
-  </div>
+  <t-cascader v-model="value" :options="options" clearable :load="load" />
 </template>
 <script>
 export default {

--- a/src/cascader/_example/max.vue
+++ b/src/cascader/_example/max.vue
@@ -1,7 +1,5 @@
 <template>
-  <div>
-    <t-cascader v-model="value" :options="options" multiple clearable :max="3" />
-  </div>
+  <t-cascader v-model="value" :options="options" multiple clearable :max="3" />
 </template>
 <script>
 export default {

--- a/src/cascader/_example/multiple.vue
+++ b/src/cascader/_example/multiple.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="t-cascader-demo">
-    <t-cascader v-model="value" :options="options" multiple clearable />
-  </div>
+  <t-cascader v-model="value" :options="options" multiple clearable />
 </template>
 <script>
 export default {

--- a/src/cascader/_example/panel.vue
+++ b/src/cascader/_example/panel.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <div class="cascader-demo-panel-container">
       <t-cascader-panel v-model="value" :options="options" />
     </div>
     <div class="cascader-demo-panel-container">
       <t-cascader-panel v-model="value2" :options="options" multiple />
     </div>
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/show-all-levels.vue
+++ b/src/cascader/_example/show-all-levels.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value" :options="options" :show-all-levels="false" />
     <t-cascader v-model="value2" :options="options" :show-all-levels="false" multiple />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/size.vue
+++ b/src/cascader/_example/size.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <!-- 非受控用法 -->
     <t-cascader :options="options" :default-value="value" clearable size="small" />
     <!-- 受控+语法糖用法 -->
     <t-cascader v-model="value" :options="options" clearable size="medium" />
     <!-- 受控用法 -->
     <t-cascader :options="options" :value="value" clearable size="large" @change="handleValueChange" />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/trigger.vue
+++ b/src/cascader/_example/trigger.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value" :options="options" trigger="click" />
     <t-cascader v-model="value" :options="options" trigger="hover" />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/value-mode.vue
+++ b/src/cascader/_example/value-mode.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     <t-cascader v-model="value1" :options="options" multiple value-mode="onlyLeaf" />
     <t-cascader v-model="value2" :options="options" multiple value-mode="parentFirst" />
     <t-cascader v-model="value3" :options="options" multiple value-mode="all" />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/_example/value-type.vue
+++ b/src/cascader/_example/value-type.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="tdesign-demo-block-row">
+  <t-space direction="vertical">
     {{ value }}
     <t-cascader v-model="value" :options="options" value-type="full" />
     {{ value2 }}
     <t-cascader v-model="value2" multiple :options="options" value-type="full" />
-  </div>
+  </t-space>
 </template>
 <script>
 export default {

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -103,7 +103,7 @@ export default defineComponent({
           checked={node.checked}
           indeterminate={node.indeterminate}
           disabled={node.isDisabled() || ((value as TreeNodeValue[]).length >= max && max !== 0)}
-          name={node.value}
+          name={String(node.value)}
           title={inputVal ? getFullPathLabel(node) : node.label}
           onChange={(vale: boolean, { e }: { e: MouseEvent }) => {
             e.stopPropagation();

--- a/src/cascader/components/Item.tsx
+++ b/src/cascader/components/Item.tsx
@@ -105,6 +105,7 @@ export default defineComponent({
           disabled={node.isDisabled() || ((value as TreeNodeValue[]).length >= max && max !== 0)}
           name={String(node.value)}
           title={inputVal ? getFullPathLabel(node) : node.label}
+          stopLabelTrigger={true}
           onChange={(vale: boolean, { e }: { e: MouseEvent }) => {
             e.stopPropagation();
             onChange();

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -15,6 +15,8 @@ export default defineComponent({
     empty: CascaderProps.empty,
     trigger: CascaderProps.trigger,
     onChange: CascaderProps.onChange,
+    loading: CascaderProps.loading,
+    loadingText: CascaderProps.loadingText,
     cascaderContext: {
       type: Object as PropType<CascaderContextType>,
     },
@@ -92,11 +94,21 @@ export default defineComponent({
         : panels.map((treeNodes, index: number) => renderList(treeNodes, false, index !== panels.length - 1, `${COMPONENT_NAME}__menu${index}`));
     };
 
+    let content;
+    if (this.loading) {
+      content = renderTNodeJSXDefault(
+        'loadingText',
+        <div class={`${COMPONENT_NAME}__panel--empty`}>{global.loadingText}</div>,
+      );
+    } else {
+      content = panels.length
+        ? renderPanels()
+        : renderTNodeJSXDefault('empty', <div class={`${COMPONENT_NAME}__panel--empty`}>{global.empty}</div>);
+    }
+
     return (
-      <div class={[`${COMPONENT_NAME}__panel`, { [`${COMPONENT_NAME}--normal`]: panels.length }]}>
-        {panels.length
-          ? renderPanels()
-          : renderTNodeJSXDefault('empty', <div class={`${COMPONENT_NAME}__panel--empty`}>{global.empty}</div>)}
+      <div class={[`${COMPONENT_NAME}__panel`, { [`${COMPONENT_NAME}--normal`]: panels.length && !this.loading }]}>
+        {content}
       </div>
     );
   },

--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -92,10 +92,7 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
           },
         }}
         onChange={onTagInputChange}
-        onClear={(context: { e: MouseEvent }) => {
-          context.e.stopPropagation();
-          p.onInnerClear;
-        }}
+        onClear={p.onInnerClear}
         onBlur={(val: TagInputValue, context: { inputValue: InputValue; e: FocusEvent }) => {
           props.onBlur?.(props.value, { ...context, tagInputValue: val });
           instance.emit('blur', props.value, { ...context, tagInputValue: val });

--- a/src/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/table/__tests__/__snapshots__/demo.test.js.snap
@@ -19944,7 +19944,7 @@ exports[`Table Table selectMultipleVue demo works fine 1`] = `
         >
           <tr>
             <th
-              class="t-table__cell-check t-table__th-row-select"
+              class="t-table__cell-check demo-multiple-select-cell t-table__th-row-select"
               data-colkey="row-select"
             >
               <div
@@ -20052,7 +20052,7 @@ exports[`Table Table selectMultipleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-multiple-select-cell"
             >
               <label
                 class="t-checkbox"
@@ -20116,7 +20116,7 @@ exports[`Table Table selectMultipleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-multiple-select-cell"
             >
               <label
                 class="t-checkbox t-is-disabled"
@@ -20181,7 +20181,7 @@ exports[`Table Table selectMultipleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-multiple-select-cell"
             >
               <label
                 class="t-checkbox"
@@ -20245,7 +20245,7 @@ exports[`Table Table selectMultipleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-multiple-select-cell"
             >
               <label
                 class="t-checkbox t-is-disabled"
@@ -20310,7 +20310,7 @@ exports[`Table Table selectMultipleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-multiple-select-cell"
             >
               <label
                 class="t-checkbox"
@@ -20459,7 +20459,7 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
         >
           <tr>
             <th
-              class="t-table__cell-check t-table__th-row-select"
+              class="t-table__cell-check demo-single-select-cell t-table__th-row-select"
               data-colkey="row-select"
             >
               <div
@@ -20551,7 +20551,7 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-single-select-cell"
             >
               <label
                 class="t-radio"
@@ -20616,7 +20616,7 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
             class="t-table__row--disabled"
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-single-select-cell"
             >
               <label
                 class="t-radio t-is-disabled"
@@ -20682,7 +20682,7 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
             class="t-table__row--selected"
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-single-select-cell"
             >
               <label
                 class="t-radio t-is-checked"
@@ -20747,7 +20747,7 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
             class="t-table__row--disabled"
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-single-select-cell"
             >
               <label
                 class="t-radio t-is-disabled"
@@ -20813,7 +20813,7 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
             class=""
           >
             <td
-              class="t-table__cell-check"
+              class="t-table__cell-check demo-single-select-cell"
             >
               <label
                 class="t-radio"

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -8171,19 +8171,19 @@ exports[`ssr snapshot test renders ./src/icon/_example/iconfont-enhanced.vue cor
 <div class="t-space t-space-vertical" style="gap:16px;">
   <div class="t-space-item">
     <div class="t-space t-space-align-center t-space-horizontal" style="gap:16px;flex-wrap:wrap;">
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep"></i></div>
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep t-size-m"></i></div>
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep t-size-l"></i></div>
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="font-size:25px;"></i></div>
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="font-size:2em;"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep t-size-m"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep t-size-l"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="font-size:25px;"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="font-size:2em;"></i></div>
     </div>
   </div>
   <div class="t-space-item">
     <div class="t-space t-space-align-center t-space-horizontal" style="gap:16px;flex-wrap:wrap;">
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="color:red;"></i></div>
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="color:green;"></i></div>
-      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="color:orange;"></i></div>
-      <div class="t-space-item"><i class="t-icon t-icon-home"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="color:red;"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="color:green;"></i></div>
+      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="color:orange;"></i></div>
+      <div class="t-space-item"><i class="t-icon-home t-icon"></i></div>
     </div>
   </div>
   <div class="t-space-item"><br></div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -18906,7 +18906,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="row-select" class="t-table__cell-check t-table__th-row-select">
+            <th data-colkey="row-select" class="t-table__cell-check demo-multiple-select-cell t-table__th-row-select">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></div>
               </div>
@@ -18942,7 +18942,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
         </thead>
         <tbody class="t-table__body">
           <tr>
-            <td class="t-table__cell-check"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
+            <td class="t-table__cell-check demo-multiple-select-cell"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
             <td>JQTest1</td>
             <td>
               <p class="status">健康</p>
@@ -18953,7 +18953,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr>
-            <td class="t-table__cell-check"><label class="t-checkbox t-is-disabled"><input type="checkbox" disabled="disabled" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
+            <td class="t-table__cell-check demo-multiple-select-cell"><label class="t-checkbox t-is-disabled"><input type="checkbox" disabled="disabled" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
             <td>JQTest2</td>
             <td>
               <!---->
@@ -18964,7 +18964,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr>
-            <td class="t-table__cell-check"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
+            <td class="t-table__cell-check demo-multiple-select-cell"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
             <td>JQTest3</td>
             <td>
               <p class="status">健康</p>
@@ -18975,7 +18975,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr>
-            <td class="t-table__cell-check"><label class="t-checkbox t-is-disabled"><input type="checkbox" disabled="disabled" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
+            <td class="t-table__cell-check demo-multiple-select-cell"><label class="t-checkbox t-is-disabled"><input type="checkbox" disabled="disabled" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
             <td>JQTest4</td>
             <td>
               <!---->
@@ -18986,7 +18986,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr>
-            <td class="t-table__cell-check"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
+            <td class="t-table__cell-check demo-multiple-select-cell"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label"></span></label></td>
             <td>JQTest5</td>
             <td>
               <p class="status">健康</p>
@@ -19022,7 +19022,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correc
         </colgroup>
         <thead class="t-table__header">
           <tr>
-            <th data-colkey="row-select" class="t-table__cell-check t-table__th-row-select">
+            <th data-colkey="row-select" class="t-table__cell-check demo-single-select-cell t-table__th-row-select">
               <div class="t-table__th-cell-inner">
                 <div class="t-table__ellipsis t-text-ellipsis"></div>
               </div>
@@ -19058,7 +19058,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correc
         </thead>
         <tbody class="t-table__body">
           <tr>
-            <td class="t-table__cell-check"><label class="t-radio"><input type="radio" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
+            <td class="t-table__cell-check demo-single-select-cell"><label class="t-radio"><input type="radio" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
             <td>JQTest1</td>
             <td>
               <p class="status">健康</p>
@@ -19069,7 +19069,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correc
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr class="t-table__row--disabled">
-            <td class="t-table__cell-check"><label class="t-radio t-is-disabled"><input type="radio" disabled="disabled" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
+            <td class="t-table__cell-check demo-single-select-cell"><label class="t-radio t-is-disabled"><input type="radio" disabled="disabled" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
             <td>JQTest2</td>
             <td>
               <!---->
@@ -19080,7 +19080,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correc
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr class="t-table__row--selected">
-            <td class="t-table__cell-check"><label class="t-radio t-is-checked"><input type="radio" checked="checked" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
+            <td class="t-table__cell-check demo-single-select-cell"><label class="t-radio t-is-checked"><input type="radio" checked="checked" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
             <td>JQTest3</td>
             <td>
               <p class="status">健康</p>
@@ -19091,7 +19091,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correc
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr class="t-table__row--disabled">
-            <td class="t-table__cell-check"><label class="t-radio t-is-disabled"><input type="radio" disabled="disabled" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
+            <td class="t-table__cell-check demo-single-select-cell"><label class="t-radio t-is-disabled"><input type="radio" disabled="disabled" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
             <td>JQTest4</td>
             <td>
               <!---->
@@ -19102,7 +19102,7 @@ exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correc
             <td><a class="link">管理</a> <a class="link">删除</a></td>
           </tr>
           <tr>
-            <td class="t-table__cell-check"><label class="t-radio"><input type="radio" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
+            <td class="t-table__cell-check demo-single-select-cell"><label class="t-radio"><input type="radio" name="" class="t-radio__former"><span class="t-radio__input"></span><span class="t-radio__label"></span></label></td>
             <td>JQTest5</td>
             <td>
               <p class="status">健康</p>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -2974,268 +2974,302 @@ exports[`ssr snapshot test renders ./src/card/_example/small.vue correctly 1`] =
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/base.vue correctly 1`] = `
-<div>
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
-    </div>
+<div class="t-input__wrap t-cascader">
+  <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+    <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><div class="t-loading--center t-size-s t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading"><foreignObject x="1" y="1" width="12" height="12"><div class="t-loading__gradient-conic"></div></foreignObject></svg></div></span>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/check-strictly.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="1 / 1.2 / 1.2.2" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="1 / 1.2 / 1.2.2" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">1/1.1/1.1.2/1.1.2.1<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">2<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">1/1.1/1.1.2/1.1.2.1<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">2<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/collapsed.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark">+2</span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark">+2</span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span style="color:#ED7B2F;">+2</span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span style="color:#ED7B2F;">+2</span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span> <span style="color:#00a870;">+2</span></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span> <span style="color:#00a870;">+2</span></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/disabled.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input disabled="disabled" readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" disabled="disabled" class="t-fake-arrow t-cascader__icon t-is-disabled"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input disabled="disabled" readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" disabled="disabled" class="t-fake-arrow t-cascader__icon t-is-disabled"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-is-disabled t-tag--disabled">选项一/子选项一</span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" disabled="disabled" class="t-fake-arrow t-cascader__icon t-is-disabled"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-disabled t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-is-disabled t-tag--disabled">选项一/子选项一</span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" disabled="disabled" class="t-fake-arrow t-cascader__icon t-is-disabled"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/ellipsis.vue correctly 1`] = `
-<div class="tdesign-demo-block-row t-cascader-demo">
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="当选项一数据展示文本过长时 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="当选项一数据展示文本过长时 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">当选项一数据展示文本过长时/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">当选项一数据展示文本过长时/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/filterable.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input autocomplete="" placeholder="请选择" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input autocomplete="" placeholder="请选择" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">当选项一数据展示文本过长时/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">当选项一数据展示文本过长时/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><input autocomplete="" placeholder="" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input autocomplete="" placeholder="请选择" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input autocomplete="" placeholder="请选择" type="text" unselectable="off" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/keys.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/load.vue correctly 1`] = `
-<div>
-  <div class="t-input__wrap t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
-    </div>
+<div class="t-input__wrap t-select-input--empty t-cascader">
+  <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+    <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/max.vue correctly 1`] = `
-<div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
-    </div>
+<div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
+  <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+    <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/multiple.vue correctly 1`] = `
-<div class="t-cascader-demo">
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
-    </div>
+<div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+  <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+    <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/panel.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="cascader-demo-panel-container">
-    <div class="t-cascader__panel t-cascader--normal">
-      <ul class="t-cascader__menu narrow-scrollbar">
-        <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><span title="选项一" role="label" class="t-cascader__item-label t-cascader__item-label--ellipsis">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
-            <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
-          </svg></li>
-        <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><span title="选项二" role="label" class="t-cascader__item-label t-cascader__item-label--ellipsis">选项二</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
-            <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
-          </svg></li>
-      </ul>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="cascader-demo-panel-container">
+      <div class="t-cascader__panel t-cascader--normal">
+        <ul class="t-cascader__menu narrow-scrollbar">
+          <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><span title="选项一" role="label" class="t-cascader__item-label t-cascader__item-label--ellipsis">选项一</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
+              <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
+            </svg></li>
+          <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><span title="选项二" role="label" class="t-cascader__item-label t-cascader__item-label--ellipsis">选项二</span><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
+              <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
+            </svg></li>
+        </ul>
+      </div>
     </div>
   </div>
-  <div class="cascader-demo-panel-container">
-    <div class="t-cascader__panel t-cascader--normal">
-      <ul class="t-cascader__menu narrow-scrollbar">
-        <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><label title="选项一" class="t-checkbox"><input type="checkbox" name="1" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">选项一</span></label><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
-            <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
-          </svg></li>
-        <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><label title="选项二" class="t-checkbox"><input type="checkbox" name="2" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">选项二</span></label><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
-            <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
-          </svg></li>
-      </ul>
+  <div class="t-space-item">
+    <div class="cascader-demo-panel-container">
+      <div class="t-cascader__panel t-cascader--normal">
+        <ul class="t-cascader__menu narrow-scrollbar">
+          <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><label title="选项一" class="t-checkbox"><input type="checkbox" name="1" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">选项一</span></label><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
+              <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
+            </svg></li>
+          <li node="[object Object]" cascaderContext="[object Object]" class="t-cascader__item t-size-m t-cascader__item--with-icon"><label title="选项二" class="t-checkbox"><input type="checkbox" name="2" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">选项二</span></label><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-chevron-right t-cascader__item-icon t-icon">
+              <path fill="currentColor" d="M6.46 12.46l-.92-.92L9.08 8 5.54 4.46l.92-.92L10.92 8l-4.46 4.46z" fill-opacity="0.9"></path>
+            </svg></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/show-all-levels.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/size.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-s t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-s t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-l t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-l t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/trigger.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/value-mode.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-select-input--empty t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
 `;
 
 exports[`ssr snapshot test renders ./src/cascader/_example/value-type.vue correctly 1`] = `
-<div class="tdesign-demo-block-row">
-  [
-  &quot;1&quot;,
-  &quot;1.1&quot;
-  ]
-  <div class="t-input__wrap t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+<div class="t-space t-space-vertical" style="gap:16px;">
+  <div class="t-space-item">
+    <div class="t-input__wrap t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
-  [
-  [
-  &quot;1&quot;,
-  &quot;1.1&quot;
-  ],
-  [
-  &quot;1&quot;,
-  &quot;1.2&quot;
-  ]
-  ]
-  <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
-    <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-      <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项二<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+  <div class="t-space-item">
+    <div class="t-input__wrap t-tag-input t-tag-input--break-line t-select-input--multiple t-cascader">
+      <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
+        <div class="t-input__prefix"><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项一<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span><span class="t-tag t-tag--default t-size-m t-tag--dark t-tag--close">选项一/子选项二<svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-close t-tag__icon-close"><path fill="currentColor" d="M8 8.92L11.08 12l.92-.92L8.92 8 12 4.92 11.08 4 8 7.08 4.92 4 4 4.92 7.08 8 4 11.08l.92.92L8 8.92z" fill-opacity="0.9"></path></svg></span></div><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
+      </div>
     </div>
   </div>
 </div>
@@ -8137,19 +8171,19 @@ exports[`ssr snapshot test renders ./src/icon/_example/iconfont-enhanced.vue cor
 <div class="t-space t-space-vertical" style="gap:16px;">
   <div class="t-space-item">
     <div class="t-space t-space-align-center t-space-horizontal" style="gap:16px;flex-wrap:wrap;">
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep"></i></div>
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep t-size-m"></i></div>
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep t-size-l"></i></div>
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="font-size:25px;"></i></div>
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="font-size:2em;"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep t-size-m"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep t-size-l"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="font-size:25px;"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="font-size:2em;"></i></div>
     </div>
   </div>
   <div class="t-space-item">
     <div class="t-space t-space-align-center t-space-horizontal" style="gap:16px;flex-wrap:wrap;">
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="color:red;"></i></div>
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="color:green;"></i></div>
-      <div class="t-space-item"><i class="cps-icon cps-icon-home-sheep" style="color:orange;"></i></div>
-      <div class="t-space-item"><i class="t-icon-home t-icon"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="color:red;"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="color:green;"></i></div>
+      <div class="t-space-item"><i class="t-icon cps-icon cps-icon-home-sheep" style="color:orange;"></i></div>
+      <div class="t-space-item"><i class="t-icon t-icon-home"></i></div>
     </div>
   </div>
   <div class="t-space-item"><br></div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -2976,7 +2976,7 @@ exports[`ssr snapshot test renders ./src/card/_example/small.vue correctly 1`] =
 exports[`ssr snapshot test renders ./src/cascader/_example/base.vue correctly 1`] = `
 <div class="t-input__wrap t-cascader">
   <div class="t-input t-size-m t-is-default t-is-readonly t-input--prefix t-input--suffix">
-    <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><div class="t-loading--center t-size-s t-loading"><svg viewBox="0 0 14 14" version="1.1" width="1em" height="1em" xmlns="http://www.w3.org/2000/svg" size="small" class="t-loading__gradient t-icon-loading"><foreignObject x="1" y="1" width="12" height="12"><div class="t-loading__gradient-conic"></div></foreignObject></svg></div></span>
+    <div class="t-input__prefix"></div><input readonly="readonly" autocomplete="" placeholder="请选择" type="text" unselectable="on" value="选项一 / 子选项一" class="t-input__inner"><span class="t-input__suffix t-input__suffix-icon"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="t-fake-arrow t-cascader__icon"><path d="M3.75 5.7998L7.99274 10.0425L12.2361 5.79921" stroke="black" stroke-opacity="0.9" stroke-width="1.3"></path></svg></span>
   </div>
 </div>
 `;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
https://github.com/Tencent/tdesign-common/pull/804
### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Cascader): 修复 `loadingText` 无效 ([vue-next #1555](https://github.com/Tencent/tdesign-vue-next/issues/1555))
- fix(Cascader): 修复 `value` 为 `number` 类型时有告警 ([vue-next #1570](https://github.com/Tencent/tdesign-vue-next/issues/1570))
- fix(Cascader): 修复在输入时 `entry` 键会默认全选第一个选项的全部内容 ([vue-next #1529](https://github.com/Tencent/tdesign-vue-next/issues/1529))
- fix(Cascader): 修复通过 `SelectInputProps`  透传方法属性导致传入 `SelectInput` 的数据变成的数组 ([vue-next #1502](https://github.com/Tencent/tdesign-vue-next/issues/1502))
- fix(SelectInput): 修复多选清除无效导致 `Cascader` 点击清除按钮表现异常
- chore: 示例代码使用 `space` 组件替换 ([issue #1281](https://github.com/Tencent/tdesign-vue/issues/1281)) 
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
