### PR TITLE
feat(table): 列宽调整策略支持 resize-sibling-column 和 resize-table 两种模式

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -398,7 +398,7 @@ export default defineComponent({
           style={{ width: `${this.tableWidth - affixedLeftBorder}px`, opacity: headerOpacity }}
           class={['scrollbar', { [this.tableBaseClass.affixedHeaderElm]: this.headerAffixedTop || this.isVirtual }]}
         >
-          <table class={this.tableElmClasses} style={this.tableElementActualStyles}>
+          <table class={this.tableElmClasses} style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}>
             {colgroup}
             <THead
               scopedSlots={this.$scopedSlots}
@@ -456,7 +456,10 @@ export default defineComponent({
               { [this.tableBaseClass.affixedFooterElm]: this.footerAffixedBottom || this.isVirtual },
             ]}
           >
-            <table class={this.tableElmClasses} style={this.tableElementActualStyles}>
+            <table
+              class={this.tableElmClasses}
+              style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}
+            >
               {this.renderColGroup(columns)}
               <TFoot
                 rowKey={this.rowKey}

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -12,6 +12,7 @@ import {
 } from '@vue/composition-api';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
+import isObject from 'lodash/isObject';
 import log from '../../_common/js/log';
 import { ClassName, Styles } from '../../common';
 import { BaseTableCol, TableRowData, TdBaseTableProps } from '../type';
@@ -125,7 +126,13 @@ export default function useFixed(
   const isFixedRightColumn = ref(false);
   const isFixedLeftColumn = ref(false);
 
-  const columnResizable = computed(() => resizable.value || allowResizeColumnWidth.value || false);
+  const columnResizable = computed(() => !!resizable.value || allowResizeColumnWidth.value || false);
+  const columnResizeType = computed(() => {
+    if (isObject(resizable.value)) {
+      return resizable.value.resizeType;
+    }
+    return 'resize-sibling-column';
+  });
 
   // 没有表头吸顶，没有虚拟滚动，则不需要表头宽度计算
   const notNeedThWidthList = computed(
@@ -577,5 +584,6 @@ export default function useFixed(
     updateThWidthList,
     setRecalculateColWidthFuncRef,
     addTableResizeObserver,
+    columnResizeType,
   };
 }

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -136,7 +136,7 @@ export interface TdBaseTableProps<T extends TableRowData = TableRowData> {
    * 是否允许调整列宽。如果想要配置宽度可调整的最小值和最大值，请使用 `column.resize`，示例：`columns: [{ resize: { minWidth: 120, maxWidth: 300 } }]`
    * @default false
    */
-  resizable?: boolean;
+  resizable?: boolean | { resizeType: 'resize-sibling-column' | 'resize-table' };
   /**
    * HTML 标签 `tr` 的属性。类型为 Function 时，参数说明：`params.row` 表示行数据；`params.rowIndex` 表示行下标；`params.type=body` 表示属性作用于 `tbody` 中的元素；`params.type=foot` 表示属性作用于 `tfoot` 中的元素。<br />示例一：{ draggable: true }，<br />示例二：[{ draggable: true }, { title: '超出省略显示' }]。<br /> 示例三：() => [{ draggable: true }]
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue/issues/1340

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 列宽调整需要支持以下两种更新策略：
   1. resize-sibling-column: 默认策略，更新与当前列相邻的列宽
   2. resize-table: 除当前列外，均不更新列宽，直接调整整个表格的宽度
2. resizable参数格式改为 boolean | { resizeType: 'resize-sibling-column' | 'resize-table' }

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(table): 列宽调整策略支持 resize-sibling-column 和 resize-table 两种模式

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
