### PR TITLE
fix: text auto height in IME

### DIFF
--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -41,6 +41,7 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
       focused: false,
       mouseHover: false,
       textareaStyle: {},
+      isComposing: false,
     };
   },
 
@@ -131,10 +132,13 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
       textArea?.blur();
     },
     handleInput(e: any): void {
-      if (e.isComposing || e.inputType === 'insertCompositionText') return;
       this.inputValueChangeHandle(e);
     },
+    onCompositionstart() {
+      this.isComposing = true;
+    },
     onCompositionend(e: InputEvent) {
+      this.isComposing = false;
       this.inputValueChangeHandle(e);
     },
     inputValueChangeHandle(e: InputEvent) {
@@ -146,7 +150,8 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
         val = typeof stringInfo === 'object' && stringInfo.characters;
       }
       this.$emit('input', val);
-      this.emitEvent('change', val, { e });
+      // 中文输入时不触发 onChange
+      !this.isComposing && this.emitEvent('change', val, { e });
 
       this.$nextTick(() => this.setInputValue(val));
       this.adjustTextareaHeight();
@@ -208,6 +213,7 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
       <div class={this.textareaClasses}>
         <textarea
           onInput={this.handleInput}
+          onCompositionstart={this.onCompositionstart}
           onCompositionend={this.onCompositionend}
           {...{ attrs: { ...this.$attrs, ...this.inputAttrs }, on: inputEvents }}
           value={this.value}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/1852

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TextArea): 修复中文输入法等 IME 情况下，`autosize` 计算失效的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
