### PR TITLE
fix: treeSelect padding 为空

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -556,7 +556,13 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
               size="small"
             />
           </div>
-          <div slot="content" class={`${this.classPrefix}-select__dropdown-inner ${this.classPrefix}-select__dropdown-inner--size-${this.dropdownInnerSize}`}>
+          <div
+            slot="content"
+            class={[
+              `${this.classPrefix}-select__dropdown-inner`,
+              `${this.classPrefix}-select__dropdown-inner--size-${this.dropdownInnerSize}`,
+            ]}
+          >
             <p
               v-show={this.showLoading}
               class={`${this.classPrefix}-select__loading-tips ${this.classPrefix}-select__right-icon-polyfill`}

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -88,6 +88,14 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
       const { popupObject } = this;
       return `${popupObject.overlayClassName} ${this.classPrefix}-select__dropdown narrow-scrollbar`;
     },
+    dropdownInnerSize(): ClassName {
+      const sizeMap = {
+        small: 's',
+        medium: 'm',
+        large: 'l',
+      };
+      return sizeMap[this.size];
+    },
     isObjectValue(): boolean {
       return this.valueType === 'object';
     },
@@ -548,7 +556,7 @@ export default mixins(getConfigReceiverMixins<Vue, TreeSelectConfig>('treeSelect
               size="small"
             />
           </div>
-          <div slot="content">
+          <div slot="content" class={`${this.classPrefix}-select__dropdown-inner ${this.classPrefix}-select__dropdown-inner--size-${this.dropdownInnerSize}`}>
             <p
               v-show={this.showLoading}
               class={`${this.classPrefix}-select__loading-tips ${this.classPrefix}-select__right-icon-polyfill`}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#229](https://github.com/Tencent/tdesign/issues/229)

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

与 Select 组件保持一致，popup Content 中的内容应当包裹在  t-select__dropdown-inner t-select__dropdown-inner--size-s  内，同时给 t-select__dropdown-inner--size > t__tree 添加 padding
<img width="771" alt="image" src="https://user-images.githubusercontent.com/15060047/191264970-4e86bf30-53be-4666-916b-c663974731f2.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
