### PR TITLE
[TreeSelect] fix can not show popup at first click; fix treeProps.keys does not work

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -124,6 +124,7 @@ export default defineComponent({
         class={`${this.classPrefix}-tree-select`}
         {...{
           props: {
+            keys: this.tKeys,
             value: this.nodeInfo,
             inputValue: this.innerInputValue,
             popupVisible: this.innerVisible,

--- a/src/tree-select/useTreeSelect.ts
+++ b/src/tree-select/useTreeSelect.ts
@@ -267,10 +267,6 @@ export default function useTreeSelect(props: TdTreeSelectProps, context: SetupCo
   const onInnerFocus: SelectInputProps['onFocus'] = (_, ctx) => {
     props.onFocus?.({ value: treeSelectValue.value, e: ctx.e });
     context.emit('focus', { value: treeSelectValue.value, e: ctx.e });
-    // open popup on focus, used for keyboard event
-    if (innerVisible.value !== true) {
-      setInnerVisible(true, { ...ctx, trigger: 'trigger-element-focus' });
-    }
   };
 
   const onInnerBlur: SelectInputProps['onBlur'] = (_, ctx) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TreeSelect): 修复第一次点击无法显示下拉框问题，[issue#2123](https://github.com/Tencent/tdesign-vue/issues/2123)
- fix(TreeSelect): 修复 `treeProps.keys` 无效问题（仅 1.1.0 有这个问题）

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
