### PR TITLE
fix(dialog): destroy dialog immediately beforeDestroy

### DIFF
--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -206,7 +206,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
 
   beforeDestroy() {
     this.addKeyboardEvent(false);
-    this.clearStyleFunc();
+    this.destroySelf();
   },
 
   directives: {
@@ -217,9 +217,14 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
     clearStyleFunc() {
       clearTimeout(this.timer);
       this.timer = setTimeout(() => {
-        this.styleEl.parentNode?.removeChild?.(this.styleEl);
+        this.destroySelf();
       }, 150);
     },
+
+    destroySelf() {
+      this.styleEl.parentNode?.removeChild?.(this.styleEl);
+    },
+
     storeUid(flag: boolean) {
       if (flag) {
         stack.push(this.uid);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 组件销毁前立即移除当前节点，不需要 `setTimeout` 等待时间

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
