### PR TITLE
fix(dialog): 修复参数footer为false时，footer节点还渲染问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@babel/runtime": "^7.14.8",
     "@popperjs/core": "^2.4.0",
     "@types/clipboard": "^2.0.1",
-    "@types/lodash": "^4.14.165",
+    "@types/lodash": "4.14.182",
     "@types/raf": "^3.4.0",
     "@types/sortablejs": "^1.10.7",
     "@types/tinycolor2": "^1.4.3",

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -393,6 +393,11 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
           })}
         </div>
       );
+      const footer = this.footer ? (
+        <div class={`${this.componentName}__footer`} onmousedown={this.onStopDown}>
+          {renderTNodeJSX(this, 'footer', defaultFooter)}
+        </div>
+      ) : null;
       // 此处获取定位方式 top 优先级较高 存在时 默认使用top定位
       return (
         // 非模态形态下draggable为true才允许拖拽
@@ -411,9 +416,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
               <div class={this.bodyClass} onmousedown={this.onStopDown}>
                 {body}
               </div>
-              <div class={`${this.componentName}__footer`} onmousedown={this.onStopDown}>
-                {renderTNodeJSX(this, 'footer', defaultFooter)}
-              </div>
+              {footer}
             </div>
           </div>
         </div>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：当dialog组件的footer参数为false时，footer节点还渲染问题
解决方案：当dialog组件的footer参数为false时，footer节点不渲染

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(dialog): 修复参数footer为false时，footer节点还渲染问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
