### PR TITLE
fix(upload): upload trigger twice

### DIFF
--- a/src/upload/dragger.tsx
+++ b/src/upload/dragger.tsx
@@ -143,6 +143,7 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload'), getG
     },
 
     reUpload(e: MouseEvent) {
+      e.stopPropagation();
       this.remove({ e, file: this.file });
       this.trigger(e);
     },
@@ -173,7 +174,10 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload'), getG
                   theme="primary"
                   variant="text"
                   class={`${this.componentName}__dragger-progress-cancel`}
-                  onClick={this.cancel}
+                  onClick={(e: MouseEvent) => {
+                    this.cancel?.(e);
+                    e.stopPropagation();
+                  }}
                 >
                   {this.locale?.cancelUploadText || this.global.cancelUploadText}
                 </TButton>
@@ -182,7 +186,10 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload'), getG
                 <TButton
                   theme="primary"
                   variant="text"
-                  onClick={(e: MouseEvent) => this.upload({ ...this.loadingFile }, e)}
+                  onClick={(e: MouseEvent) => {
+                    this.upload({ ...this.loadingFile }, e);
+                    e.stopPropagation();
+                  }}
                 >
                   {this.locale?.triggerUploadText?.normal || this.global.triggerUploadText.normal}
                 </TButton>
@@ -198,7 +205,14 @@ export default mixins(getConfigReceiverMixins<Vue, UploadConfig>('upload'), getG
                 >
                   {this.locale?.triggerUploadText?.reupload || this.global.triggerUploadText.reupload}
                 </TButton>
-                <TButton theme="primary" variant="text" onClick={this.remove}>
+                <TButton
+                  theme="primary"
+                  variant="text"
+                  onClick={(e: MouseEvent) => {
+                    this.remove?.({ e, file: this.file });
+                    e.stopPropagation();
+                  }}
+                >
                   {this.locale?.triggerUploadText?.delete || this.global.triggerUploadText.delete}
                 </TButton>
               </div>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Upload): 在 `wujie` 环境中，部分按钮会触发两次

已在实际业务中验证

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
