### PR TITLE
feat(table): 新增 column.resizable 支持自定义任意列是否可拖拽调整宽度

### DIFF
--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -54,7 +54,7 @@ export default function useColumnResize(
 
   // 表格列宽拖拽事件
   // 只在表头显示拖拽图标
-  const onColumnMouseover = (e: MouseEvent) => {
+  const onColumnMouseover = (e: MouseEvent, col: BaseTableCol<TableRowData>) => {
     if (!resizeLineRef.value) return;
 
     const target = (e.target as HTMLElement).closest('th');
@@ -63,25 +63,30 @@ export default function useColumnResize(
       // 当离右边框的距离不超过 8 时，显示拖拽图标
       const distance = 8;
       if (targetBoundRect.right - e.pageX <= distance) {
-        target.style.cursor = 'col-resize';
-        resizeLineParams.draggingCol = target;
-        resizeLineParams.effectCol = 'next';
+        const colResizable = col.resizable ?? true;
+        if (colResizable) {
+          target.style.cursor = 'col-resize';
+          resizeLineParams.draggingCol = target;
+          resizeLineParams.effectCol = 'next';
+          return;
+        }
       } else if (e.pageX - targetBoundRect.left <= distance) {
         const prevEl = target.previousElementSibling;
         if (prevEl) {
-          target.style.cursor = 'col-resize';
-          resizeLineParams.draggingCol = prevEl as HTMLElement;
-          resizeLineParams.effectCol = 'prev';
-        } else {
-          target.style.cursor = '';
-          resizeLineParams.draggingCol = null;
-          resizeLineParams.effectCol = null;
+          const effectPrevCol = effectColMap.value[col.colKey].prev;
+          const colResizable = effectPrevCol.resizable ?? true;
+          if (colResizable) {
+            target.style.cursor = 'col-resize';
+            resizeLineParams.draggingCol = prevEl as HTMLElement;
+            resizeLineParams.effectCol = 'prev';
+            return;
+          }
         }
-      } else {
-        target.style.cursor = '';
-        resizeLineParams.draggingCol = null;
-        resizeLineParams.effectCol = null;
       }
+      // 重置记录值
+      target.style.cursor = '';
+      resizeLineParams.draggingCol = null;
+      resizeLineParams.effectCol = null;
     }
   };
 

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -469,6 +469,13 @@ export default function useFixed(
 
   watch([maxHeight, data, columns, bordered], updateFixedHeader, { immediate: true });
 
+  watch(finalColumns, () => {
+    resetThWidthList();
+    if (columnResizable.value) {
+      recalculateColWidth.value(finalColumns.value, thWidthList.value, tableLayout.value, tableElmWidth.value);
+    }
+  });
+
   // 影响表头宽度的元素
   watch(
     [
@@ -485,14 +492,6 @@ export default function useFixed(
     updateThWidthListHandler,
     { immediate: true },
   );
-
-  watch(finalColumns, () => {
-    updateTableWidth();
-    resetThWidthList();
-    if (columnResizable.value) {
-      recalculateColWidth.value(finalColumns.value, thWidthList.value, tableLayout.value, tableElmWidth.value);
-    }
-  });
 
   const refreshTable = debounce(() => {
     updateTableWidth();

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -28,7 +28,7 @@ export interface TheadProps {
   columnResizeParams: {
     resizeLineRef: HTMLDivElement;
     resizeLineStyle: Object;
-    onColumnMouseover: (e: MouseEvent) => void;
+    onColumnMouseover: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
     onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
   };
   resizable: Boolean;
@@ -115,7 +115,7 @@ export default defineComponent({
           const resizeColumnListener = this.resizable
             ? {
               mousedown: (e: MouseEvent) => this.columnResizeParams?.onColumnMousedown?.(e, col),
-              mousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e),
+              mousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e, col),
             }
             : {};
           const content = isFunction(col.ellipsisTitle) ? col.ellipsisTitle(h, { col, colIndex: index }) : undefined;

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -301,6 +301,11 @@ export interface BaseTableCol<T extends TableRowData = TableRowData> {
    */
   resize?: TableColumnResizeConfig;
   /**
+   * 是否允许拖拽调整该列大小，仅当 `table.resizable = true` 时生效
+   * @default true
+   */
+  resizable?: boolean;
+  /**
    * 自定义表头渲染。值类型为 Function 表示以函数形式渲染表头。值类型为 string 表示使用插槽渲染，插槽名称为 title 的值。优先级高于 render
    */
   title?: string | TNode<{ col: BaseTableCol; colIndex: number }>;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

#1348 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 新增 column.resizable 支持自定义任意列是否可拖拽调整宽度

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(table): 新增 column.resizable 支持自定义任意列是否可拖拽调整宽度

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
