### PR TITLE
[Table] ellipsis.props and ellipsis.content support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ docClass: timeline
   - 请求支持带上自定义 `headers` @chaishi ([#1579](https://github.com/Tencent/tdesign-vue/pull/1579))
   - 请求支持带上 `withCredentials` @chaishi ([#1579](https://github.com/Tencent/tdesign-vue/pull/1579))
 
+<<<<<<< Updated upstream
 ## 🌈 0.48.3 `2022-09-28` 
 ### 🚀 Features
 - `ImageViewer`: 新增 `ImageViewer` 图片预览组件 @sinbadmaster ([#1520](https://github.com/Tencent/tdesign-vue/pull/1520))
@@ -61,6 +62,44 @@ docClass: timeline
 - `TimePicker`: 修复部分场景 `style` 属性内的 token 缺失导致滚动异常的问题 @uyarn ([common#877](https://github.com/Tencent/tdesign-common/pull/877))
 ### 🚧 Others
 - `Swiper`: 修复组件的 demo 显示不正确问题 @yusongH ([#1557](https://github.com/Tencent/tdesign-vue/pull/1557))
+=======
+## 🌈 0.48.3 `2022-09-28` 
+### 🚀 Features
+- `ImageViewer`: 新增 `ImageViewer` 图片预览组件 @sinbadmaster ([#1520](https://github.com/Tencent/tdesign-vue/pull/1520))
+- `Upload`: 组件重构 @chaishi ([#1561](https://github.com/Tencent/tdesign-vue/pull/1561))
+  - ⚠️ `formatResponse` 不再对 `file` 对象进行格式化，仅处理 `response` 属性进行处理。如果要扩展 `file` 对象，请在 `onChange`
+  - 新增`beforeAllFilesUpload`，所有文件上传之前执行，支持一次性判定所有文件是否继续上传。已经存在的 `beforeUpload` 用于判定单个文件的是否继续上传
+  - 新增事件 `onValidate`，文件校验不通过时触发，可能情况有：自定义全文件校验不通过、文件数量校验不通过、文件数量校验不通过
+  - 新增事件 `onOneFileSuccess` ，多文件上传场景下，在单个文件上传成功后触发
+  - `beforeUpload` 存在时，依然支持 `sizeLimit` 检测
+  - `formatRequest` 用于新增或修改上传请求参数
+  - 一个请求上传多个文件时，参数携带全部文件
+  - 新增 `triggerButtonProps` 用于指定触发按钮风格
+- `Table`: @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+  - 支持属性 `tree.treeNodeColumnIndex` 动态修改， [tdesign-vue-next#1487](https://github.com/Tencent/tdesign-vue-next/issues/1487)
+  - `Table`: 新增 `showHeader`，支持隐藏表头 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+  - `Table`: 新增 `column.colKey = serial-number`，支持序号列功能 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+  - `Table`: 新增 `showSortColumnBgColor`，用于控制是否显示排序列背景色 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+### 🐞 Bug Fixes
+- `Select`: @skytt ([#1566](https://github.com/Tencent/tdesign-vue/pull/1566))
+  - 修复可创建新条目场景下回车选择错误的问题(#1563 )
+  - 修复创建条目和选中已有条目同时触发的问题
+  - 完善键盘事件, 创建的新条目可通过键盘选择
+- `Table`: @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+  - 树形结构，叶子节点缩进距离修正
+  - 超出省略功能，`ellipsisTitle`优先级应当高于 `ellipsis`， [issue#1404](https://github.com/Tencent/tdesign-vue/issues/1404)
+  - 行选中功能，修复 `column.type=single` 时，`column.title` 无效问题，[issue#1372](https://github.com/Tencent/tdesign-vue/issues/1372)
+  - 过滤功能，`list.value` 值为 `number` 无法高亮过滤图标问题 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+  - 行选中功能，数据变化时，选中的数据依旧是变化前的数据，[tdesign-vue-nex#1722](https://github.com/Tencent/tdesign-vue-next/issues/1722)
+  - 不提供`expandedRowKeys`的绑定会报错 ，缺少判空，[tdesign-vue-nex#1704](https://github.com/Tencent/tdesign-vue-next/issues/1704) @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
+  - 修复视图切换或表格变化的场景下 吸顶吸底效果没有重新渲染计算的问题 [issue#1529](https://github.com/Tencent/tdesign-vue/issues/1529) @uyarn ([#1570](https://github.com/Tencent/tdesign-vue/pull/1570))
+- `DatePicker`:
+  - 修复手动清空输入框关闭弹窗没有重置数据问题 @HQ-Lin ([#1565](https://github.com/Tencent/tdesign-vue/pull/1565))
+  - 修复 `disableDate` 传入 lambda 函数被频繁触发的问题 @HQ-Lin ([#1569](https://github.com/Tencent/tdesign-vue/pull/1569))
+- `TimePicker`: 修复部分场景 `style` 属性内的 token 缺失导致滚动异常的问题 @uyarn ([common#877](https://github.com/Tencent/tdesign-common/pull/877))
+### 🚧 Others
+- `Swiper`: 修复组件的 demo 显示不正确问题 @yusongH ([#1557](https://github.com/Tencent/tdesign-vue/pull/1557))
+>>>>>>> Stashed changes
 - `TimePicker`: 调整 TimePicker 底部边距及点击动画 @wanghanzhen ([#1558](https://github.com/Tencent/tdesign-vue/pull/1558))
 
 ## 🌈 0.48.2 `2022-09-23` 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,43 +26,6 @@ docClass: timeline
   - 请求支持带上自定义 `headers` @chaishi ([#1579](https://github.com/Tencent/tdesign-vue/pull/1579))
   - 请求支持带上 `withCredentials` @chaishi ([#1579](https://github.com/Tencent/tdesign-vue/pull/1579))
 
-<<<<<<< Updated upstream
-## 🌈 0.48.3 `2022-09-28` 
-### 🚀 Features
-- `ImageViewer`: 新增 `ImageViewer` 图片预览组件 @sinbadmaster ([#1520](https://github.com/Tencent/tdesign-vue/pull/1520))
-- `Upload`: 组件重构 @chaishi ([#1561](https://github.com/Tencent/tdesign-vue/pull/1561))
-  - 新增`beforeAllFilesUpload`，所有文件上传之前执行，支持一次性判定所有文件是否继续上传。已经存在的 `beforeUpload` 用于判定单个文件的是否继续上传
-  - 新增事件 `onValidate`，文件校验不通过时触发，可能情况有：自定义全文件校验不通过、文件数量校验不通过、文件数量校验不通过
-  - 新增事件 `onOneFileSuccess` ，多文件上传场景下，在单个文件上传成功后触发
-  - `beforeUpload` 存在时，依然支持 `sizeLimit` 检测
-  - `formatRequest` 用于新增或修改上传请求参数
-  - 一个请求上传多个文件时，参数携带全部文件
-  - 新增 `triggerButtonProps` 用于指定触发按钮风格
-- `Table`: @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-  - 支持属性 `tree.treeNodeColumnIndex` 动态修改， [tdesign-vue-next#1487](https://github.com/Tencent/tdesign-vue-next/issues/1487)
-  - `Table`: 新增 `showHeader`，支持隐藏表头 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-  - `Table`: 新增 `column.colKey = serial-number`，支持序号列功能 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-  - `Table`: 新增 `showSortColumnBgColor`，用于控制是否显示排序列背景色 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-### 🐞 Bug Fixes
-- `Select`: @skytt ([#1566](https://github.com/Tencent/tdesign-vue/pull/1566))
-  - 修复可创建新条目场景下回车选择错误的问题(#1563 )
-  - 修复创建条目和选中已有条目同时触发的问题
-  - 完善键盘事件, 创建的新条目可通过键盘选择
-- `Table`: @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-  - 树形结构，叶子节点缩进距离修正
-  - 超出省略功能，`ellipsisTitle`优先级应当高于 `ellipsis`， [issue#1404](https://github.com/Tencent/tdesign-vue/issues/1404)
-  - 行选中功能，修复 `column.type=single` 时，`column.title` 无效问题，[issue#1372](https://github.com/Tencent/tdesign-vue/issues/1372)
-  - 过滤功能，`list.value` 值为 `number` 无法高亮过滤图标问题 @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-  - 行选中功能，数据变化时，选中的数据依旧是变化前的数据，[tdesign-vue-nex#1722](https://github.com/Tencent/tdesign-vue-next/issues/1722)
-  - 不提供`expandedRowKeys`的绑定会报错 ，缺少判空，[tdesign-vue-nex#1704](https://github.com/Tencent/tdesign-vue-next/issues/1704) @chaishi ([#1562](https://github.com/Tencent/tdesign-vue/pull/1562))
-  - 修复视图切换或表格变化的场景下 吸顶吸底效果没有重新渲染计算的问题 [issue#1529](https://github.com/Tencent/tdesign-vue/issues/1529) @uyarn ([#1570](https://github.com/Tencent/tdesign-vue/pull/1570))
-- `DatePicker`:
-  - 修复手动清空输入框关闭弹窗没有重置数据问题 @HQ-Lin ([#1565](https://github.com/Tencent/tdesign-vue/pull/1565))
-  - 修复 `disableDate` 传入 lambda 函数被频繁触发的问题 @HQ-Lin ([#1569](https://github.com/Tencent/tdesign-vue/pull/1569))
-- `TimePicker`: 修复部分场景 `style` 属性内的 token 缺失导致滚动异常的问题 @uyarn ([common#877](https://github.com/Tencent/tdesign-common/pull/877))
-### 🚧 Others
-- `Swiper`: 修复组件的 demo 显示不正确问题 @yusongH ([#1557](https://github.com/Tencent/tdesign-vue/pull/1557))
-=======
 ## 🌈 0.48.3 `2022-09-28` 
 ### 🚀 Features
 - `ImageViewer`: 新增 `ImageViewer` 图片预览组件 @sinbadmaster ([#1520](https://github.com/Tencent/tdesign-vue/pull/1520))
@@ -99,7 +62,6 @@ docClass: timeline
 - `TimePicker`: 修复部分场景 `style` 属性内的 token 缺失导致滚动异常的问题 @uyarn ([common#877](https://github.com/Tencent/tdesign-common/pull/877))
 ### 🚧 Others
 - `Swiper`: 修复组件的 demo 显示不正确问题 @yusongH ([#1557](https://github.com/Tencent/tdesign-vue/pull/1557))
->>>>>>> Stashed changes
 - `TimePicker`: 调整 TimePicker 底部边距及点击动画 @wanghanzhen ([#1558](https://github.com/Tencent/tdesign-vue/pull/1558))
 
 ## 🌈 0.48.2 `2022-09-23` 

--- a/src/hooks/useCommonClassName.ts
+++ b/src/hooks/useCommonClassName.ts
@@ -41,3 +41,5 @@ export default function useCommonClassName() {
     },
   };
 }
+
+export type CommonClassNameType = ReturnType<typeof useCommonClassName>;

--- a/src/message/plugin.tsx
+++ b/src/message/plugin.tsx
@@ -162,6 +162,9 @@ MessagePlugin.install = () => {
   Vue.prototype.$message = MessagePlugin;
 };
 
+/** message 和 MessagePlugin 等效 */
+export const message = MessagePlugin;
+
 export default MessagePlugin;
 
 declare module 'vue/types/vue' {

--- a/src/notification/plugin.ts
+++ b/src/notification/plugin.ts
@@ -104,6 +104,10 @@ NotificationPlugin.install = () => {
   Vue.prototype.$notification = NotificationPlugin;
 };
 
+/** notify 和 NotificationPlugin 等效 */
+export const notify = NotificationPlugin;
+
+/** NotifyPlugin 均和 NotificationPlugin 等效 */
 export const NotifyPlugin = NotificationPlugin;
 
 export default NotifyPlugin;

--- a/src/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/table/__tests__/__snapshots__/demo.test.js.snap
@@ -1313,6 +1313,8 @@ exports[`Table Table baseVue demo works fine 1`] = `
               <th
                 class="custom-column-class-name t-table__th-serial-number t-align-center"
                 data-colkey="serial-number"
+                data-id="first-column"
+                style="[object Object]"
               >
                 <div
                   class="t-table__th-cell-inner"
@@ -17508,21 +17510,12 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
       class="t-table--layout-fixed"
     >
       <colgroup>
-        <col
-          style="width: 100px;"
-        />
-        <col
-          style="width: 100px;"
-        />
-        <col
-          style="width: 100px;"
-        />
-        <col
-          style="width: 100px;"
-        />
-        <col
-          style="width: 100px;"
-        />
+        <col />
+        <col />
+        <col />
+        <col />
+        <col />
+        <col />
       </colgroup>
       <thead
         class="t-table__header"
@@ -17570,12 +17563,13 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           </th>
           <th
             class="row t-table__th-description"
+            colspan="2"
             data-colkey="description"
           >
             <div
               class="t-table__th-cell-inner"
             >
-              说明
+              合并单行表头的最后两列
             </div>
           </th>
         </tr>
@@ -17608,6 +17602,11 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           >
             Y
           </td>
+          <td
+            class=""
+          >
+            表头合并
+          </td>
         </tr>
         <tr
           class=""
@@ -17629,6 +17628,11 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           >
             描述
           </td>
+          <td
+            class=""
+          >
+            表头合并
+          </td>
         </tr>
         <tr
           class=""
@@ -17648,6 +17652,11 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
             class="row"
           >
             复杂类型
+          </td>
+          <td
+            class=""
+          >
+            表头合并
           </td>
         </tr>
         <tr
@@ -17672,6 +17681,11 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
             class="row"
           >
             标识符
+          </td>
+          <td
+            class=""
+          >
+            表头合并
           </td>
         </tr>
         <tr
@@ -17700,6 +17714,11 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
           >
             数据源
           </td>
+          <td
+            class=""
+          >
+            表头合并
+          </td>
         </tr>
         <tr
           class=""
@@ -17713,6 +17732,11 @@ exports[`Table Table mergeCellsVue demo works fine 1`] = `
             class="row"
           >
             描述
+          </td>
+          <td
+            class=""
+          >
+            表头合并
           </td>
         </tr>
       </tbody>
@@ -19828,42 +19852,52 @@ exports[`Table Table selectSingleVue demo works fine 1`] = `
 <div
   class="tdesign-demo__table"
 >
-  <div>
-    <label
-      class="t-checkbox"
+  <div
+    class="t-space t-space-horizontal"
+    style="gap: 16px;"
+  >
+    <div
+      class="t-space-item"
     >
-      <input
-        class="t-checkbox__former"
-        type="checkbox"
-        value=""
-      />
-      <span
-        class="t-checkbox__input"
-      />
-      <span
-        class="t-checkbox__label"
+      <label
+        class="t-checkbox"
       >
-        高亮行选中
-      </span>
-    </label>
-     
-    <label
-      class="t-checkbox"
+        <input
+          class="t-checkbox__former"
+          type="checkbox"
+          value=""
+        />
+        <span
+          class="t-checkbox__input"
+        />
+        <span
+          class="t-checkbox__label"
+        >
+          高亮行选中
+        </span>
+      </label>
+    </div>
+    <div
+      class="t-space-item"
     >
-      <input
-        class="t-checkbox__former"
-        type="checkbox"
-        value=""
-      />
-      <span
-        class="t-checkbox__input"
-      />
-      <span
-        class="t-checkbox__label"
+      <label
+        class="t-checkbox"
       >
-        整行选中
-      </span>
-    </label>
+        <input
+          class="t-checkbox__former"
+          type="checkbox"
+          value=""
+        />
+        <span
+          class="t-checkbox__input"
+        />
+        <span
+          class="t-checkbox__label"
+        >
+          整行选中
+        </span>
+      </label>
+    </div>
   </div>
    
   <div

--- a/src/table/__tests__/__snapshots__/demo.test.js.snap
+++ b/src/table/__tests__/__snapshots__/demo.test.js.snap
@@ -1904,130 +1904,149 @@ exports[`Table Table customColButtonVue demo works fine 1`] = `
 <div
   class="tdesign-demo-block-column-large tdesign-demo__table"
 >
-  <div>
+  <div
+    class="t-space t-space-vertical"
+    style="gap: 16px;"
+  >
     <div
-      class="t-radio-group t-size-m t-radio-group--filled"
+      class="t-space-item"
     >
-      <label
-        class="t-radio-button"
-      >
-        <input
-          class="t-radio-button__former"
-          name=""
-          type="radio"
-          value="top-left"
-        />
-        <span
-          class="t-radio-button__input"
-        />
-        <span
-          class="t-radio-button__label"
-        >
-          左上角
-        </span>
-      </label>
-       
-      <label
-        class="t-radio-button t-is-checked"
-      >
-        <input
-          class="t-radio-button__former"
-          name=""
-          type="radio"
-          value="top-right"
-        />
-        <span
-          class="t-radio-button__input"
-        />
-        <span
-          class="t-radio-button__label"
-        >
-          右上角
-        </span>
-      </label>
-       
-      <label
-        class="t-radio-button"
-      >
-        <input
-          class="t-radio-button__former"
-          name=""
-          type="radio"
-          value="bottom-left"
-        />
-        <span
-          class="t-radio-button__input"
-        />
-        <span
-          class="t-radio-button__label"
-        >
-          左下角
-        </span>
-      </label>
-       
-      <label
-        class="t-radio-button"
-      >
-        <input
-          class="t-radio-button__former"
-          name=""
-          type="radio"
-          value="bottom-right"
-        />
-        <span
-          class="t-radio-button__input"
-        />
-        <span
-          class="t-radio-button__label"
-        >
-          右下角
-        </span>
-      </label>
       <div
-        class="t-radio-group__bg-block"
-        style="width: 0px; left: 0px;"
-      />
+        class="t-radio-group t-size-m t-radio-group--filled"
+      >
+        <label
+          class="t-radio-button"
+        >
+          <input
+            class="t-radio-button__former"
+            name=""
+            type="radio"
+            value="top-left"
+          />
+          <span
+            class="t-radio-button__input"
+          />
+          <span
+            class="t-radio-button__label"
+          >
+            左上角
+          </span>
+        </label>
+         
+        <label
+          class="t-radio-button t-is-checked"
+        >
+          <input
+            class="t-radio-button__former"
+            name=""
+            type="radio"
+            value="top-right"
+          />
+          <span
+            class="t-radio-button__input"
+          />
+          <span
+            class="t-radio-button__label"
+          >
+            右上角
+          </span>
+        </label>
+         
+        <label
+          class="t-radio-button"
+        >
+          <input
+            class="t-radio-button__former"
+            name=""
+            type="radio"
+            value="bottom-left"
+          />
+          <span
+            class="t-radio-button__input"
+          />
+          <span
+            class="t-radio-button__label"
+          >
+            左下角
+          </span>
+        </label>
+         
+        <label
+          class="t-radio-button"
+        >
+          <input
+            class="t-radio-button__former"
+            name=""
+            type="radio"
+            value="bottom-right"
+          />
+          <span
+            class="t-radio-button__input"
+          />
+          <span
+            class="t-radio-button__label"
+          >
+            右下角
+          </span>
+        </label>
+        <div
+          class="t-radio-group__bg-block"
+          style="width: 0px; left: 0px;"
+        />
+      </div>
     </div>
-     
-    <br />
-    <br />
-     
-    <label
-      class="t-checkbox t-is-checked"
+    <div
+      class="t-space-item"
     >
-      <input
-        class="t-checkbox__former"
-        type="checkbox"
-        value=""
-      />
-      <span
-        class="t-checkbox__input"
-      />
-      <span
-        class="t-checkbox__label"
+      <div
+        class="t-space t-space-horizontal"
+        style="gap: 16px;"
       >
-        是否显示边框
-      </span>
-    </label>
-     
-    <label
-      class="t-checkbox"
-      style="margin-left: 16px;"
-    >
-      <input
-        class="t-checkbox__former"
-        type="checkbox"
-        value=""
-      />
-      <span
-        class="t-checkbox__input"
-      />
-      <span
-        class="t-checkbox__label"
-      >
-        自定义列配置按钮
-      </span>
-    </label>
+        <div
+          class="t-space-item"
+        >
+          <label
+            class="t-checkbox t-is-checked"
+          >
+            <input
+              class="t-checkbox__former"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="t-checkbox__input"
+            />
+            <span
+              class="t-checkbox__label"
+            >
+              是否显示边框
+            </span>
+          </label>
+        </div>
+        <div
+          class="t-space-item"
+        >
+          <label
+            class="t-checkbox"
+            style="margin-left: 16px;"
+          >
+            <input
+              class="t-checkbox__former"
+              type="checkbox"
+              value=""
+            />
+            <span
+              class="t-checkbox__input"
+            />
+            <span
+              class="t-checkbox__label"
+            >
+              自定义列配置按钮
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
    
   <div
@@ -22822,6 +22841,42 @@ exports[`Table Table treeVue demo works fine 1`] = `
         </tbody>
         <!---->
       </table>
+    </div>
+    <div
+      class="t-table__bottom-content"
+    >
+      <div
+        class="t-table__column-controller-trigger t-align-bottom-left"
+      >
+        <button
+          class="t-button t-size-m t-button--variant-outline t-button--theme-default"
+          type="button"
+        >
+          <svg
+            class="t-icon t-icon-setting"
+            fill="none"
+            height="1em"
+            viewBox="0 0 16 16"
+            width="1em"
+          >
+            <path
+              d="M11 8a3 3 0 11-6 0 3 3 0 016 0zm-1 0a2 2 0 10-4 0 2 2 0 004 0z"
+              fill="currentColor"
+              fill-opacity="0.9"
+            />
+            <path
+              d="M8 1.25l6.06 3.38v6.75L8 14.75l-6.06-3.38V4.63L8 1.25zM2.94 5.21v5.58L8 13.6l5.06-2.82V5.2L8 2.4 2.94 5.21z"
+              fill="currentColor"
+              fill-opacity="0.9"
+            />
+          </svg>
+          <span
+            class="t-button__text"
+          >
+            列配置
+          </span>
+        </button>
+      </div>
     </div>
     <div
       class="t-table__pagination-wrap"

--- a/src/table/_example/custom-col-button.vue
+++ b/src/table/_example/custom-col-button.vue
@@ -1,17 +1,19 @@
 <template>
   <div class="tdesign-demo-block-column-large tdesign-demo__table">
     <!-- 按钮操作区域 -->
-    <div>
+    <t-space direction="vertical">
       <t-radio-group v-model="placement" variant="default-filled">
         <t-radio-button value="top-left">左上角</t-radio-button>
         <t-radio-button value="top-right">右上角</t-radio-button>
         <t-radio-button value="bottom-left">左下角</t-radio-button>
         <t-radio-button value="bottom-right">右下角</t-radio-button>
       </t-radio-group>
-      <br /><br />
-      <t-checkbox v-model="bordered">是否显示边框</t-checkbox>
-      <t-checkbox v-model="customText" style="margin-left: 16px">自定义列配置按钮</t-checkbox>
-    </div>
+
+      <t-space>
+        <t-checkbox v-model="bordered">是否显示边框</t-checkbox>
+        <t-checkbox v-model="customText" style="margin-left: 16px">自定义列配置按钮</t-checkbox>
+      </t-space>
+    </t-space>
 
     <!-- 1. defaultDisplayColumns = ['platform'] 设置默认显示哪些列，仅第一次有效 -->
     <!-- 2. displayColumns 动态设置显示哪些列，受控属性，支持 displayColumns.sync 语法糖 -->

--- a/src/table/_example/ellipsis.vue
+++ b/src/table/_example/ellipsis.vue
@@ -1,0 +1,127 @@
+<template>
+  <div>
+    <t-table row-key="id" :data="data" :columns="columns" />
+  </div>
+</template>
+
+<script lang="jsx">
+import { MessagePlugin } from 'tdesign-vue';
+import { FileCopyIcon } from 'tdesign-icons-vue';
+
+// thanks to https://www.zhangxinxu.com/wordpress/2021/10/js-copy-paste-clipboard/
+function copyToClipboard(text) {
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(text);
+  } else {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.style.position = 'fixed';
+    textarea.style.clip = 'rect(0 0 0 0)';
+    textarea.style.top = '10px';
+    textarea.value = text;
+    textarea.select();
+    document.execCommand('copy', true);
+    document.body.removeChild(textarea);
+  }
+  MessagePlugin.success('文本复制成功');
+}
+
+const data = [];
+const total = 5;
+for (let i = 0; i < total; i++) {
+  data.push({
+    id: i + 1,
+    desc: ['单元格文本超出省略设置', '这是普通文本的超出省略'][i % 2],
+    link: 'Long link text. Popup content is pure text',
+    something: '仅标题省略',
+    // 透传 Tooltip Props 到浮层组件
+    ellipsisProps: 'Setting ellipsis tooltip to be light',
+    // 完全自定义超出省略的 Tips 内容
+    ellipsisContent: 'Custom Ellipsis Content',
+    propsAndContent1: 'Setting props and content at the same time',
+    propsAndContent2: 'Setting props and content at the same time',
+  });
+}
+
+export default {
+  data() {
+    return {
+      data,
+      columns: [
+        // {
+        //   title: 'ID',
+        //   colKey: 'id',
+        //   width: 80,
+        // },
+        {
+          title: 'Description',
+          colKey: 'desc',
+          ellipsis: true,
+        },
+        {
+          title: '这是一个很长很长的标题',
+          colKey: 'something',
+          width: 120,
+          ellipsisTitle: true,
+        },
+        {
+          title: 'Link',
+          colKey: 'link',
+          // 超出省略的内容显示纯文本，不带任何样式和元素
+          ellipsis: (h, { row }) => row.link,
+          // 注意这种 JSX 写法需设置 <script lang="jsx" setup>
+          cell: (h, { row }) => (
+            <a href="/vue-next/components/table" target="_blank">
+              {row.link}
+            </a>
+          ),
+        },
+        {
+          title: 'Ellipsis Props',
+          colKey: 'ellipsisProps',
+          // 浮层浅色背景，方向默认朝下出现
+          ellipsis: {
+            theme: 'light',
+            placement: 'bottom',
+          },
+        },
+        {
+          title: 'Ellipsis Content',
+          colKey: 'ellipsisContent',
+          // ellipsis 定义超出省略的浮层内容，cell 定义单元格内容
+          ellipsis: (h, { row }) => (
+            <div>
+              {row.ellipsisContent}
+              <FileCopyIcon
+                style={{ cursor: 'pointer', marginLeft: '4px' }}
+                onClick={() => copyToClipboard(row.ellipsisContent)}
+              />
+            </div>
+          ),
+        },
+        {
+          title: 'Props & Content',
+          colKey: 'propsAndContent1',
+          // 支持同时设置 tooltipProps 和 浮层内容,
+          ellipsis: {
+            props: {
+              theme: 'light',
+              placement: 'bottom-right',
+            },
+            content: (h, { row }) => (
+              <div>
+                <p>
+                  <b>Tooltip1:</b> {row.propsAndContent1}
+                </p>
+                <p>
+                  <b>Tooltip2:</b> {row.propsAndContent2}
+                </p>
+              </div>
+            ),
+          },
+        },
+      ],
+    };
+  },
+};
+</script>

--- a/src/table/_example/merge-cells.vue
+++ b/src/table/_example/merge-cells.vue
@@ -18,6 +18,7 @@ const data = new Array(6).fill(null).map((_, i) => ({
   default: ['[]', '""', '{}', 'false', '-1', '0'][i % 5],
   needed: ['Y', 'N'][i % 1],
   description: ['数据源', '描述', '复杂类型', '标识符', '位置'][i % 4],
+  comment: '表头合并',
 }));
 export default {
   data() {
@@ -25,39 +26,42 @@ export default {
       data,
       columns: [
         {
-          align: 'left',
-          width: '100',
           className: 'test',
           colKey: 'platform',
           title: '平台',
         },
         {
-          align: 'left',
-          width: '100',
           className: 'row',
           colKey: 'type',
           title: '类型',
         },
         {
-          align: 'left',
-          width: '100',
           className: 'test4',
           colKey: 'default',
           title: '默认值',
         },
         {
-          align: 'left',
-          width: '100',
           className: 'test3',
           colKey: 'needed',
           title: '是否必传',
         },
         {
-          align: 'left',
-          width: '100',
           className: 'row',
           colKey: 'description',
-          title: '说明',
+          // 多行表头合并请参考「多级表头示例」
+          title: '合并单行表头的最后两列',
+          // 仅适用于单行表头合并列
+          colspan: 2,
+          // 设置列样式，注释的示例代码有效
+          // attrs: ({ type, col, row, colIndex, rowIndex }) => ({
+          //   style: {
+          //     color: 'blue',
+          //   },
+          // }),
+        },
+        {
+          colKey: 'comment',
+          title: '合并列',
         },
       ],
     };

--- a/src/table/_example/select-single.vue
+++ b/src/table/_example/select-single.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="tdesign-demo__table">
-    <div>
+    <t-space>
       <t-checkbox v-model="highlightSelectedRow">高亮行选中</t-checkbox>
       <t-checkbox v-model="selectedOnRowClick">整行选中</t-checkbox>
-    </div>
+    </t-space>
 
     <!-- 支持非受控属性 default-selected-row-keys -->
     <!-- 支持语法糖 selected-row-keys.sync -->
@@ -117,9 +117,9 @@ export default {
     font-size: 12px;
     position: absolute;
     right: 0;
-    bottom: 0;
-    width: 60px;
-    height: 35px;
+    bottom: 18px;
+    width: 20px;
+    height: 16px;
   }
 }
 </style>

--- a/src/table/_example/style.vue
+++ b/src/table/_example/style.vue
@@ -75,7 +75,7 @@ export default {
   },
 
   methods: {
-    getRowClassName({ row, rowIndex }) {
+    getRowClassName({ rowIndex }) {
       if (rowIndex === 2) return 'custom-third-class-name';
       return '';
     },

--- a/src/table/_example/style.vue
+++ b/src/table/_example/style.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="t-demo__style">
+    <!-- row-class-name 设置行类名 -->
+    <t-table row-key="id" :data="data" :columns="columns" :row-class-name="getRowClassName">
+      <template #footerSummary>
+        <div class="t-table__row-filter-inner">汇总：近期数据波动较大</div>
+      </template>
+    </t-table>
+  </div>
+</template>
+
+<script>
+const data = [];
+const total = 5;
+for (let i = 0; i < total; i++) {
+  data.push({
+    id: i,
+    framework: ['tdesign-vue', 'tdesign-react', 'tdesign-vue-next'][i % 3],
+    data: ['100,000', '21,514', '7,884', '1,290'][i % 4],
+    ringRatio: ['8%', '30%', '75%', '200%'][i % 4],
+    yearRatio: ['10%', '20%', '80%', '100%'][i % 4],
+  });
+}
+
+export default {
+  data() {
+    return {
+      data,
+      columns: [
+        {
+          colKey: 'serial-number',
+          title: '序号',
+          align: 'center',
+          width: 80,
+        },
+        { colKey: 'framework', title: '框架' },
+        {
+          colKey: 'data',
+          title: '数据',
+          align: 'right',
+          // 设置单元格内联样式
+          attrs: ({ type, row }) => ({
+            style:
+              type === 'td' && row.data === '21,514'
+                ? {
+                  color: 'green',
+                  fontWeight: 600,
+                  backgroundColor: 'var(--td-brand-color-1)',
+                  fontSize: '16px',
+                }
+                : undefined,
+          }),
+        },
+        {
+          colKey: 'ringRatio',
+          title: '环比',
+          align: 'right',
+          // 设置单元格类名
+          className: ({ type, row }) => {
+            if (type === 'td' && row.ringRatio === '200%') {
+              return 'custom-cell-class-name';
+            }
+            return '';
+          },
+        },
+        {
+          colKey: 'yearRatio',
+          title: '同比',
+          align: 'right',
+          // 设置列类名
+          className: 'last-column-class-name',
+        },
+      ],
+    };
+  },
+
+  methods: {
+    getRowClassName({ row, rowIndex }) {
+      if (rowIndex === 2) return 'custom-third-class-name';
+      return '';
+    },
+  },
+};
+</script>
+
+<style>
+.t-demo__style .t-table .custom-third-class-name > td {
+  color: green;
+  font-weight: bold;
+}
+
+.t-demo__style .t-table td.last-column-class-name {
+  color: orange;
+  font-weight: bold;
+}
+
+.t-table td.custom-cell-class-name {
+  color: orange;
+  font-size: 18px;
+  font-weight: bold;
+}
+</style>

--- a/src/table/_example/tree.vue
+++ b/src/table/_example/tree.vue
@@ -19,6 +19,7 @@
     <!-- 第一列展开树结点，缩进为 24px，子节点字段 childrenKey 默认为 children -->
     <!-- !!! 树形结构 EnhancedTable 才支持，普通 Table 不支持 !!! -->
     <!-- Ref: this.$refs.table.dataSource 查看树形结构平铺数据，获取属性结构使用 this.$refs.table.getTreeNode() -->
+    <!-- 可以使用受控属性 :displayColumns.sync="displayColumns" 完全自由控制显示列 -->
     <t-enhanced-table
       ref="table"
       rowKey="key"
@@ -29,7 +30,6 @@
       :treeExpandAndFoldIcon="treeExpandIcon"
       :pagination="pagination"
       :beforeDragSort="beforeDragSort"
-      :displayColumns.sync="displayColumns"
       :columnController="{
         placement: 'bottom-left',
         // 允许控制哪些列显示或隐藏

--- a/src/table/_example/tree.vue
+++ b/src/table/_example/tree.vue
@@ -29,6 +29,13 @@
       :treeExpandAndFoldIcon="treeExpandIcon"
       :pagination="pagination"
       :beforeDragSort="beforeDragSort"
+      :displayColumns.sync="displayColumns"
+      :columnController="{
+        placement: 'bottom-left',
+        // 允许控制哪些列显示或隐藏
+        fields: ['id', 'platform', 'operate'],
+        dialogProps: { preventScrollThrough: true },
+      }"
       @page-change="onPageChange"
       @abnormal-drag-sort="onAbnormalDragSort"
       @drag-sort="onDragSort"
@@ -137,6 +144,7 @@ export default {
         defaultPageSize: 10,
         total: TOTAL,
       },
+      displayColumns: ['drag', 'id', 'key', 'platform', 'operate'],
       columns: [
         {
           // 列拖拽排序必要参数

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -59,10 +59,12 @@ export default defineComponent({
     const tableFootHeight = ref(0);
 
     const {
-      virtualScrollClasses, tableLayoutClasses, tableBaseClass, tableColFixedClasses,
+      classPrefix, virtualScrollClasses, tableLayoutClasses, tableBaseClass, tableColFixedClasses,
     } = useClassName();
     // 表格基础样式类
-    const { tableClasses, tableContentStyles, tableElementStyles } = useStyle(props);
+    const {
+      tableClasses, sizeClassNames, tableContentStyles, tableElementStyles,
+    } = useStyle(props);
     const { global } = useConfig('table');
     const { isMultipleHeader, spansAndLeafNodes, thList } = useTableHeader(props);
     const finalColumns = computed(() => spansAndLeafNodes.value?.leafColumns || props.columns);
@@ -268,6 +270,7 @@ export default defineComponent({
     return {
       columnResizable,
       thList,
+      classPrefix,
       isVirtual,
       global,
       tableFootHeight,
@@ -275,6 +278,7 @@ export default defineComponent({
       tableElmWidth,
       tableRef,
       tableElmRef,
+      sizeClassNames,
       tableBaseClass,
       spansAndLeafNodes,
       dynamicBaseTableClasses,
@@ -347,6 +351,23 @@ export default defineComponent({
       );
     },
 
+    getHeadProps() {
+      const headProps = {
+        isFixedHeader: this.isFixedHeader,
+        rowAndColFixedPosition: this.rowAndColFixedPosition,
+        isMultipleHeader: this.isMultipleHeader,
+        bordered: this.bordered,
+        spansAndLeafNodes: this.spansAndLeafNodes,
+        thList: this.thList,
+        thWidthList: this.thWidthList,
+        resizable: this.resizable,
+        columnResizeParams: this.columnResizeParams,
+        classPrefix: this.classPrefix,
+        ellipsisOverlayClassName: this.size !== 'medium' ? this.sizeClassNames[this.size] : '',
+      };
+      return headProps;
+    },
+
     /**
      * Affixed Header
      */
@@ -380,18 +401,7 @@ export default defineComponent({
         >
           <table class={this.tableElmClasses} style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}>
             {colgroup}
-            <THead
-              scopedSlots={this.$scopedSlots}
-              isFixedHeader={this.isFixedHeader}
-              rowAndColFixedPosition={this.rowAndColFixedPosition}
-              isMultipleHeader={this.isMultipleHeader}
-              bordered={this.bordered}
-              spansAndLeafNodes={this.spansAndLeafNodes}
-              thList={this.thList}
-              thWidthList={this.thWidthList}
-              resizable={this.columnResizable}
-              columnResizeParams={this.columnResizeParams}
-            />
+            <THead scopedSlots={this.$scopedSlots} props={this.getHeadProps()} />
           </table>
         </div>
       );
@@ -520,6 +530,7 @@ export default defineComponent({
       bufferSize: this.bufferSize,
       scroll: this.scroll,
       cellEmptyContent: this.cellEmptyContent,
+      classPrefix: this.classPrefix,
       handleRowMounted: this.handleRowMounted,
       renderExpandedRow: this.renderExpandedRow,
       ...pick(this.$props, extendTableProps),
@@ -536,20 +547,7 @@ export default defineComponent({
         {this.isVirtual && <div class={this.virtualScrollClasses.cursor} style={virtualStyle} />}
         <table ref="tableElmRef" class={this.tableElmClasses} style={this.tableElementStyles}>
           {this.renderColGroup(columns)}
-          {this.showHeader && (
-            <THead
-              scopedSlots={this.$scopedSlots}
-              isFixedHeader={this.isFixedHeader}
-              rowAndColFixedPosition={this.rowAndColFixedPosition}
-              isMultipleHeader={this.isMultipleHeader}
-              bordered={this.bordered}
-              spansAndLeafNodes={this.spansAndLeafNodes}
-              thList={this.thList}
-              thWidthList={this.thWidthList}
-              resizable={this.columnResizable}
-              columnResizeParams={this.columnResizeParams}
-            />
-          )}
+          {this.showHeader && <THead scopedSlots={this.$scopedSlots} props={this.getHeadProps()} />}
           <TBody ref="tableBodyRef" scopedSlots={this.$scopedSlots} props={tableBodyProps} on={tBodyListener} />
           <TFoot
             rowKey={this.rowKey}

--- a/src/table/enhanced-table.tsx
+++ b/src/table/enhanced-table.tsx
@@ -20,6 +20,8 @@ const PRIMARY_B_EVENTS = [
   'sort-change',
   'data-change',
   'async-loading-click',
+  'column-change',
+  'display-columns-change',
 ];
 
 const PRIMARY_ALL_EVENTS = BASE_TABLE_ALL_EVENTS.concat(PRIMARY_B_EVENTS);
@@ -96,6 +98,9 @@ export default defineComponent({
       PRIMARY_ALL_EVENTS.forEach((key) => {
         listeners[key] = (...args: any) => {
           this.$emit(key, ...args);
+          if (key === 'display-columns-change') {
+            this.$emit('update:displayColumns', ...args);
+          }
         };
       });
       return listeners;

--- a/src/table/enhanced-table.tsx
+++ b/src/table/enhanced-table.tsx
@@ -109,7 +109,7 @@ export default defineComponent({
 
   render() {
     const props = {
-      ...this.$props,
+      ...this.$options.propsData,
       data: this.dataSource,
       columns: this.tColumns,
       // 半选状态节点

--- a/src/table/hooks/useClassName.ts
+++ b/src/table/hooks/useClassName.ts
@@ -3,6 +3,7 @@ import { useConfig } from '../../config-provider/useConfig';
 export default function useClassName() {
   const { classPrefix } = useConfig();
   const classNames = {
+    classPrefix: classPrefix.value,
     tableBaseClass: {
       table: `${classPrefix.value}-table`,
       columnResizableTable: `${classPrefix.value}-table--column-resizable`,

--- a/src/table/hooks/useFilter.tsx
+++ b/src/table/hooks/useFilter.tsx
@@ -12,15 +12,19 @@ import { useTNodeDefault } from '../../hooks/tnode';
 import TableFilterController from '../filter-controller';
 import { useConfig } from '../../hooks/useConfig';
 
+function isFilterValueExist(value: any) {
+  const isArrayTrue = value instanceof Array && value.length;
+  const isObject = typeof value === 'object' && !(value instanceof Array);
+  const isObjectTrue = isObject && Object.keys(value).length;
+  return isArrayTrue || isObjectTrue || !['null', '', 'undefined'].includes(String(value));
+}
+
 // 筛选条件不为空，才需要显示筛选结果行
 function filterEmptyData(data: FilterValue) {
   const newFilterValue: FilterValue = {};
   Object.keys(data).forEach((key) => {
     const item = data[key];
-    const isArrayTrue = item instanceof Array && item.length;
-    const isObject = typeof item === 'object' && !(item instanceof Array);
-    const isObjectTrue = isObject && Object.keys(item).length;
-    if (isArrayTrue || isObjectTrue || !['null', '', 'undefined'].includes(String(item))) {
+    if (isFilterValueExist(item)) {
       newFilterValue[key] = item;
     }
   });
@@ -94,7 +98,7 @@ export default function useFilter(props: TdPrimaryTableProps, context: SetupCont
           });
           value = label.join();
         }
-        if (value) {
+        if (isFilterValueExist(value)) {
           arr.push(`${col.title}：${value}`);
         }
       });

--- a/src/table/hooks/useFilter.tsx
+++ b/src/table/hooks/useFilter.tsx
@@ -129,12 +129,12 @@ export default function useFilter(props: TdPrimaryTableProps, context: SetupCont
       ...tFilterValue.value,
       [column.colKey]:
         column.filter.resetValue
-        || {
+        ?? {
           single: '',
           multiple: [],
           input: '',
         }[column.filter.type]
-        || '',
+        ?? '',
     };
     emitFilterChange(filterValue, column);
   }

--- a/src/table/hooks/useFilter.tsx
+++ b/src/table/hooks/useFilter.tsx
@@ -128,12 +128,12 @@ export default function useFilter(props: TdPrimaryTableProps, context: SetupCont
     const filterValue: FilterValue = {
       ...tFilterValue.value,
       [column.colKey]:
-        {
+        column.filter.resetValue
+        || {
           single: '',
           multiple: [],
           input: '',
         }[column.filter.type]
-        || column.filter.resetValue
         || '',
     };
     emitFilterChange(filterValue, column);

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -499,7 +499,10 @@ export default function useFixed(
       footerAffixedBottom,
       tableContentWidth,
     ],
-    updateThWidthListHandler,
+    () => {
+      updateThWidthListHandler();
+      updateAffixPosition();
+    },
     { immediate: true },
   );
 

--- a/src/table/hooks/useStyle.ts
+++ b/src/table/hooks/useStyle.ts
@@ -43,6 +43,7 @@ export default function useStyle(props: TdBaseTableProps) {
   }));
 
   return {
+    sizeClassNames,
     tableClasses,
     tableElementStyles,
     tableContentStyles,

--- a/src/table/hooks/useTableHeader.tsx
+++ b/src/table/hooks/useTableHeader.tsx
@@ -50,6 +50,10 @@ export default function useTableHeader(props: TdBaseTableProps) {
     colIndex: number,
     ellipsisTitle: BaseTableCol['ellipsisTitle'],
     attach: HTMLElement,
+    extra?: {
+      classPrefix: string;
+      ellipsisOverlayClassName: string;
+    },
   ) => {
     const classes = {
       [tableSortClasses.sortable]: sortIcon,
@@ -66,6 +70,8 @@ export default function useTableHeader(props: TdBaseTableProps) {
               attach={attach ? () => attach : undefined}
               tooltipContent={content && (() => content)}
               tooltipProps={typeof ellipsisTitle === 'object' ? ellipsisTitle : undefined}
+              classPrefix={extra?.classPrefix}
+              overlayClassName={extra?.ellipsisOverlayClassName}
             >
               {title}
             </TEllipsis>

--- a/src/table/hooks/useTableHeader.tsx
+++ b/src/table/hooks/useTableHeader.tsx
@@ -10,6 +10,7 @@ import { BaseTableColumns } from '../interface';
 import useClassName from './useClassName';
 import { TNodeReturnValue } from '../../common';
 import TEllipsis from '../ellipsis';
+import log from '../../_common/js/log';
 
 // 渲染表头的通用方法
 export function renderTitle(h: CreateElement, slots: SetupContext['slots'], col: BaseTableColumns[0], index: number) {
@@ -18,6 +19,15 @@ export function renderTitle(h: CreateElement, slots: SetupContext['slots'], col:
     return col.title(h, params);
   }
   if (isString(col.title) && slots[col.title]) {
+    if (col.colKey === col.title) {
+      log.error(
+        'Table',
+        [
+          `both colKey '${col.colKey}' and title have the same slot name`,
+          'please set a different slot name for col and title.',
+        ].join(', '),
+      );
+    }
     return slots[col.title](params);
   }
   if (isFunction(col.render)) {

--- a/src/table/hooks/useTreeData.tsx
+++ b/src/table/hooks/useTreeData.tsx
@@ -63,10 +63,10 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
     });
   }
 
-  const uniqueKeys = computed(() => store.value?.getAllUniqueKeys(data.value, rowDataKeys.value)?.join() || '');
+  // const uniqueKeys = computed(() => store.value?.getAllUniqueKeys(data.value, rowDataKeys.value)?.join() || '');
 
   watch(
-    [uniqueKeys],
+    [data],
     () => {
       if (!data.value) return [];
       if (!props.tree) {

--- a/src/table/hooks/useTreeData.tsx
+++ b/src/table/hooks/useTreeData.tsx
@@ -63,10 +63,10 @@ export default function useTreeData(props: TdEnhancedTableProps, context: SetupC
     });
   }
 
-  // const uniqueKeys = computed(() => store.value?.getAllUniqueKeys(data.value, rowDataKeys.value)?.join() || '');
+  const uniqueKeys = computed(() => store.value?.getAllUniqueKeys(data.value, rowDataKeys.value)?.join() || '');
 
   watch(
-    [data],
+    [uniqueKeys],
     () => {
       if (!data.value) return [];
       if (!props.tree) {

--- a/src/table/primary-table-props.ts
+++ b/src/table/primary-table-props.ts
@@ -34,6 +34,7 @@ export default {
   /** 列配置功能中，当前显示的列 */
   displayColumns: {
     type: Array as PropType<TdPrimaryTableProps['displayColumns']>,
+    default: undefined,
   },
   /** 列配置功能中，当前显示的列，非受控属性 */
   defaultDisplayColumns: {
@@ -73,7 +74,7 @@ export default {
   /** 展开行 */
   expandedRowKeys: {
     type: Array as PropType<TdPrimaryTableProps['expandedRowKeys']>,
-    default: (): TdPrimaryTableProps['expandedRowKeys'] => [],
+    default: undefined,
   },
   /** 展开行，非受控属性 */
   defaultExpandedRowKeys: {
@@ -91,6 +92,7 @@ export default {
   /** 过滤数据的值 */
   filterValue: {
     type: Object as PropType<TdPrimaryTableProps['filterValue']>,
+    default: undefined,
   },
   /** 过滤数据的值，非受控属性 */
   defaultFilterValue: {
@@ -107,7 +109,7 @@ export default {
   /** 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制 */
   selectedRowKeys: {
     type: Array as PropType<TdPrimaryTableProps['selectedRowKeys']>,
-    default: (): TdPrimaryTableProps['selectedRowKeys'] => [],
+    default: undefined,
   },
   /** 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制，非受控属性 */
   defaultSelectedRowKeys: {
@@ -119,6 +121,7 @@ export default {
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序 */
   sort: {
     type: [Object, Array] as PropType<TdPrimaryTableProps['sort']>,
+    default: undefined,
   },
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序，非受控属性 */
   defaultSort: {

--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -21,6 +21,7 @@ import useClassName from './hooks/useClassName';
 import useEditableCell from './hooks/useEditableCell';
 import useEditableRow from './hooks/useEditableRow';
 import { EditableCellProps } from './editable-cell';
+import useStyle from './hooks/useStyle';
 
 export { BASE_TABLE_ALL_EVENTS } from './base-table';
 
@@ -62,8 +63,9 @@ export default defineComponent({
     const { columns } = toRefs(props);
     const primaryTableRef = ref(null);
     const {
-      tableDraggableClasses, tableBaseClass, tableSelectedClasses, tableSortClasses,
+      classPrefix, tableDraggableClasses, tableBaseClass, tableSelectedClasses, tableSortClasses,
     } = useClassName();
+    const { sizeClassNames } = useStyle(props);
     // 自定义列配置功能
     const { tDisplayColumns, renderColumnController } = useColumnController(props, context);
     // 展开/收起行功能
@@ -174,6 +176,10 @@ export default defineComponent({
               p.colIndex,
               ellipsisTitle,
               attach,
+              {
+                classPrefix,
+                ellipsisOverlayClassName: props.size !== 'medium' ? sizeClassNames[props.size] : '',
+              },
             );
           };
           item.ellipsisTitle = false;

--- a/src/table/tbody.tsx
+++ b/src/table/tbody.tsx
@@ -16,6 +16,8 @@ import { TdBaseTableProps } from './type';
 
 export const ROW_AND_TD_LISTENERS = ROW_LISTENERS.concat('cell-click');
 export interface TableBodyProps extends BaseTableProps {
+  classPrefix: string;
+  ellipsisOverlayClassName: string;
   // 固定列 left/right 具体值
   rowAndColFixedPosition: RowAndColFixedPosition;
   showColumnShadow: { left: boolean; right: boolean };
@@ -66,6 +68,8 @@ export default defineComponent({
   name: 'TBody',
 
   props: {
+    classPrefix: String,
+    ellipsisOverlayClassName: String,
     data: Array as PropType<TableBodyProps['data']>,
     columns: Array as PropType<TableBodyProps['columns']>,
     rowAndColFixedPosition: Map as PropType<TableBodyProps['rowAndColFixedPosition']>,
@@ -180,6 +184,8 @@ export default defineComponent({
     const trNodeList: JSX.Element[] = [];
 
     const properties = [
+      'classPrefix',
+      'ellipsisOverlayClassName',
       'rowAndColFixedPosition',
       'scroll',
       'tableElm',

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -6,39 +6,41 @@ import { CreateElement } from 'vue';
 import { getColumnFixedStyles } from './hooks/useFixed';
 import { RowAndColFixedPosition, BaseTableColumns, ThRowspanAndColspan } from './interface';
 import useClassName from './hooks/useClassName';
-import { useConfig } from '../config-provider/useConfig';
 import { BaseTableCol, TableRowData } from './type';
 import { renderTitle } from './hooks/useTableHeader';
 import TEllipsis from './ellipsis';
 import { formatClassNames } from './utils';
 
 export interface TheadProps {
+  classPrefix?: string;
+  ellipsisOverlayClassName?: string;
   // 是否固定表头
-  isFixedHeader: boolean;
+  isFixedHeader?: boolean;
   // 固定列 left/right 具体值
-  rowAndColFixedPosition: RowAndColFixedPosition;
+  rowAndColFixedPosition?: RowAndColFixedPosition;
   // 虚拟滚动单独渲染表头；表头吸顶单独渲染表头
   thWidthList?: { [colKey: string]: number };
-  bordered: boolean;
-  isMultipleHeader: boolean;
-  spansAndLeafNodes: {
+  bordered?: boolean;
+  isMultipleHeader?: boolean;
+  spansAndLeafNodes?: {
     rowspanAndColspanMap: ThRowspanAndColspan;
     leafColumns: BaseTableCol<TableRowData>[];
   };
-  thList: BaseTableCol<TableRowData>[][];
-  columnResizeParams: {
+  thList?: BaseTableCol<TableRowData>[][];
+  columnResizeParams?: {
     resizeLineRef: HTMLDivElement;
     resizeLineStyle: Object;
     onColumnMouseover: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
     onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
   };
-  resizable: Boolean;
+  resizable?: Boolean;
 }
 
 export default defineComponent({
   name: 'THead',
 
   props: {
+    ellipsisOverlayClassName: String,
     isFixedHeader: Boolean,
     rowAndColFixedPosition: Map as PropType<TheadProps['rowAndColFixedPosition']>,
     thWidthList: Object as PropType<TheadProps['thWidthList']>,
@@ -54,7 +56,6 @@ export default defineComponent({
     const theadRef = ref<HTMLHeadElement>();
     const classnames = useClassName();
     const { tableHeaderClasses, tableBaseClass } = classnames;
-    const { classPrefix } = useConfig();
     const theadClasses = computed(() => [
       tableHeaderClasses.header,
       {
@@ -64,11 +65,28 @@ export default defineComponent({
       },
     ]);
 
+    // 单行表格合并
+    const colspanSkipMap = computed(() => {
+      const map: { [key: string]: boolean } = {};
+      const list = props.thList[0];
+      for (let i = 0, len = list.length; i < len; i++) {
+        const item = list[i];
+        if (item.colspan > 1) {
+          for (let j = i + 1; j < i + item.colspan; j++) {
+            if (list[j]) {
+              map[list[j].colKey] = true;
+            }
+          }
+        }
+      }
+      return map;
+    });
+
     return {
       ...classnames,
+      colspanSkipMap,
       theadRef,
       theadClasses,
-      classPrefix,
       slots,
     };
   },
@@ -85,6 +103,8 @@ export default defineComponent({
       const thRowspanAndColspan = this.spansAndLeafNodes.rowspanAndColspanMap;
       return this.thList.map((row, rowIndex) => {
         const thRow = row.map((col: BaseTableColumns[0], index: number) => {
+          // 因合并单行表头，跳过
+          if (this.colspanSkipMap[col.colKey]) return null;
           const rowspanAndColspan = thRowspanAndColspan.get(col);
           if (index === 0 && rowspanAndColspan.rowspan > 1) {
             for (let j = rowIndex + 1; j < rowIndex + rowspanAndColspan.rowspan; j++) {
@@ -121,13 +141,17 @@ export default defineComponent({
             : {};
           const content = isFunction(col.ellipsisTitle) ? col.ellipsisTitle(h, { col, colIndex: index }) : undefined;
           const isEllipsis = col.ellipsisTitle !== undefined ? Boolean(col.ellipsisTitle) : Boolean(col.ellipsis);
+          const attrs = (isFunction(col.attrs) ? col.attrs({ ...colParams, type: 'th' }) : col.attrs) || {};
+          if (col.colspan > 1) {
+            attrs.colspan = col.colspan;
+          }
           return (
             <th
               key={col.colKey}
               data-colkey={col.colKey}
               class={thClasses}
               style={styles}
-              attrs={{ ...rowspanAndColspan }}
+              attrs={{ ...attrs, ...rowspanAndColspan }}
               on={resizeColumnListener}
             >
               <div class={this.tableBaseClass.thCellInner}>
@@ -137,6 +161,8 @@ export default defineComponent({
                     attach={this.theadRef ? () => this.theadRef : undefined}
                     tooltipContent={content && (() => content)}
                     tooltipProps={typeof col.ellipsisTitle === 'object' ? col.ellipsisTitle : undefined}
+                    overlayClassName={this.ellipsisOverlayClassName}
+                    classPrefix={this.classPrefix}
                   >
                     {innerTh}
                   </TEllipsis>

--- a/src/table/tr.tsx
+++ b/src/table/tr.tsx
@@ -67,7 +67,9 @@ export type TrPropsKeys = typeof TABLE_PROPS[number];
 export interface TrProps extends TrCommonProps {
   row: TableRowData;
   rowIndex: number;
-  dataLength: number;
+  ellipsisOverlayClassName?: string;
+  classPrefix?: string;
+  dataLength?: number;
   rowAndColFixedPosition?: RowAndColFixedPosition;
   skipSpansMap?: Map<string, SkipSpansValue>;
   tableElm?: HTMLDivElement;
@@ -77,7 +79,7 @@ export interface TrProps extends TrCommonProps {
   trs?: Map<number, object>;
   bufferSize?: number;
   tableContentElm?: HTMLDivElement;
-  cellEmptyContent: TdBaseTableProps['cellEmptyContent'];
+  cellEmptyContent?: TdBaseTableProps['cellEmptyContent'];
 }
 
 export const ROW_LISTENERS = ['click', 'dblclick', 'mouseover', 'mousedown', 'mouseenter', 'mouseleave', 'mouseup'];
@@ -124,6 +126,8 @@ export default defineComponent({
   props: {
     row: Object as PropType<TableRowData>,
     rowIndex: Number,
+    ellipsisOverlayClassName: String,
+    classPrefix: String,
     dataLength: Number,
     rowAndColFixedPosition: Map as PropType<RowAndColFixedPosition>,
     // 合并单元格，是否跳过渲染
@@ -237,13 +241,22 @@ export default defineComponent({
     ) {
       const { cellNode } = params;
       const { col } = cellParams;
-      const content = isFunction(col.ellipsis) ? col.ellipsis(h, cellParams) : undefined;
+      let content = isFunction(col.ellipsis) ? col.ellipsis(h, cellParams) : undefined;
+      if (typeof col.ellipsis === 'object' && isFunction(col.ellipsis.content)) {
+        content = col.ellipsis.content(h, cellParams);
+      }
+      let tooltipProps = {};
+      if (typeof col.ellipsis === 'object') {
+        tooltipProps = 'props' in col.ellipsis ? col.ellipsis.props : col.ellipsis || undefined;
+      }
       return (
         <TEllipsis
           placement={'top'}
           attach={this.tableElm ? () => this.tableElm : undefined}
           tooltipContent={content && (() => content)}
-          tooltipProps={typeof col.ellipsis === 'object' ? col.ellipsis : undefined}
+          tooltipProps={tooltipProps}
+          overlayClassName={this.ellipsisOverlayClassName}
+          classPrefix={this.classPrefix}
         >
           {cellNode}
         </TEllipsis>
@@ -274,8 +287,10 @@ export default defineComponent({
         // Vue3 ignore this line
         this.$emit('cell-click', p);
       };
+      const normalAttrs = isFunction(col.attrs) ? col.attrs({ ...params, type: 'td' }) : col.attrs;
+      const attrs: { [key: string]: any } = { ...normalAttrs, ...cellSpans };
       return (
-        <td class={classes} style={tdStyles.style} attrs={{ ...col.attrs, ...cellSpans }} onClick={onClick}>
+        <td class={classes} attrs={attrs} style={{ ...tdStyles.style, ...attrs.style }} onClick={onClick}>
           {col.ellipsis ? this.renderEllipsisCell(h, params, { cellNode }) : cellNode}
         </td>
       );

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -75,12 +75,12 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
    * 请更为使用 `footerAffixedBottom`。表尾吸底基于 Affix 组件开发，透传全部 Affix 组件属性。
    * @deprecated
    */
-  footerAffixProps?: AffixProps;
+  footerAffixProps?: Partial<AffixProps>;
   /**
    * 表尾吸底。使用此向功能，需要非常注意表格是相对于哪一个父元素进行滚动。值为 `true`，则表示相对于整个窗口吸底。如果表格滚动的父元素不是整个窗口，请通过 `footerAffixedBottom.container` 调整固钉的吸顶范围。基于 Affix 组件开发，透传全部 Affix 组件属性
    * @default false
    */
-  footerAffixedBottom?: boolean | AffixProps;
+  footerAffixedBottom?: boolean | Partial<AffixProps>;
   /**
    * 表尾总结行
    */
@@ -89,12 +89,12 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
    * 请更为使用 `headerAffixedTop`。表头吸顶基于 Affix 组件开发，透传全部 Affix 组件属性
    * @deprecated
    */
-  headerAffixProps?: AffixProps;
+  headerAffixProps?: Partial<AffixProps>;
   /**
    * 表头吸顶。使用该功能，需要非常注意表格是相对于哪一个父元素进行滚动。值为 `true`，表示相对于整个窗口吸顶。如果表格滚动的父元素不是整个窗口，请通过 `headerAffixedTop.container` 调整吸顶的位置。基于 Affix 组件开发，透传全部 Affix 组件属性。
    * @default false
    */
-  headerAffixedTop?: boolean | AffixProps;
+  headerAffixedTop?: boolean | Partial<AffixProps>;
   /**
    * 表格高度，超出后会出现滚动条。示例：100,  '30%',  '300'。值为数字类型，会自动加上单位 px。如果不是绝对固定表格高度，建议使用 `maxHeight`
    */
@@ -102,7 +102,7 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
   /**
    * 滚动条吸底。基于 Affix 组件开发，透传全部 Affix 组件属性
    */
-  horizontalScrollAffixedBottom?: boolean | AffixProps;
+  horizontalScrollAffixedBottom?: boolean | Partial<AffixProps>;
   /**
    * 是否显示鼠标悬浮状态
    * @default false
@@ -131,7 +131,7 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
   /**
    * 分页吸底。基于 Affix 组件开发，透传全部 Affix 组件属性
    */
-  paginationAffixedBottom?: boolean | AffixProps;
+  paginationAffixedBottom?: boolean | Partial<AffixProps>;
   /**
    * 是否允许调整列宽。如果想要配置宽度可调整的最小值和最大值，请使用 `column.resize`，示例：`columns: [{ resize: { minWidth: 120, maxWidth: 300 } }]`
    * @default false
@@ -257,7 +257,7 @@ export interface BaseTableCol<T extends TableRowData = TableRowData> {
   /**
    * 透传 HTML 属性到列元素
    */
-  attrs?: object;
+  attrs?: BaseTableColumnAttributes<T>;
   /**
    * 自定义单元格渲染。值类型为 Function 表示以函数形式渲染单元格。值类型为 string 表示使用插槽渲染，插槽名称为 cell 的值。默认使用 colKey 作为插槽名称。优先级高于 render。泛型 T 指表格数据类型
    */
@@ -276,14 +276,26 @@ export interface BaseTableCol<T extends TableRowData = TableRowData> {
    */
   colKey?: string;
   /**
-   * 单元格和表头内容超出时，是否显示省略号。如果仅希望单元格超出省略，可设置 `ellipsisTitle = false`。<br/> 值为 `true`，则浮层默认显示单元格内容；<br/>值类型为 `Function` 则自定义浮层显示内容；<br/>值类型为 `Object`，则自动透传属性到 Tooltip 组件，可用于调整浮层方向等特性
+   * 单行表头合并列。多行表头请参考「多级表头」文档示例
+   */
+  colspan?: number;
+  /**
+   * 单元格和表头内容超出时，是否显示省略号。如果仅希望单元格超出省略，可设置 `ellipsisTitle = false`。<br/> 值为 `true`，则超出省略浮层默认显示单元格内容；<br/>值类型为 `Function` 则自定义超出省略浮中层显示的内容；<br/>值类型为 `Object`，则自动透传属性到 Tooltip 组件，可用于调整浮层背景色和方向等特性。<br/> 同时透传 Tooltip 属性和自定义浮层内容，请使用 `{ props: { theme: 'light' }, content: () => 'something' }`
    * @default false
    */
-  ellipsis?: boolean | TNode<BaseTableCellParams<T>> | TooltipProps;
+  ellipsis?:
+    | boolean
+    | TNode<BaseTableCellParams<T>>
+    | TooltipProps
+    | { props: TooltipProps; content: TNode<BaseTableCellParams<T>> };
   /**
-   * 表头内容超出时，是否显示省略号。优先级高于 `ellipsis`。<br/>值为 `true`，则浮层默认显示表头全部内容；<br/>值类型为 `Function` 则自定义浮层显示表头内容；<br/>值类型为 `Object`，则自动透传属性到 Tooltip 组件，可用于调整浮层方向等特性
+   * 表头内容超出时，是否显示省略号。优先级高于 `ellipsis`。<br/>值为 `true`，则超出省略的浮层默认显示表头全部内容；<br/>值类型为 `Function` 用于自定义超出省略浮层显示的表头内容；<br/>值类型为 `Object`，则自动透传属性到 Tooltip 组件，则自动透传属性到 Tooltip 组件，可用于调整浮层背景色和方向等特性。<br/> 同时透传 Tooltip 属性和自定义浮层内容，请使用 `{ props: { theme: 'light' }, content: () => 'something' }`
    */
-  ellipsisTitle?: boolean | TNode<BaseTableColParams<T>> | TooltipProps;
+  ellipsisTitle?:
+    | boolean
+    | TNode<BaseTableColParams<T>>
+    | TooltipProps
+    | { props: TooltipProps; content: TNode<BaseTableColParams<T>> };
   /**
    * 固定列显示位置
    * @default left
@@ -541,7 +553,7 @@ export interface PrimaryTableCol<T extends TableRowData = TableRowData>
    */
   children?: Array<PrimaryTableCol<T>>;
   /**
-   * 渲染列所需字段，必须唯一。值为 `row-select` 表示当前列为行选中操作列。值为 `drag` 表示当前列为拖拽排序操作列。值为 `serial-number` 表示当前列列「序号」列
+   * 渲染列所需字段，必须唯一。值为 `row-select` 表示当前列为行选中操作列。值为 `drag` 表示当前列为拖拽排序操作列。值为 `serial-number` 表示当前列为「序号」列
    * @default ''
    */
   colKey?: string;
@@ -892,6 +904,8 @@ export interface TableRowData {
   [key: string]: any;
   children?: TableRowData[];
 }
+
+export type BaseTableColumnAttributes<T> = { [key: string]: any } | ((context: CellData<T>) => { [key: string]: any });
 
 export interface BaseTableCellParams<T> {
   row: T;

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -17188,7 +17188,7 @@ exports[`ssr snapshot test renders ./src/table/_example/base.vue correctly 1`] =
           </colgroup>
           <thead class="t-table__header">
             <tr>
-              <th data-colkey="serial-number" class="custom-column-class-name t-table__th-serial-number t-align-center">
+              <th data-colkey="serial-number" data-id="first-column" class="custom-column-class-name t-table__th-serial-number t-align-center">
                 <div class="t-table__th-cell-inner">序号</div>
               </th>
               <th data-colkey="platform" class="t-table__th-platform">
@@ -18453,6 +18453,154 @@ exports[`ssr snapshot test renders ./src/table/_example/editable-row.vue correct
 </div>
 `;
 
+exports[`ssr snapshot test renders ./src/table/_example/ellipsis.vue correctly 1`] = `
+<div>
+  <div class="t-table" style="position:relative;">
+    <div class="t-table__content">
+      <table class="t-table--layout-fixed" style="width:;">
+        <colgroup>
+          <col>
+          <col style="width:120px;">
+          <col>
+          <col>
+          <col>
+          <col>
+        </colgroup>
+        <thead class="t-table__header">
+          <tr>
+            <th data-colkey="desc" class="t-table__th-desc">
+              <div class="t-table__th-cell-inner">
+                <div class="t-table__ellipsis t-text-ellipsis">Description</div>
+              </div>
+            </th>
+            <th data-colkey="something" class="t-table__th-something">
+              <div class="t-table__th-cell-inner">
+                <div class="t-table__ellipsis t-text-ellipsis">这是一个很长很长的标题</div>
+              </div>
+            </th>
+            <th data-colkey="link" class="t-table__th-link">
+              <div class="t-table__th-cell-inner">
+                <div class="t-table__ellipsis t-text-ellipsis">Link</div>
+              </div>
+            </th>
+            <th data-colkey="ellipsisProps" class="t-table__th-ellipsisProps">
+              <div class="t-table__th-cell-inner">
+                <div class="t-table__ellipsis t-text-ellipsis">Ellipsis Props</div>
+              </div>
+            </th>
+            <th data-colkey="ellipsisContent" class="t-table__th-ellipsisContent">
+              <div class="t-table__th-cell-inner">
+                <div class="t-table__ellipsis t-text-ellipsis">Ellipsis Content</div>
+              </div>
+            </th>
+            <th data-colkey="propsAndContent1" class="t-table__th-propsAndContent1">
+              <div class="t-table__th-cell-inner">
+                <div class="t-table__ellipsis t-text-ellipsis">Props &amp; Content</div>
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="t-table__body">
+          <tr>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">单元格文本超出省略设置</div>
+            </td>
+            <td>仅标题省略</td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis"><a href="/vue-next/components/table" target="_blank">Long link text. Popup content is pure text</a></div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting ellipsis tooltip to be light</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Custom Ellipsis Content</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting props and content at the same time</div>
+            </td>
+          </tr>
+          <tr>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">这是普通文本的超出省略</div>
+            </td>
+            <td>仅标题省略</td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis"><a href="/vue-next/components/table" target="_blank">Long link text. Popup content is pure text</a></div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting ellipsis tooltip to be light</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Custom Ellipsis Content</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting props and content at the same time</div>
+            </td>
+          </tr>
+          <tr>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">单元格文本超出省略设置</div>
+            </td>
+            <td>仅标题省略</td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis"><a href="/vue-next/components/table" target="_blank">Long link text. Popup content is pure text</a></div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting ellipsis tooltip to be light</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Custom Ellipsis Content</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting props and content at the same time</div>
+            </td>
+          </tr>
+          <tr>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">这是普通文本的超出省略</div>
+            </td>
+            <td>仅标题省略</td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis"><a href="/vue-next/components/table" target="_blank">Long link text. Popup content is pure text</a></div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting ellipsis tooltip to be light</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Custom Ellipsis Content</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting props and content at the same time</div>
+            </td>
+          </tr>
+          <tr>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">单元格文本超出省略设置</div>
+            </td>
+            <td>仅标题省略</td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis"><a href="/vue-next/components/table" target="_blank">Long link text. Popup content is pure text</a></div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting ellipsis tooltip to be light</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Custom Ellipsis Content</div>
+            </td>
+            <td class="t-table-td--ellipsis">
+              <div class="t-table__ellipsis t-text-ellipsis">Setting props and content at the same time</div>
+            </td>
+          </tr>
+        </tbody>
+        <!---->
+      </table>
+    </div>
+    <div class="t-table__pagination-wrap" style="opacity:1;"></div>
+    <div class="t-table__resize-line" style="display:none;height:10px;left:10px;bottom:0;"></div>
+  </div>
+</div>
+`;
+
 exports[`ssr snapshot test renders ./src/table/_example/empty.vue correctly 1`] = `
 <div class="tdesign-demo-block-column-large">
   <div class="t-table" style="position:relative;">
@@ -19693,11 +19841,12 @@ exports[`ssr snapshot test renders ./src/table/_example/merge-cells.vue correctl
   <div class="t-table__content">
     <table class="t-table--layout-fixed" style="width:;">
       <colgroup>
-        <col style="width:100px;">
-        <col style="width:100px;">
-        <col style="width:100px;">
-        <col style="width:100px;">
-        <col style="width:100px;">
+        <col>
+        <col>
+        <col>
+        <col>
+        <col>
+        <col>
       </colgroup>
       <thead class="t-table__header">
         <tr>
@@ -19713,8 +19862,8 @@ exports[`ssr snapshot test renders ./src/table/_example/merge-cells.vue correctl
           <th data-colkey="needed" class="test3 t-table__th-needed">
             <div class="t-table__th-cell-inner">是否必传</div>
           </th>
-          <th data-colkey="description" class="row t-table__th-description">
-            <div class="t-table__th-cell-inner">说明</div>
+          <th data-colkey="description" colspan="2" class="row t-table__th-description">
+            <div class="t-table__th-cell-inner">合并单行表头的最后两列</div>
           </th>
         </tr>
       </thead>
@@ -19724,32 +19873,38 @@ exports[`ssr snapshot test renders ./src/table/_example/merge-cells.vue correctl
           <td class="row">Array&lt;any&gt;</td>
           <td class="test4">[]</td>
           <td colspan="2" class="test3">Y</td>
+          <td>表头合并</td>
         </tr>
         <tr>
           <td rowspan="2" colspan="2" class="row">String</td>
           <td class="test3">Y</td>
           <td class="row">描述</td>
+          <td>表头合并</td>
         </tr>
         <tr>
           <td rowspan="2" class="test t-table__td-first-col">公有</td>
           <td class="test3">Y</td>
           <td class="row">复杂类型</td>
+          <td>表头合并</td>
         </tr>
         <tr>
           <td class="row">Boolean</td>
           <td class="test4">false</td>
           <td class="test3">Y</td>
           <td class="row">标识符</td>
+          <td>表头合并</td>
         </tr>
         <tr>
           <td rowspan="2" class="test t-table__td-last-row t-table__td-first-col">公有</td>
           <td class="row">Array&lt;any&gt;</td>
           <td rowspan="2" colspan="2" class="test4 t-table__td-last-row">-1</td>
           <td class="row">数据源</td>
+          <td>表头合并</td>
         </tr>
         <tr>
           <td class="row">String</td>
           <td class="row">描述</td>
+          <td>表头合并</td>
         </tr>
       </tbody>
       <!---->
@@ -20324,7 +20479,10 @@ exports[`ssr snapshot test renders ./src/table/_example/select-multiple.vue corr
 
 exports[`ssr snapshot test renders ./src/table/_example/select-single.vue correctly 1`] = `
 <div class="tdesign-demo__table">
-  <div><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">高亮行选中</span></label> <label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">整行选中</span></label></div>
+  <div class="t-space t-space-horizontal" style="gap:16px;">
+    <div class="t-space-item"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">高亮行选中</span></label></div>
+    <div class="t-space-item"><label class="t-checkbox"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">整行选中</span></label></div>
+  </div>
   <div class="t-table" style="position:relative;">
     <div class="t-table__content">
       <table class="t-table--layout-fixed" style="width:;">
@@ -20602,6 +20760,91 @@ exports[`ssr snapshot test renders ./src/table/_example/single-sort.vue correctl
           </tr>
         </tbody>
         <!---->
+      </table>
+    </div>
+    <div class="t-table__pagination-wrap" style="opacity:1;"></div>
+    <div class="t-table__resize-line" style="display:none;height:10px;left:10px;bottom:0;"></div>
+  </div>
+</div>
+`;
+
+exports[`ssr snapshot test renders ./src/table/_example/style.vue correctly 1`] = `
+<div class="t-demo__style">
+  <div class="t-table" style="position:relative;">
+    <div class="t-table__content">
+      <table class="t-table--layout-fixed" style="width:;">
+        <colgroup>
+          <col style="width:80px;">
+          <col>
+          <col>
+          <col>
+          <col>
+        </colgroup>
+        <thead class="t-table__header">
+          <tr>
+            <th data-colkey="serial-number" class="t-table__th-serial-number t-align-center">
+              <div class="t-table__th-cell-inner">序号</div>
+            </th>
+            <th data-colkey="framework" class="t-table__th-framework">
+              <div class="t-table__th-cell-inner">框架</div>
+            </th>
+            <th data-colkey="data" class="t-table__th-data t-align-right">
+              <div class="t-table__th-cell-inner">数据</div>
+            </th>
+            <th data-colkey="ringRatio" class="t-table__th-ringRatio t-align-right">
+              <div class="t-table__th-cell-inner">环比</div>
+            </th>
+            <th data-colkey="yearRatio" class="last-column-class-name t-table__th-yearRatio t-align-right">
+              <div class="t-table__th-cell-inner">同比</div>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="t-table__body">
+          <tr>
+            <td class="t-align-center">1</td>
+            <td>tdesign-vue</td>
+            <td class="t-align-right">100,000</td>
+            <td class="t-align-right">8%</td>
+            <td class="last-column-class-name t-align-right">10%</td>
+          </tr>
+          <tr>
+            <td class="t-align-center">2</td>
+            <td>tdesign-react</td>
+            <td class="t-align-right" style="color:green;font-weight:600;background-color:var(--td-brand-color-1);font-size:16px;">21,514</td>
+            <td class="t-align-right">30%</td>
+            <td class="last-column-class-name t-align-right">20%</td>
+          </tr>
+          <tr class="custom-third-class-name">
+            <td class="t-align-center">3</td>
+            <td>tdesign-vue-next</td>
+            <td class="t-align-right">7,884</td>
+            <td class="t-align-right">75%</td>
+            <td class="last-column-class-name t-align-right">80%</td>
+          </tr>
+          <tr>
+            <td class="t-align-center">4</td>
+            <td>tdesign-vue</td>
+            <td class="t-align-right">1,290</td>
+            <td class="custom-cell-class-name t-align-right">200%</td>
+            <td class="last-column-class-name t-align-right">100%</td>
+          </tr>
+          <tr>
+            <td class="t-align-center">5</td>
+            <td>tdesign-react</td>
+            <td class="t-align-right">100,000</td>
+            <td class="t-align-right">8%</td>
+            <td class="last-column-class-name t-align-right">10%</td>
+          </tr>
+        </tbody>
+        <tfoot class="t-table__footer">
+          <tr class="t-table__row--full">
+            <td colspan="5">
+              <div class="t-table__row-full-element">
+                <div class="t-table__row-filter-inner">汇总：近期数据波动较大</div>
+              </div>
+            </td>
+          </tr>
+        </tfoot>
       </table>
     </div>
     <div class="t-table__pagination-wrap" style="opacity:1;"></div>

--- a/test/ssr/__snapshots__/ssr.test.js.snap
+++ b/test/ssr/__snapshots__/ssr.test.js.snap
@@ -17488,10 +17488,18 @@ exports[`ssr snapshot test renders ./src/table/_example/custom-col.vue correctly
 
 exports[`ssr snapshot test renders ./src/table/_example/custom-col-button.vue correctly 1`] = `
 <div class="tdesign-demo-block-column-large tdesign-demo__table">
-  <div>
-    <div class="t-radio-group t-size-m t-radio-group--filled"><label class="t-radio-button"><input type="radio" value="top-left" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">左上角</span></label> <label class="t-radio-button t-is-checked"><input type="radio" checked="checked" value="top-right" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">右上角</span></label> <label class="t-radio-button"><input type="radio" value="bottom-left" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">左下角</span></label> <label class="t-radio-button"><input type="radio" value="bottom-right" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">右下角</span></label>
-      <div class="t-radio-group__bg-block" style="width:0px;left:0px;"></div>
-    </div> <br><br> <label class="t-checkbox t-is-checked"><input type="checkbox" checked="checked" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">是否显示边框</span></label> <label class="t-checkbox" style="margin-left:16px;"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">自定义列配置按钮</span></label>
+  <div class="t-space t-space-vertical" style="gap:16px;">
+    <div class="t-space-item">
+      <div class="t-radio-group t-size-m t-radio-group--filled"><label class="t-radio-button"><input type="radio" value="top-left" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">左上角</span></label> <label class="t-radio-button t-is-checked"><input type="radio" checked="checked" value="top-right" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">右上角</span></label> <label class="t-radio-button"><input type="radio" value="bottom-left" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">左下角</span></label> <label class="t-radio-button"><input type="radio" value="bottom-right" name="" class="t-radio-button__former"><span class="t-radio-button__input"></span><span class="t-radio-button__label">右下角</span></label>
+        <div class="t-radio-group__bg-block" style="width:0px;left:0px;"></div>
+      </div>
+    </div>
+    <div class="t-space-item">
+      <div class="t-space t-space-horizontal" style="gap:16px;">
+        <div class="t-space-item"><label class="t-checkbox t-is-checked"><input type="checkbox" checked="checked" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">是否显示边框</span></label></div>
+        <div class="t-space-item"><label class="t-checkbox" style="margin-left:16px;"><input type="checkbox" class="t-checkbox__former"><span class="t-checkbox__input"></span><span class="t-checkbox__label">自定义列配置按钮</span></label></div>
+      </div>
+    </div>
   </div>
   <div class="t-table t-table--bordered t-table--striped t-table--col-draggable" style="position:relative;">
     <div class="t-table__top-content">
@@ -21015,6 +21023,12 @@ exports[`ssr snapshot test renders ./src/table/_example/tree.vue correctly 1`] =
         </tbody>
         <!---->
       </table>
+    </div>
+    <div class="t-table__bottom-content">
+      <div class="t-table__column-controller-trigger t-align-bottom-left"><button type="button" class="t-button t-size-m t-button--variant-outline t-button--theme-default"><svg fill="none" viewBox="0 0 16 16" width="1em" height="1em" class="t-icon t-icon-setting">
+            <path fill="currentColor" d="M11 8a3 3 0 11-6 0 3 3 0 016 0zm-1 0a2 2 0 10-4 0 2 2 0 004 0z" fill-opacity="0.9"></path>
+            <path fill="currentColor" d="M8 1.25l6.06 3.38v6.75L8 14.75l-6.06-3.38V4.63L8 1.25zM2.94 5.21v5.58L8 13.6l5.06-2.82V5.2L8 2.4 2.94 5.21z" fill-opacity="0.9"></path>
+          </svg><span class="t-button__text">列配置</span></button></div>
     </div>
     <div class="t-table__pagination-wrap" style="opacity:1;">
       <div class="t-table__pagination">


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 表格列属性 `attrs` 支持自定义任意单元格属性
- feat(Table): 新增列属性 `colspan`，用于设置单行表头合并
- feat(Table): 超出省略功能，支持同时设置省略浮层内容 `ellipsis.content` 和属性透传 `ellipsis.props`
- feat(Table): 增强型表格，支持列配置，支持不传 `displayColumns` 时默认显示全部列，[issue#1784](https://github.com/Tencent/tdesign-vue-next/issues/1784)
- fix(Table): 筛选功能，`resetValue` 无效，[issue#1611](https://github.com/Tencent/tdesign-vue/issues/1611)
- fix(Table): 表头吸顶功能，数据变化更新吸顶位置，[issue#1585](https://github.com/Tencent/tdesign-vue/issues/1585)


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
