### PR TITLE
fix(table): 当配置吸底滚动条时，margin-top造成遮挡

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -619,7 +619,11 @@ export default defineComponent({
           <Affix
             offsetBottom={0}
             props={getAffixProps(this.horizontalScrollAffixedBottom)}
-            style={{ marginTop: `-${this.scrollbarWidth * 2}px` }}
+            style={
+              this.showAffixFooter
+                ? { marginTop: `-${this.scrollbarWidth * 2}px` }
+                : { float: 'right', visibility: 'hidden' }
+            }
             ref="horizontalScrollAffixRef"
           >
             <div

--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -63,8 +63,13 @@ export default function useAffix(props: TdBaseTableProps) {
     }
   };
 
-  // 吸底的元素（footer、横向滚动条、分页器）是否显示
+  // 吸底的元素（footer、分页器）是否显示
   const isAffixedBottomElementShow = (elementRect: DOMRect, tableRect: DOMRect, headerHeight: number) => tableRect.top + headerHeight < elementRect.top && elementRect.top > elementRect.height;
+
+  // 横向滚动条是否显示
+  const isAffixedBottomScrollShow = (elementRect: DOMRect, tableRect: DOMRect, headerHeight: number) => tableContentRef.value.scrollWidth > tableContentRef.value.clientWidth
+    && tableRect.top + headerHeight < elementRect.top
+    && elementRect.top > elementRect.height;
 
   const getOffsetTop = (props: boolean | AffixProps) => {
     if (typeof props === 'boolean') return 0;
@@ -92,7 +97,7 @@ export default function useAffix(props: TdBaseTableProps) {
       showAffixFooter.value = isAffixedBottomElementShow(footerRect, pos, headerHeight);
     } else if (props.horizontalScrollAffixedBottom && horizontalScrollbarRef?.value) {
       const horizontalScrollbarRect = horizontalScrollbarRef.value.getBoundingClientRect();
-      showAffixFooter.value = isAffixedBottomElementShow(horizontalScrollbarRect, pos, headerHeight);
+      showAffixFooter.value = isAffixedBottomScrollShow(horizontalScrollbarRect, pos, headerHeight);
     }
     if (props.paginationAffixedBottom && paginationRef.value) {
       const pageRect = paginationRef.value.getBoundingClientRect();

--- a/src/table/hooks/useAffix.ts
+++ b/src/table/hooks/useAffix.ts
@@ -68,8 +68,7 @@ export default function useAffix(props: TdBaseTableProps) {
 
   // 横向滚动条是否显示
   const isAffixedBottomScrollShow = (elementRect: DOMRect, tableRect: DOMRect, headerHeight: number) => tableContentRef.value.scrollWidth > tableContentRef.value.clientWidth
-    && tableRect.top + headerHeight < elementRect.top
-    && elementRect.top > elementRect.height;
+    && isAffixedBottomElementShow(elementRect, tableRect, headerHeight);
 
   const getOffsetTop = (props: boolean | AffixProps) => {
     if (typeof props === 'boolean') return 0;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
table配置了吸底滚动条，但是表格没有滚动条时，没有底部border: 
https://codesandbox.io/s/tdesign-vue-demo-forked-zzpftg?file=/src/demo.vue

[table] 分页器吸底 在 windows的firefox下样式异常:
#1452 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
当配置了吸底滚动条，但表格没有滚动条时，吸底滚动条的 `margin-top` 造成遮挡。

解决方案：
检查当表格没有横向滚动条时，去掉margin-top并隐藏吸底滚动条


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 当配置吸底滚动条时，margin-top造成遮挡

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
