### PR TITLE
fix(input): auto-width support chinese pinyin

### DIFF
--- a/src/input/input.tsx
+++ b/src/input/input.tsx
@@ -36,6 +36,7 @@ interface InputInstance extends Vue {
 export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input'), getGlobalIconMixins()).extend({
   name: 'TInput',
   inheritAttrs: false,
+
   props: {
     ...props,
     showInput: {
@@ -49,9 +50,11 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       default: false,
     },
   },
+
   inject: {
     tFormItem: { default: undefined },
   },
+
   data() {
     return {
       formDisabled: undefined,
@@ -62,6 +65,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       composingRef: false,
       composingRefValue: this.value,
       resizeObserver: null as ResizeObserver,
+      preValue: this.value,
     };
   },
   computed: {
@@ -159,6 +163,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
     value: {
       handler(val) {
         this.inputValue = this.format ? this.format(val) : val;
+        this.preValue = this.inputValue;
       },
       immediate: true,
     },
@@ -337,6 +342,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
       this.$emit('click', e);
     },
     handleInput(e: InputEvent | CompositionEvent) {
+      this.preValue = this.inputValue + e.data;
       let {
         currentTarget: { value: val },
       }: any = e;
@@ -490,7 +496,7 @@ export default mixins(getConfigReceiverMixins<InputInstance, InputConfig>('input
         )}
         {this.autoWidth && (
           <span ref="inputPreRef" class={`${this.classPrefix}-input__input-pre`}>
-            {this.value || this.tPlaceholder}
+            {this.preValue || this.tPlaceholder}
           </span>
         )}
         {suffixContent}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Input): 宽度自适应 `auto-width` 支持中文拼音输入也实时调整宽度，[issue#2079](https://github.com/Tencent/tdesign-vue-next/issues/2079)

实现效果如下，

https://user-images.githubusercontent.com/11605702/204307601-e5bb39d9-c392-4a8c-b49d-1e22e2aae62f.mov


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
