### PR TITLE
[Upload] fix upload put into form width when theme=single-input

### DIFF
--- a/src/upload/themes/normal-file.tsx
+++ b/src/upload/themes/normal-file.tsx
@@ -1,4 +1,4 @@
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import {
   CloseIcon as TdCloseIcon,
   TimeFilledIcon as TdTimeFilledIcon,
@@ -36,9 +36,12 @@ const NormalFile = defineComponent({
       CloseCircleFilledIcon: TdCloseCircleFilledIcon,
     });
 
-    const uploadPrefix = `${props.classPrefix}-upload`;
+    const uploadPrefix = computed(() => `${props.classPrefix}-upload`);
+
+    const classes = computed(() => [`${uploadPrefix.value}__single`, `${uploadPrefix.value}__single-${props.theme}`]);
 
     return {
+      classes,
       uploadPrefix,
       icons,
     };
@@ -138,10 +141,9 @@ const NormalFile = defineComponent({
   },
 
   render() {
-    const classes = [`${this.uploadPrefix}__single`, `${this.uploadPrefix}__single-${this.theme}`];
     const fileListDisplay = renderTNodeJSX(this, 'fileListDisplay', { params: { files: this.displayFiles } });
     return (
-      <div class={classes}>
+      <div class={this.classes}>
         {this.theme === 'file-input' && this.renderFilePreviewAsInput()}
 
         {this.$scopedSlots.default?.(null)}

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -72,10 +72,18 @@ export default defineComponent({
       },
     }));
 
+    const uploadClasses = computed(() => [
+      `${classPrefix.value}-upload`,
+      {
+        [`${classPrefix.value}-upload--theme-${props.theme}`]: props.theme === 'file-input',
+      },
+    ]);
+
     return {
       ...uploadData,
       commonDisplayFileProps,
       dragProps,
+      uploadClasses,
     };
   },
 
@@ -190,7 +198,7 @@ export default defineComponent({
 
   render() {
     return (
-      <div class={`${this.classPrefix}-upload`}>
+      <div class={this.uploadClasses}>
         <input
           ref="inputRef"
           type="file"


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
https://github.com/Tencent/tdesign-vue/issues/1925

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Upload): 上传组件的输入框模式在 Form 表单中的宽度问题修复

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
