### PR TITLE
fix(tree-select): trigger onblur exclude expand icon

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -171,7 +171,7 @@ export default defineComponent({
       trigger: TreeSelectValueChangeTrigger,
     ) => {
       setTreeSelectValue(valueParam, { node, trigger });
-      setInnerInputValue('');
+      if (props.filterable && innerInputValue) setInnerInputValue('');
       changeNodeInfo();
     };
 

--- a/src/tree/hooks/useItemEvents.ts
+++ b/src/tree/hooks/useItemEvents.ts
@@ -1,7 +1,6 @@
 import { SetupContext } from '@vue/composition-api';
 import { usePrefixClass } from '../../hooks/useConfig';
 import { TypeTreeItemProps, TypeEventState } from '../interface';
-
 // 这里封装 tree-item 的一般事件
 // 拖动事件，虚拟滚动事件不要安排到这里
 export default function useItemEvents(props: TypeTreeItemProps, context: SetupContext) {
@@ -19,11 +18,6 @@ export default function useItemEvents(props: TypeTreeItemProps, context: SetupCo
   };
 
   let clicked = false;
-
-  const handleMousedown = (evt: MouseEvent) => {
-    // 在mousedown阶段阻止冒泡 应用于处理如展开阻止下拉框失焦等场景
-    evt.preventDefault();
-  };
 
   const handleClick = (evt: MouseEvent) => {
     const { expandOnClickNode } = props;
@@ -56,6 +50,5 @@ export default function useItemEvents(props: TypeTreeItemProps, context: SetupCo
   return {
     handleChange,
     handleClick,
-    handleMousedown,
   };
 }

--- a/src/tree/hooks/useRenderIcon.tsx
+++ b/src/tree/hooks/useRenderIcon.tsx
@@ -19,6 +19,11 @@ export default function useRenderIcon(props: TypeTreeItemProps) {
     return <CaretRightSmallIcon />;
   };
 
+  const handleMousedown = (evt: MouseEvent) => {
+    // 在点击展开按钮 mousedown阶段 阻止冒泡 应用于处理如展开阻止下拉框失焦等场景
+    evt.preventDefault();
+  };
+
   const renderIcon = (h: CreateElement) => {
     const { node, treeScope } = props;
     const { scopedSlots } = treeScope;
@@ -57,6 +62,7 @@ export default function useRenderIcon(props: TypeTreeItemProps) {
         ]}
         trigger="expand"
         ignore="active"
+        onmousedown={handleMousedown}
       >
         {iconNode}
       </span>

--- a/src/tree/hooks/useTreeItem.tsx
+++ b/src/tree/hooks/useTreeItem.tsx
@@ -15,7 +15,7 @@ export default function useTreeItem(props: TypeTreeItemProps, context: SetupCont
   const classPrefix = usePrefixClass().value;
   const componentName = usePrefixClass('tree').value;
 
-  const { handleClick, handleMousedown } = useItemEvents(props, context);
+  const { handleClick } = useItemEvents(props, context);
   const { renderIcon } = useRenderIcon(props);
   const { renderLabel } = useRenderLabel(props, context);
   const { renderLine } = useRenderLine(props);
@@ -107,7 +107,6 @@ export default function useTreeItem(props: TypeTreeItemProps, context: SetupCont
         data-value={value}
         data-level={level}
         style={styles}
-        onMousedown={handleMousedown}
         onClick={(evt: MouseEvent) => handleClick(evt)}
         draggable={node.isDraggable()}
         onDragstart={(evt: DragEvent) => handleDragStart(evt)}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree-select): 修复单选下选中值后没有触发onblur的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
