### PR TITLE
fix(table): 当禁用resizable时，基础表格表头默认使用用户定义的列宽 

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -334,13 +334,16 @@ export default defineComponent({
   },
 
   methods: {
-    renderColGroup(columns: BaseTableCol<TableRowData>[]) {
+    renderColGroup(columns: BaseTableCol<TableRowData>[], isAffixHeader = true) {
       const defaultColWidth = this.tableLayout === 'fixed' && this.isWidthOverflow ? '100px' : undefined;
       return (
         <colgroup>
           {columns.map((col) => {
             const style: Styles = {
-              width: formatCSSUnit(this.thWidthList[col.colKey] || col.width) || defaultColWidth,
+              width:
+                formatCSSUnit(
+                  (isAffixHeader || this.columnResizable ? this.thWidthList[col.colKey] : undefined) || col.width,
+                ) || defaultColWidth,
             };
             if (col.minWidth) {
               style.minWidth = formatCSSUnit(col.minWidth);
@@ -351,7 +354,7 @@ export default defineComponent({
       );
     },
 
-    getHeadProps() {
+    getHeadProps(isAffixHeader = true) {
       const headProps = {
         isFixedHeader: this.isFixedHeader,
         rowAndColFixedPosition: this.rowAndColFixedPosition,
@@ -359,7 +362,7 @@ export default defineComponent({
         bordered: this.bordered,
         spansAndLeafNodes: this.spansAndLeafNodes,
         thList: this.thList,
-        thWidthList: this.thWidthList,
+        thWidthList: isAffixHeader || this.columnResizable ? this.thWidthList : {},
         resizable: this.resizable,
         columnResizeParams: this.columnResizeParams,
         classPrefix: this.classPrefix,
@@ -389,7 +392,7 @@ export default defineComponent({
         opacity: headerOpacity,
         marginTop: onlyVirtualScrollBordered ? `${borderWidth}px` : 0,
       };
-      const colgroup = this.renderColGroup(columns);
+      const colgroup = this.renderColGroup(columns, true);
       // 多级表头左边线缺失
       const affixedLeftBorder = this.bordered ? 1 : 0;
 
@@ -401,7 +404,7 @@ export default defineComponent({
         >
           <table class={this.tableElmClasses} style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}>
             {colgroup}
-            <THead scopedSlots={this.$scopedSlots} props={this.getHeadProps()} />
+            <THead scopedSlots={this.$scopedSlots} props={this.getHeadProps(true)} />
           </table>
         </div>
       );
@@ -450,7 +453,7 @@ export default defineComponent({
               class={this.tableElmClasses}
               style={{ ...this.tableElementStyles, width: `${this.tableElmWidth}px` }}
             >
-              {this.renderColGroup(columns)}
+              {this.renderColGroup(columns, true)}
               <TFoot
                 rowKey={this.rowKey}
                 scopedSlots={this.$scopedSlots}
@@ -546,8 +549,8 @@ export default defineComponent({
       >
         {this.isVirtual && <div class={this.virtualScrollClasses.cursor} style={virtualStyle} />}
         <table ref="tableElmRef" class={this.tableElmClasses} style={this.tableElementStyles}>
-          {this.renderColGroup(columns)}
-          {this.showHeader && <THead scopedSlots={this.$scopedSlots} props={this.getHeadProps()} />}
+          {this.renderColGroup(columns, false)}
+          {this.showHeader && <THead scopedSlots={this.$scopedSlots} props={this.getHeadProps(false)} />}
           <TBody ref="tableBodyRef" scopedSlots={this.$scopedSlots} props={tableBodyProps} on={tBodyListener} />
           <TFoot
             rowKey={this.rowKey}


### PR DESCRIPTION
…x header

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next/issues/1934

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 表格在resizable=false是，基础表格的表头读取用户设置进来的默认宽度

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(table): 当禁用resizable时，基础表格表头默认使用用户定义的列宽 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
