### PR TITLE
fix(Input): fix auto-width in display: none

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -188,7 +188,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     this.addTableResizeObserver(this.$refs.inputPreRef as Element);
   },
 
-  beforeMount() {
+  beforeDestroy() {
     this.resizeObserver?.unobserve(this.$refs.inputPreRef as Element);
     this.resizeObserver?.disconnect();
   },

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -6,7 +6,7 @@ import {
 } from 'tdesign-icons-vue';
 import camelCase from 'lodash/camelCase';
 import kebabCase from 'lodash/kebabCase';
-import { getUnicodeLength, limitUnicodeMaxLength } from '../_common/js/utils/helper';
+import { getIEVersion, getUnicodeLength, limitUnicodeMaxLength } from '../_common/js/utils/helper';
 import { InputValue, TdInputProps } from './type';
 import { getCharacterLength, omit } from '../utils/helper';
 import getConfigReceiverMixins, { InputConfig, getGlobalIconMixins } from '../config-provider/config-receiver';
@@ -32,6 +32,8 @@ interface InputInstance extends Vue {
   composing: boolean;
   tFormItem: InstanceType<typeof FormItem>;
 }
+
+let resizeObserver: ResizeObserver = null;
 
 export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input'), getGlobalIconMixins()).extend({
   name: 'TInput',
@@ -183,6 +185,15 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     this.innerStatus && this.onValidateChange();
   },
 
+  mounted() {
+    this.addTableResizeObserver(this.$refs.inputPreRef as Element);
+  },
+
+  beforeMount() {
+    resizeObserver?.unobserve(this.$refs.inputPreRef as Element);
+    resizeObserver?.disconnect();
+  },
+
   methods: {
     addListeners() {
       this.$watch(
@@ -195,6 +206,15 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
         },
         { immediate: true },
       );
+    },
+    // 当元素默认为 display: none 状态，无法提前准确计算宽度，因此需要监听元素宽度变化。比如：Tabs 场景切换。
+    addTableResizeObserver(element: Element) {
+      // IE 11 以下使用设置 minWidth 兼容；IE 11 以上使用 ResizeObserver
+      if (typeof window.ResizeObserver === 'undefined') return;
+      resizeObserver = new window.ResizeObserver(() => {
+        this.updateInputWidth();
+      });
+      resizeObserver.observe(element);
     },
     mouseEvent(v: boolean) {
       this.isHover = v;

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -6,7 +6,7 @@ import {
 } from 'tdesign-icons-vue';
 import camelCase from 'lodash/camelCase';
 import kebabCase from 'lodash/kebabCase';
-import { getIEVersion, getUnicodeLength, limitUnicodeMaxLength } from '../_common/js/utils/helper';
+import { getUnicodeLength, limitUnicodeMaxLength } from '../_common/js/utils/helper';
 import { InputValue, TdInputProps } from './type';
 import { getCharacterLength, omit } from '../utils/helper';
 import getConfigReceiverMixins, { InputConfig, getGlobalIconMixins } from '../config-provider/config-receiver';
@@ -32,8 +32,6 @@ interface InputInstance extends Vue {
   composing: boolean;
   tFormItem: InstanceType<typeof FormItem>;
 }
-
-let resizeObserver: ResizeObserver = null;
 
 export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input'), getGlobalIconMixins()).extend({
   name: 'TInput',
@@ -63,6 +61,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       inputValue: this.value,
       composingRef: false,
       composingRefValue: this.value,
+      resizeObserver: null as ResizeObserver,
     };
   },
   computed: {
@@ -190,8 +189,8 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
   },
 
   beforeMount() {
-    resizeObserver?.unobserve(this.$refs.inputPreRef as Element);
-    resizeObserver?.disconnect();
+    this.resizeObserver?.unobserve(this.$refs.inputPreRef as Element);
+    this.resizeObserver?.disconnect();
   },
 
   methods: {
@@ -211,10 +210,10 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     addTableResizeObserver(element: Element) {
       // IE 11 以下使用设置 minWidth 兼容；IE 11 以上使用 ResizeObserver
       if (typeof window.ResizeObserver === 'undefined') return;
-      resizeObserver = new window.ResizeObserver(() => {
+      this.resizeObserver = new window.ResizeObserver(() => {
         this.updateInputWidth();
       });
-      resizeObserver.observe(element);
+      this.resizeObserver.observe(element);
     },
     mouseEvent(v: boolean) {
       this.isHover = v;

--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -209,7 +209,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     // 当元素默认为 display: none 状态，无法提前准确计算宽度，因此需要监听元素宽度变化。比如：Tabs 场景切换。
     addTableResizeObserver(element: Element) {
       // IE 11 以下使用设置 minWidth 兼容；IE 11 以上使用 ResizeObserver
-      if (typeof window.ResizeObserver === 'undefined') return;
+      if (typeof window.ResizeObserver === 'undefined' || !element) return;
       this.resizeObserver = new window.ResizeObserver(() => {
         this.updateInputWidth();
       });

--- a/src/pagination/pagination.tsx
+++ b/src/pagination/pagination.tsx
@@ -18,6 +18,7 @@ import props from './props';
 import { ClassName } from '../common';
 import { emitEvent } from '../utils/event';
 import { TdPaginationProps } from './type';
+import { getIEVersion } from '../_common/js/utils/helper';
 
 const min = 1;
 
@@ -83,6 +84,7 @@ export default mixins(getConfigReceiverMixins<Vue, PaginationConfig>('pagination
         this.commonSizeClassName[this.size],
         {
           [this.commonStatusClassName.disabled]: this.disabled,
+          [`${this.componentName}-ie`]: getIEVersion() < 11,
         },
       ];
     },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

子仓库：https://github.com/Tencent/tdesign-common/pull/968

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 修复在输入框进行预渲染处于 `display: none` 状态时，宽度计算不正确问题，[issue#1678](https://github.com/Tencent/tdesign-vue/issues/1678)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
