### PR TITLE
fix: stackblitz less dependency error

### DIFF
--- a/site/src/components/stackblitz/content.js
+++ b/site/src/components/stackblitz/content.js
@@ -80,6 +80,7 @@ export const packageJSONContent = JSON.stringify(
     },
     devDependencies: {
       vite: orgPkg.devDependencies.vite,
+      less: orgPkg.devDependencies.less,
       'vite-plugin-vue2': orgPkg.devDependencies['vite-plugin-vue2'],
       'vue-template-compiler': orgPkg.devDependencies['vue-template-compiler'],
     },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

部分组件 demo 中使用了 less
<img width="374" alt="image" src="https://user-images.githubusercontent.com/7600149/210351439-ace3acc6-a93c-437b-8efc-0bfcb58a5e84.png">

但没有在 stackblitz 的 demo 中引入 less 依赖，导致打开例子时报错：
<img width="1349" alt="image" src="https://user-images.githubusercontent.com/7600149/210351687-d8c3f578-6cf0-4e8f-b11d-ec5b9c025950.png">


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- stackblitz 添加 less 依赖，防止 demo 中使用 less 维护样式打开报错的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
