### PR TITLE
fix: drawer message notification组件基础用例的generate配置有误

### DIFF
--- a/script/generate-usage/config.js
+++ b/script/generate-usage/config.js
@@ -539,7 +539,7 @@ module.exports = {
       drawer: `
         <div>
           <t-button @click="handleClick">Open Drawer</t-button>
-          <t-drawer v-bind="configProps" :visible.sync="visible" header="header" :close-btn="true">
+          <t-drawer v-bind="configProps" :visible.sync="visible" header="header">
             <p>This is a Drawer</p>
           </t-drawer>
         </div>
@@ -549,13 +549,13 @@ module.exports = {
   message: {
     panelStr: `const panelList = [{label: 'message', value: 'message'}];`,
     render: {
-      message: `<t-message v-bind="configProps" :duration="0" content="这里是 Message 信息"  :closeBtn="true" />`,
+      message: `<t-message v-bind="configProps" :duration="0" content="这里是 Message 信息" />`,
     },
   },
   notification: {
     panelStr: `const panelList = [{label: 'notification', value: 'notification'}];`,
     render: {
-      notification: `<t-notification v-bind="configProps" duration="0" title="标题名称" content="这是一条消息通知" :closeBtn="true" />`,
+      notification: `<t-notification v-bind="configProps" duration="0" title="标题名称" content="这是一条消息通知" />`,
     },
   },
   popconfirm: {

--- a/src/drawer/_usage/index.vue
+++ b/src/drawer/_usage/index.vue
@@ -4,7 +4,7 @@
     <template #drawer="{ configProps }">
       <div>
         <t-button @click="handleClick">Open Drawer</t-button>
-        <t-drawer v-bind="configProps" :visible.sync="visible" header="header" :close-btn="true">
+        <t-drawer v-bind="configProps" :visible.sync="visible" header="header">
           <p>This is a Drawer</p>
         </t-drawer>
       </div>
@@ -26,7 +26,7 @@ const panelList = [{ label: 'drawer', value: 'drawer' }];
 
 const usageCodeMap = {
   drawer:
-    '\n        <div>\n          <t-button @click="handleClick">Open Drawer</t-button>\n          <t-drawer v-bind="configProps" :visible.sync="visible" header="header" :close-btn="true">\n            <p>This is a Drawer</p>\n          </t-drawer>\n        </div>\n      ',
+    '\n        <div>\n          <t-button @click="handleClick">Open Drawer</t-button>\n          <t-drawer v-bind="configProps" :visible.sync="visible" header="header">\n            <p>This is a Drawer</p>\n          </t-drawer>\n        </div>\n      ',
 };
 const usageCode = ref(`<template>${usageCodeMap[panelList[0].value].trim()}</template>`);
 

--- a/src/message/_usage/index.vue
+++ b/src/message/_usage/index.vue
@@ -2,7 +2,7 @@
 <template>
   <base-usage :code="usageCode" :config-list="configList" :panel-list="panelList" @PanelChange="onPanelChange">
     <template #message="{ configProps }">
-      <t-message v-bind="configProps" :duration="0" content="这里是 Message 信息" :closeBtn="true" />
+      <t-message v-bind="configProps" :duration="0" content="这里是 Message 信息" />
     </template>
   </base-usage>
 </template>
@@ -15,9 +15,7 @@ import configJson from './props.json';
 const configList = ref(configJson);
 const panelList = [{ label: 'message', value: 'message' }];
 
-const usageCodeMap = {
-  message: '<t-message v-bind="configProps" :duration="0" content="这里是 Message 信息"  :closeBtn="true" />',
-};
+const usageCodeMap = { message: '<t-message v-bind="configProps" :duration="0" content="这里是 Message 信息" />' };
 const usageCode = ref(`<template>${usageCodeMap[panelList[0].value].trim()}</template>`);
 
 function onPanelChange(panel) {

--- a/src/notification/_usage/index.vue
+++ b/src/notification/_usage/index.vue
@@ -2,7 +2,7 @@
 <template>
   <base-usage :code="usageCode" :config-list="configList" :panel-list="panelList" @PanelChange="onPanelChange">
     <template #notification="{ configProps }">
-      <t-notification v-bind="configProps" duration="0" title="标题名称" content="这是一条消息通知" :closeBtn="true" />
+      <t-notification v-bind="configProps" duration="0" title="标题名称" content="这是一条消息通知" />
     </template>
   </base-usage>
 </template>
@@ -16,8 +16,7 @@ const configList = ref(configJson);
 const panelList = [{ label: 'notification', value: 'notification' }];
 
 const usageCodeMap = {
-  notification:
-    '<t-notification v-bind="configProps" duration="0" title="标题名称" content="这是一条消息通知" :closeBtn="true" />',
+  notification: '<t-notification v-bind="configProps" duration="0" title="标题名称" content="这是一条消息通知" />',
 };
 const usageCode = ref(`<template>${usageCodeMap[panelList[0].value].trim()}</template>`);
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

generate-usage生成的基础用例文件存在同名属性覆盖了组件props，导致基础用例切换该属性值时不生效

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(generate-usage): 修复文档中基础用例与预期不符

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
