### PR TITLE
[Table]Support Select on Row Click

### DIFF
--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -69,7 +69,7 @@ export default mixins(classPrefixMixins, Vue as VueConstructor<CheckboxInstance>
 
   render(): VNode {
     return (
-      <label class={this.labelClasses} title={this.$attrs.title}>
+      <label class={this.labelClasses} title={this.$attrs.title} onClick={this.handleClick}>
         <input
           type="checkbox"
           on={{ ...omit(this.$listeners, ['checked', 'change']) }}
@@ -96,6 +96,11 @@ export default mixins(classPrefixMixins, Vue as VueConstructor<CheckboxInstance>
       // 在tree等组件中使用  阻止label触发checked 与expand冲突
       if (this.stopLabelTrigger) e.preventDefault();
     },
+
+    handleClick(e: MouseEvent) {
+      this.$emit('click', { e });
+    },
+
     handleChange(e: Event) {
       const value = !this.checked$;
       emitEvent<Parameters<TdCheckboxProps['onChange']>>(this, 'change', value, { e });

--- a/src/common.ts
+++ b/src/common.ts
@@ -24,6 +24,13 @@ export type FormSubmitEvent = Event;
 export interface Styles {
   [css: string]: string | number;
 }
+
+export interface UploadDisplayDragEvents {
+  drop?: (event: DragEvent) => void;
+  dragenter?: (event: DragEvent) => void;
+  dragover?: (event: DragEvent) => void;
+  dragleave?: (event: DragEvent) => void;
+}
 /** 通用全局类型 */
 
 export type OptionData = {

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -67,7 +67,7 @@ export default mixins(Vue as VueConstructor<RadioInstance>, classPrefixMixins).e
     ];
 
     return (
-      <label class={inputClass}>
+      <label class={inputClass} onClick={this.handleRadioClick}>
         <input
           type="radio"
           class={`${prefixCls}__former`}
@@ -92,8 +92,12 @@ export default mixins(Vue as VueConstructor<RadioInstance>, classPrefixMixins).e
         emitEvent<Parameters<TdRadioProps['onChange']>>(this, 'change', target.checked, { e });
       }
     },
+
+    handleRadioClick(e: MouseEvent) {
+      this.$emit('click', { e });
+    },
+
     handleClick(e: Event) {
-      this.$emit('click');
       if (!this.checked || !this.allowUncheck) return;
       if (this.radioGroup) {
         // this.radioGroup.$emit('checked-change', undefined, { e });

--- a/src/table/filter-controller.tsx
+++ b/src/table/filter-controller.tsx
@@ -211,7 +211,7 @@ export default defineComponent({
             {getBottomButtons(h, column)}
           </div>
         )}
-        {...popupProps}
+        props={popupProps}
       >
         <div ref="triggerElementRef">{this.renderTNode('filterIcon', defaultFilterIcon)}</div>
       </Popup>

--- a/src/table/filter-controller.tsx
+++ b/src/table/filter-controller.tsx
@@ -3,8 +3,7 @@ import { CreateElement } from 'vue';
 import { FilterIcon as TdFilterIcon } from 'tdesign-icons-vue';
 import isEmpty from 'lodash/isEmpty';
 import lowerFirst from 'lodash/lowerFirst';
-
-import Popup from '../popup';
+import Popup, { PopupProps } from '../popup';
 import { CheckboxGroup } from '../checkbox';
 import { RadioGroup } from '../radio';
 import Input from '../input';
@@ -36,6 +35,7 @@ export interface TableFilterControllerProps {
   isFocusClass: string;
   column: PrimaryTableCol;
   primaryTableElement: HTMLDivElement;
+  popupProps: PopupProps;
 }
 
 export default defineComponent({
@@ -48,6 +48,7 @@ export default defineComponent({
     tableFilterClasses: Object as PropType<TableFilterControllerProps['tableFilterClasses']>,
     isFocusClass: String,
     primaryTableElement: {},
+    popupProps: Object as PropType<TableFilterControllerProps['popupProps']>,
   },
 
   // eslint-disable-next-line
@@ -180,7 +181,7 @@ export default defineComponent({
       );
     };
 
-    const { column, FilterIcon } = this;
+    const { column, FilterIcon, popupProps } = this;
     if (!column.filter || (column.filter && !Object.keys(column.filter).length)) return null;
     const defaultFilterIcon = this.t(this.global.filterIcon) || <FilterIcon />;
     const filterValue = this.tFilterValue?.[column.colKey];
@@ -210,6 +211,7 @@ export default defineComponent({
             {getBottomButtons(h, column)}
           </div>
         )}
+        {...popupProps}
       >
         <div ref="triggerElementRef">{this.renderTNode('filterIcon', defaultFilterIcon)}</div>
       </Popup>

--- a/src/table/hooks/useFilter.tsx
+++ b/src/table/hooks/useFilter.tsx
@@ -158,6 +158,7 @@ export default function useFilter(props: TdPrimaryTableProps, context: SetupCont
         innerFilterValue={innerFilterValue.value}
         tableFilterClasses={tableFilterClasses}
         isFocusClass={isFocusClass}
+        popupProps={col.filter.popupProps}
         primaryTableElement={primaryTableRef.value?.$el}
         on={{
           reset: onReset,

--- a/src/table/hooks/useRowSelect.tsx
+++ b/src/table/hooks/useRowSelect.tsx
@@ -124,7 +124,7 @@ export default function useRowSelect(
         ...checkProps,
       },
       on: {
-        click: (e: MouseEvent) => {
+        click: ({ e }: { e: MouseEvent }) => {
           // 选中行功能中，点击 checkbox/radio 需阻止事件冒泡，避免触发不必要的 onRowClick
           e?.stopPropagation();
         },

--- a/src/table/hooks/useRowSelect.tsx
+++ b/src/table/hooks/useRowSelect.tsx
@@ -102,12 +102,21 @@ export default function useRowSelect(
     );
   }
 
+  function getRowSelectDisabledData(p: PrimaryTableCellParams<TableRowData>) {
+    const { col, row, rowIndex } = p;
+    const disabled: boolean = typeof col.disabled === 'function' ? col.disabled({ row, rowIndex }) : col.disabled;
+    const checkProps = isFunction(col.checkProps) ? col.checkProps({ row, rowIndex }) : col.checkProps;
+    return {
+      disabled: disabled || checkProps?.disabled,
+      checkProps,
+    };
+  }
+
   // eslint-disable-next-line
   function renderSelectCell(h: CreateElement, p: PrimaryTableCellParams<TableRowData>) {
-    const { col: column, row = {}, rowIndex } = p;
+    const { col: column, row = {} } = p;
     const checked = tSelectedRowKeys.value.includes(get(row, props.rowKey || 'id'));
-    const disabled = typeof column.disabled === 'function' ? column.disabled({ row, rowIndex }) : column.disabled;
-    const checkProps = isFunction(column.checkProps) ? column.checkProps({ row, rowIndex }) : column.checkProps;
+    const { disabled, checkProps } = getRowSelectDisabledData(p);
     const selectBoxProps = {
       props: {
         checked,
@@ -179,6 +188,18 @@ export default function useRowSelect(
     };
   }
 
+  const onInnerSelectRowClick: TdPrimaryTableProps['onRowClick'] = ({ row, index }) => {
+    const selectedColIndex = props.columns.findIndex((item) => item.colKey === 'row-select');
+    const { disabled } = getRowSelectDisabledData({
+      row,
+      rowIndex: index,
+      col: props.columns[selectedColIndex],
+      colIndex: selectedColIndex,
+    });
+    if (disabled) return;
+    handleSelectChange(row);
+  };
+
   watch(
     () => [[...data.value], rowKey],
     () => {
@@ -194,5 +215,6 @@ export default function useRowSelect(
     currentPaginateData,
     setTSelectedRowKeys,
     formatToRowSelectColumn,
+    onInnerSelectRowClick,
   };
 }

--- a/src/table/hooks/useSorter.tsx
+++ b/src/table/hooks/useSorter.tsx
@@ -1,5 +1,5 @@
 import {
-  SetupContext, computed, toRefs, ref,
+  SetupContext, computed, toRefs, ref, watch,
 } from '@vue/composition-api';
 import { CreateElement } from 'vue';
 import isFunction from 'lodash/isFunction';
@@ -19,6 +19,7 @@ export default function useSorter(props: TdPrimaryTableProps, { emit, slots }: S
   const [tData, setTData] = useDefaultValue(data, [], props.onDataChange, 'data', 'data-change');
   // 本地数据排序：用于记录哪些字段是自定义排序函数
   const sorterFuncMap = computed(() => getSorterFuncMap(props.columns));
+  const innerSort = ref<SortInfo | SortInfo[]>();
 
   const sortArray = computed<Array<SortInfo>>(() => {
     const sort = tSortInfo.value;
@@ -97,10 +98,10 @@ export default function useSorter(props: TdPrimaryTableProps, { emit, slots }: S
     const currentData = newData || tData.value;
     const currentDataSource = currentData;
     setTSortInfo(sortInfo, { currentDataSource, col });
-
     props.onChange?.({ sorter: sortInfo }, { currentData, trigger: 'sorter' });
     // Vue3 ignore next line
     emit('change', { sorter: sortInfo }, { currentData, col, trigger: 'sorter' });
+    innerSort.value = sortInfo;
   }
 
   function getSortOrder(descending: boolean) {
@@ -152,6 +153,35 @@ export default function useSorter(props: TdPrimaryTableProps, { emit, slots }: S
       />
     );
   }
+
+  const isSortInfoSame = (a: SortInfo | SortInfo[], b: SortInfo | SortInfo[]) => {
+    const tmpSortInfo = Array.isArray(a) ? a : [a];
+    const tmpInnerSortInfo = Array.isArray(b) ? b : [b];
+    if (tmpSortInfo.length && !b) return false;
+    // eslint-disable-next-line
+    for (let i = 0, len = tmpSortInfo.length; i < len; i++) {
+      const item = tmpSortInfo[i];
+      const result = tmpInnerSortInfo.find((t) => t.sortBy === item.sortBy);
+      if (!result) return false;
+      return item.descending === result.descending;
+    }
+  };
+
+  /**
+   * 如果外部的排序不为空，且和内部排序字段不同，说明传入的 sortInfo 和 data 可能存在不一致，
+   * 此时，需要在组件内部进行排序，并输出事件
+   */
+  watch(
+    tSortInfo,
+    () => {
+      if (!tSortInfo.value) return;
+      // isSortInfoSame 的两个参数顺序不可变
+      if (!isSortInfoSame(tSortInfo.value, innerSort.value)) {
+        handleDataSort(tSortInfo.value);
+      }
+    },
+    { immediate: true },
+  );
 
   return {
     renderSortIcon,

--- a/src/table/primary-table-props.ts
+++ b/src/table/primary-table-props.ts
@@ -34,7 +34,6 @@ export default {
   /** 列配置功能中，当前显示的列 */
   displayColumns: {
     type: Array as PropType<TdPrimaryTableProps['displayColumns']>,
-    default: undefined,
   },
   /** 列配置功能中，当前显示的列，非受控属性 */
   defaultDisplayColumns: {
@@ -74,7 +73,7 @@ export default {
   /** 展开行 */
   expandedRowKeys: {
     type: Array as PropType<TdPrimaryTableProps['expandedRowKeys']>,
-    default: undefined,
+    default: (): TdPrimaryTableProps['expandedRowKeys'] => [],
   },
   /** 展开行，非受控属性 */
   defaultExpandedRowKeys: {
@@ -92,7 +91,6 @@ export default {
   /** 过滤数据的值 */
   filterValue: {
     type: Object as PropType<TdPrimaryTableProps['filterValue']>,
-    default: undefined,
   },
   /** 过滤数据的值，非受控属性 */
   defaultFilterValue: {
@@ -111,10 +109,12 @@ export default {
     type: Boolean,
     default: true,
   },
+  /** 是否在点击整行时选中 */
+  selectOnRowClick: Boolean,
   /** 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制 */
   selectedRowKeys: {
     type: Array as PropType<TdPrimaryTableProps['selectedRowKeys']>,
-    default: undefined,
+    default: (): TdPrimaryTableProps['selectedRowKeys'] => [],
   },
   /** 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制，非受控属性 */
   defaultSelectedRowKeys: {
@@ -126,7 +126,6 @@ export default {
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序 */
   sort: {
     type: [Object, Array] as PropType<TdPrimaryTableProps['sort']>,
-    default: undefined,
   },
   /** 排序控制。sortBy 排序字段；descending 是否进行降序排列。值为数组时，表示正进行多字段排序，非受控属性 */
   defaultSort: {

--- a/src/table/primary-table.tsx
+++ b/src/table/primary-table.tsx
@@ -37,6 +37,7 @@ const OMIT_PROPS = [
   'multipleSort',
   'expandIcon',
   'reserveSelectedRowOnPaginate',
+  'selectOnRowClick',
   'onChange',
   'onAsyncLoadingClick',
   'onChange',
@@ -77,11 +78,12 @@ export default defineComponent({
     const { renderSortIcon } = useSorter(props, context);
     // 行选中功能
     const {
-      selectedRowClassNames, currentPaginateData, formatToRowSelectColumn, setTSelectedRowKeys,
-    } = useRowSelect(
-      props,
-      tableSelectedClasses,
-    );
+      selectedRowClassNames,
+      currentPaginateData,
+      formatToRowSelectColumn,
+      setTSelectedRowKeys,
+      onInnerSelectRowClick,
+    } = useRowSelect(props, tableSelectedClasses);
     // 过滤功能
     const {
       hasEmptyCondition,
@@ -258,6 +260,11 @@ export default defineComponent({
       }
     };
 
+    const onInnerRowClick: TdPrimaryTableProps['onRowClick'] = (context) => {
+      onInnerExpandRowClick(context);
+      onInnerSelectRowClick(context);
+    };
+
     return {
       tColumns,
       showExpandedRow,
@@ -274,6 +281,7 @@ export default defineComponent({
       renderColumnController,
       renderExpandedRow,
       onInnerExpandRowClick,
+      onInnerRowClick,
       renderFirstFilterRow,
       renderAsyncLoading,
       onInnerPageChange,
@@ -348,8 +356,8 @@ export default defineComponent({
       ...this.getListener(),
       'page-change': this.onInnerPageChange,
     };
-    if (this.expandOnRowClick) {
-      on['row-click'] = this.onInnerExpandRowClick;
+    if (this.expandOnRowClick || this.selectOnRowClick) {
+      on['row-click'] = this.onInnerRowClick;
     }
     on.LeafColumnsChange = this.setDragSortColumns;
     // replace `scopedSlots={this.$scopedSlots}` of `v-slots={this.$slots}` in Vue3

--- a/src/table/table.en-US.md
+++ b/src/table/table.en-US.md
@@ -124,6 +124,7 @@ hideSortTips | Boolean | - | hide sort tips | N
 indeterminateSelectedRowKeys | Array | - | indeterminate selected row keys, row key is from data[rowKey]。Typescript：`Array<string \| number>` | N
 multipleSort | Boolean | false | support multiple column fields sort | N
 reserveSelectedRowOnPaginate | Boolean | true | \- | N
+selectOnRowClick | Boolean | - | select row data on row click | N
 selectedRowKeys | Array | [] | selected row keys, row key is from data[rowKey]。`.sync` is supported。Typescript：`Array<string \| number>` | N
 defaultSelectedRowKeys | Array | [] | selected row keys, row key is from data[rowKey]。uncontrolled property。Typescript：`Array<string \| number>` | N
 showSortColumnBgColor | Boolean | false | column shows sort bg color | N
@@ -250,6 +251,7 @@ name | type | default | description | required
 component | Slot / Function | - | Typescript：`ComponentType`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 confirmEvents | Array | - | Typescript：`string[]` | N
 list | Array | - | Typescript：`Array<OptionData>`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+popupProps | Object | - | Typescript：`PopupProps`，[Popup API Documents](./popup?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 props | Array | - | Typescript：`FilterProps` `type FilterProps = RadioProps \| CheckboxProps \| InputProps \| { [key: string]: any }`，[Input API Documents](./input?tab=api)。[see more ts definition](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 resetValue | \- | - | Typescript：`any` | N
 showConfirmAndReset | Boolean | false | \- | N

--- a/src/table/table.md
+++ b/src/table/table.md
@@ -124,6 +124,7 @@ hideSortTips | Boolean | - | 隐藏排序文本提示，支持全局配置 `Glob
 indeterminateSelectedRowKeys | Array | - | 半选状态行。选中行请更为使用 `selectedRowKeys` 控制。TS 类型：`Array<string \| number>` | N
 multipleSort | Boolean | false | 是否支持多列排序 | N
 reserveSelectedRowOnPaginate | Boolean | true | 行选中功能，是否在分页时保留上一页选中结果不清空，本地数据分页场景下，会全选所有页数据。值为 `false` 则表示全部选中操作停留在当前页，不跨分页；本地数据分页场景下，全选仅选中当前页 | N
+selectOnRowClick | Boolean | - | 是否在点击整行时选中 | N
 selectedRowKeys | Array | [] | 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制。支持语法糖 `.sync`。TS 类型：`Array<string \| number>` | N
 defaultSelectedRowKeys | Array | [] | 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制。非受控属性。TS 类型：`Array<string \| number>` | N
 showSortColumnBgColor | Boolean | false | 当前排序列是否显示背景色 | N
@@ -250,6 +251,7 @@ rowIndex | Number | - | 必需。表格行下标，值为 `-1` 标识当前行�
 component | Slot / Function | - | 用于自定义筛选器，只要保证自定义筛选器包含 value 属性 和 change 事件，即可像内置筛选器一样正常使用。示例：`component: DatePicker`。TS 类型：`ComponentType`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 confirmEvents | Array | - | 哪些事件触发后会进行过滤搜索（确认按钮无需配置，会默认触发搜索）。输入框组件示例：`confirmEvents: ['onEnter']`。TS 类型：`string[]` | N
 list | Array | - | 用于配置当前筛选器可选值有哪些，仅当 `filter.type` 等于 `single` 或 `multiple` 时有效。TS 类型：`Array<OptionData>`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+popupProps | Object | - | 透传 Popup 组件全部属性到筛选器浮层。TS 类型：`PopupProps`，[Popup API Documents](./popup?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 props | Array | - | 用于透传筛选器属性，可以对筛选器进行任何原组件支持的属性配置。TS 类型：`FilterProps` `type FilterProps = RadioProps \| CheckboxProps \| InputProps \| { [key: string]: any }`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/table/type.ts) | N
 resetValue | \- | - | 重置时设置的值，示例：'' 或 []。TS 类型：`any` | N
 showConfirmAndReset | Boolean | false | 是否显示重置和确认。值为真，过滤事件（filter-change）会在确定时触发；值为假，则数据变化时会立即触发过滤事件 | N

--- a/src/table/type.ts
+++ b/src/table/type.ts
@@ -12,6 +12,7 @@ import { CheckboxGroupValue } from '../checkbox';
 import { SortableEvent, SortableOptions } from 'sortablejs';
 import { CheckboxProps } from '../checkbox';
 import { RadioProps } from '../radio';
+import { PopupProps } from '../popup';
 import { InputProps } from '../input';
 import { ButtonProps } from '../button';
 import { CheckboxGroupProps } from '../checkbox';
@@ -437,6 +438,10 @@ export interface TdPrimaryTableProps<T extends TableRowData = TableRowData>
    */
   reserveSelectedRowOnPaginate?: boolean;
   /**
+   * 是否在点击整行时选中
+   */
+  selectOnRowClick?: boolean;
+  /**
    * 选中行，控制属性。半选状态行请更为使用 `indeterminateSelectedRowKeys` 控制
    * @default []
    */
@@ -732,6 +737,10 @@ export interface TableColumnFilter {
    * 用于配置当前筛选器可选值有哪些，仅当 `filter.type` 等于 `single` 或 `multiple` 时有效
    */
   list?: Array<OptionData>;
+  /**
+   * 透传 Popup 组件全部属性到筛选器浮层
+   */
+  popupProps?: PopupProps;
   /**
    * 用于透传筛选器属性，可以对筛选器进行任何原组件支持的属性配置
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Table): 可筛选表格，新增 `filter.popupProps` ，支持透传 Popup 组件全部属性，[tdesign-vue-next#2088](https://github.com/Tencent/tdesign-vue-next/issues/2088)
- feat(Table): 选中行表格，新增 `selectOnRowClick`，支持点击行选中，[tdesign-vue-next#1954](https://github.com/Tencent/tdesign-vue-next/issues/1954)
- feat(Table): 本地排序功能，支持对默认数据进行排序
- refactor(Radio): `click` 事件更为从最外层输出，否则会出现无法在外层阻止冒泡问题
- refactor(Checkbox): `click` 事件更为从最外层输出，否则会出现无法在外层阻止冒泡问题


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
