### PR TITLE
refactor: 处理引用类型的数据onchange回调中带有__ob__属性

### DIFF
--- a/src/hooks/useVModel.ts
+++ b/src/hooks/useVModel.ts
@@ -61,11 +61,11 @@ export default function useVModel<T, P extends any[]>(
   return [
     internalValue,
     (newValue, ...args) => {
-      internalValue.value = newValue;
       onChange?.(newValue, ...args);
       if (eventName && eventName !== 'input') {
         emit?.(eventName, newValue, ...args);
       }
+      internalValue.value = newValue;
     },
   ];
 }


### PR DESCRIPTION
处理引用类型的数据onchange回调中带有observer属性

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

部分组件的value是引用类型，比如collapse、dateRangePicker等组件，使用现有的useVModal方法，@change回调中的值会带有__ob__属性：
<img width="414" alt="image" src="https://user-images.githubusercontent.com/7193949/201049428-92a1bf31-6767-4e0e-ab73-7f528dad7b81.png">
用户期望的应该是这样的结果：
<img width="236" alt="image" src="https://user-images.githubusercontent.com/7193949/201049618-ca36e519-554b-423f-8242-892f9dd8b33f.png">


### 💡 需求背景和解决方案
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
