### PR TITLE
[TreeSelect] support tree.keys

### DIFF
--- a/src/tree-select/__tests__/mount.jsx
+++ b/src/tree-select/__tests__/mount.jsx
@@ -61,3 +61,26 @@ export function getTreeSelectMultipleMount(TreeSelect, props, events) {
     { attachTo: '#focus-dom' },
   );
 }
+
+const OPTIONS1 = [
+  { name: 'tdesign-vue', key: 1 },
+  {
+    name: 'tdesign-react',
+    key: 2,
+    children: [
+      { name: 'tdesign-web-react', key: '2.1' },
+      { name: 'tdesign-mobile-react', key: '2.2' },
+    ],
+  },
+  { name: 'tdesign-miniprogram', key: 3 },
+];
+
+// test keys and treeProps.keys
+export function getTreeSelectKeysMount(TreeSelect, props, events) {
+  const value = [1];
+  return mount({
+    render() {
+      return <TreeSelect value={value} data={OPTIONS1} props={props} on={events}></TreeSelect>;
+    },
+  });
+}

--- a/src/tree-select/__tests__/vitest-tree-select.test.jsx
+++ b/src/tree-select/__tests__/vitest-tree-select.test.jsx
@@ -14,9 +14,13 @@ import {
   simulateInputEnter,
 } from '@test/utils';
 import { TreeSelect } from '..';
-import { getTreeSelectDefaultMount, getTreeSelectMultipleMount } from './mount';
+import { getTreeSelectDefaultMount, getTreeSelectMultipleMount, getTreeSelectKeysMount } from './mount';
 
 describe('TreeSelect Component', () => {
+  afterEach(() => {
+    document.querySelectorAll('.t-popup').forEach((node) => node?.remove());
+  });
+
   it('props.autofocus is equal to false', () => {
     const wrapper = mount({
       render() {
@@ -74,7 +78,6 @@ describe('TreeSelect Component', () => {
   it('props.clearable: show clear icon on mouse enter in single tree select', async () => {
     const wrapper = getTreeSelectDefaultMount(TreeSelect, { value: 1, clearable: true });
     wrapper.find('.t-input').trigger('mouseenter');
-    await wrapper.vm.$nextTick();
     await mockDelay(0);
     expect(wrapper.find('.t-input__suffix-clear').exists()).toBeTruthy();
   });
@@ -191,8 +194,6 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const tSelectEmptyDom = document.querySelector('.t-select__empty');
     expect(tSelectEmptyDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    tSelectEmptyDom?.remove();
   });
 
   it('props.disabled works fine', () => {
@@ -234,7 +235,6 @@ describe('TreeSelect Component', () => {
   it('props.disabled: cant not show clear icon on mouse enter in single tree select', async () => {
     const wrapper = getTreeSelectDefaultMount(TreeSelect, { value: 1, disabled: true });
     wrapper.find('.t-input').trigger('mouseenter');
-    await wrapper.vm.$nextTick();
     await mockDelay(0);
     expect(wrapper.find('.t-input__suffix-clear').exists()).toBeFalsy();
   });
@@ -256,8 +256,6 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const customNodeDom = document.querySelector('.custom-node');
     expect(customNodeDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    customNodeDom?.remove();
   });
 
   it('slots.empty works fine', async () => {
@@ -270,8 +268,6 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const customNodeDom = document.querySelector('.custom-node');
     expect(customNodeDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    customNodeDom?.remove();
   });
 
   it('props.filter: multiple tree select & filterable', async () => {
@@ -282,12 +278,9 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const inputDom1 = wrapper.find('input').element;
     simulateInputChange(inputDom1, 'tdesign-react');
-    await wrapper.vm.$nextTick();
     await mockDelay(100);
     const tTreeItemNotTTreeItemHiddenDom = document.querySelectorAll('.t-tree__item:not(.t-tree__item--hidden)');
     expect(tTreeItemNotTTreeItemHiddenDom.length).toBe(1);
-    // remove nodes from document to avoid influencing following test cases
-    tTreeItemNotTTreeItemHiddenDom.forEach((node) => node.remove());
     document.querySelectorAll('.t-popup').forEach((node) => node.remove());
   });
 
@@ -300,12 +293,9 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const inputDom1 = wrapper.find('input').element;
     simulateInputChange(inputDom1, 'tdesign-react');
-    await wrapper.vm.$nextTick();
     await mockDelay(100);
     const tTreeItemNotTTreeItemHiddenDom = document.querySelectorAll('.t-tree__item:not(.t-tree__item--hidden)');
     expect(tTreeItemNotTTreeItemHiddenDom.length).toBe(6);
-    // remove nodes from document to avoid influencing following test cases
-    tTreeItemNotTTreeItemHiddenDom.forEach((node) => node.remove());
     document.querySelectorAll('.t-popup').forEach((node) => node.remove());
   });
 
@@ -315,7 +305,6 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const inputDom1 = wrapper.find('input').element;
     simulateInputChange(inputDom1, 'tdesign-vue');
-    await wrapper.vm.$nextTick();
     await mockDelay(100);
     document.querySelector('.t-tree__item:first-child').click();
     await wrapper.vm.$nextTick();
@@ -329,7 +318,6 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const inputDom1 = wrapper.find('input').element;
     simulateInputChange(inputDom1, 'tdesign-vue');
-    await wrapper.vm.$nextTick();
     await mockDelay(100);
     document.querySelector('.t-tree__item:first-child').click();
     await wrapper.vm.$nextTick();
@@ -345,12 +333,9 @@ describe('TreeSelect Component', () => {
   it('props.filterable works fine', async () => {
     const wrapper = getTreeSelectDefaultMount(TreeSelect, { inputValue: 'tdesign-vue', filterable: true });
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(100);
     const tTreeItemNotTTreeItemHiddenDom = document.querySelectorAll('.t-tree__item:not(.t-tree__item--hidden)');
     expect(tTreeItemNotTTreeItemHiddenDom.length).toBe(1);
-    // remove nodes from document to avoid influencing following test cases
-    tTreeItemNotTTreeItemHiddenDom.forEach((node) => node.remove());
     document.querySelectorAll('.t-popup').forEach((node) => node.remove());
   });
 
@@ -399,6 +384,94 @@ describe('TreeSelect Component', () => {
     expect(onInputChangeFn.mock.calls[0][1].trigger).toBe('input');
   });
 
+  it('props.keys: single tree select, keys works fined', async () => {
+    getTreeSelectKeysMount(TreeSelect, {
+      keys: { label: 'name', value: 'key' },
+      popupVisible: true,
+      treeProps: { expandAll: true },
+      popupProps: { overlayClassName: 'singleTreeSelectKeys' },
+    });
+    await mockDelay(200);
+    const singleTreeSelectKeysTTreeItemDom = document.querySelector('.singleTreeSelectKeys .t-tree__item');
+    expect(singleTreeSelectKeysTTreeItemDom.textContent).toBe('tdesign-vue');
+    const singleTreeSelectKeysTTreeItemNthChild2Dom = document.querySelector(
+      '.singleTreeSelectKeys .t-tree__item:nth-child(2)',
+    );
+    expect(singleTreeSelectKeysTTreeItemNthChild2Dom.textContent).toBe('tdesign-react');
+    const singleTreeSelectKeysTTreeItemNthChild3Dom = document.querySelector(
+      '.singleTreeSelectKeys .t-tree__item:nth-child(3)',
+    );
+    expect(singleTreeSelectKeysTTreeItemNthChild3Dom.textContent).toBe('tdesign-web-react');
+    const singleTreeSelectKeysTTreeItemLastChildDom = document.querySelector(
+      '.singleTreeSelectKeys .t-tree__item:last-child',
+    );
+    expect(singleTreeSelectKeysTTreeItemLastChildDom.textContent).toBe('tdesign-miniprogram');
+  });
+
+  it('props.keys: multiple tree select, keys works fined', async () => {
+    getTreeSelectKeysMount(TreeSelect, {
+      multiple: true,
+      popupVisible: true,
+      keys: { label: 'name', value: 'key' },
+      treeProps: { expandAll: true },
+      popupProps: { overlayClassName: 'multipleTreeSelectKeys' },
+    });
+    await mockDelay(200);
+    const multipleTreeSelectKeysTTreeItemDom = document.querySelector('.multipleTreeSelectKeys .t-tree__item');
+    expect(multipleTreeSelectKeysTTreeItemDom.textContent).toBe('tdesign-vue');
+    const multipleTreeSelectKeysTTreeItemNthChild2Dom = document.querySelector(
+      '.multipleTreeSelectKeys .t-tree__item:nth-child(2)',
+    );
+    expect(multipleTreeSelectKeysTTreeItemNthChild2Dom.textContent).toBe('tdesign-react');
+    const multipleTreeSelectKeysTTreeItemNthChild3Dom = document.querySelector(
+      '.multipleTreeSelectKeys .t-tree__item:nth-child(3)',
+    );
+    expect(multipleTreeSelectKeysTTreeItemNthChild3Dom.textContent).toBe('tdesign-web-react');
+    const multipleTreeSelectKeysTTreeItemLastChildDom = document.querySelector(
+      '.multipleTreeSelectKeys .t-tree__item:last-child',
+    );
+    expect(multipleTreeSelectKeysTTreeItemLastChildDom.textContent).toBe('tdesign-miniprogram');
+  });
+
+  it('props.keys: single tree select, change event works fine', async () => {
+    const onChangeFn = vi.fn();
+    const wrapper = getTreeSelectKeysMount(
+      TreeSelect,
+      {
+        value: 1,
+        popupVisible: true,
+        treeProps: { expandAll: true, keys: { label: 'name', value: 'key' } },
+        popupProps: { overlayClassName: 'keysPropsSingle' },
+      },
+      { change: onChangeFn },
+    );
+    await mockDelay(200);
+    document.querySelector('.keysPropsSingle .t-tree__item:last-child').click();
+    await wrapper.vm.$nextTick();
+    expect(onChangeFn).toHaveBeenCalled();
+    expect(onChangeFn.mock.calls[0][0]).toBe(3);
+  });
+
+  it('props.keys: multiple tree select, change event works fine', async () => {
+    const onChangeFn = vi.fn();
+    const wrapper = getTreeSelectKeysMount(
+      TreeSelect,
+      {
+        value: [1],
+        multiple: true,
+        popupVisible: true,
+        treeProps: { expandAll: true, keys: { label: 'name', value: 'key' } },
+        popupProps: { overlayClassName: 'keysPropsMultiple' },
+      },
+      { change: onChangeFn },
+    );
+    await mockDelay(200);
+    document.querySelector('.keysPropsMultiple .t-tree__item:last-child .t-checkbox__label').click();
+    await wrapper.vm.$nextTick();
+    expect(onChangeFn).toHaveBeenCalled();
+    expect(onChangeFn.mock.calls[0][0]).toEqual([1, 3]);
+  });
+
   it('props.loading: TreeSelect contains element `.t-loading`', () => {
     // loading default value is false
     const wrapper = mount({
@@ -433,12 +506,8 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const customNodeDom = document.querySelector('.custom-node');
     expect(customNodeDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    customNodeDom?.remove();
     const tSelectLoadingTipsDom = document.querySelector('.t-select__loading-tips');
     expect(tSelectLoadingTipsDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    tSelectLoadingTipsDom?.remove();
   });
 
   it('slots.loadingText works fine', async () => {
@@ -456,12 +525,8 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const customNodeDom = document.querySelector('.custom-node');
     expect(customNodeDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    customNodeDom?.remove();
     const tSelectLoadingTipsDom = document.querySelector('.t-select__loading-tips');
     expect(tSelectLoadingTipsDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    tSelectLoadingTipsDom?.remove();
   });
   it('slots.loading-text works fine', async () => {
     const wrapper = mount({
@@ -478,12 +543,8 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const customNodeDom = document.querySelector('.custom-node');
     expect(customNodeDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    customNodeDom?.remove();
     const tSelectLoadingTipsDom = document.querySelector('.t-select__loading-tips');
     expect(tSelectLoadingTipsDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    tSelectLoadingTipsDom?.remove();
   });
 
   it('props.loadingText: loading status show loading text in panel', async () => {
@@ -496,15 +557,12 @@ describe('TreeSelect Component', () => {
     await wrapper.vm.$nextTick();
     const tSelectLoadingTipsDom = document.querySelector('.t-select__loading-tips');
     expect(tSelectLoadingTipsDom).toBeTruthy();
-    // remove node in document to avoid influencing following test cases
-    tSelectLoadingTipsDom?.remove();
   });
 
   it('props.max works fine', async () => {
     const onChangeFn1 = vi.fn();
     const wrapper = getTreeSelectMultipleMount(TreeSelect, { max: 2, value: [1, '4'] }, { change: onChangeFn1 });
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(300);
     document.querySelector('.t-popup .t-tree__item:last-child .t-checkbox__label').click();
     await wrapper.vm.$nextTick();
@@ -650,6 +708,92 @@ describe('TreeSelect Component', () => {
     expect(wrapper.findAll('.t-input__tips').length).toBe(1);
   });
 
+  it('props.treeProps: single tree select, treeProps.keys works fined', async () => {
+    getTreeSelectKeysMount(TreeSelect, {
+      popupVisible: true,
+      treeProps: { expandAll: true, keys: { label: 'name', value: 'key' } },
+      popupProps: { overlayClassName: 'singleTreeSelectKeys' },
+    });
+    await mockDelay(200);
+    const singleTreeSelectKeysTTreeItemDom = document.querySelector('.singleTreeSelectKeys .t-tree__item');
+    expect(singleTreeSelectKeysTTreeItemDom.textContent).toBe('tdesign-vue');
+    const singleTreeSelectKeysTTreeItemNthChild2Dom = document.querySelector(
+      '.singleTreeSelectKeys .t-tree__item:nth-child(2)',
+    );
+    expect(singleTreeSelectKeysTTreeItemNthChild2Dom.textContent).toBe('tdesign-react');
+    const singleTreeSelectKeysTTreeItemNthChild3Dom = document.querySelector(
+      '.singleTreeSelectKeys .t-tree__item:nth-child(3)',
+    );
+    expect(singleTreeSelectKeysTTreeItemNthChild3Dom.textContent).toBe('tdesign-web-react');
+    const singleTreeSelectKeysTTreeItemLastChildDom = document.querySelector(
+      '.singleTreeSelectKeys .t-tree__item:last-child',
+    );
+    expect(singleTreeSelectKeysTTreeItemLastChildDom.textContent).toBe('tdesign-miniprogram');
+  });
+
+  it('props.treeProps: multiple tree select, treeProps.keys works fined', async () => {
+    getTreeSelectKeysMount(TreeSelect, {
+      multiple: true,
+      popupVisible: true,
+      treeProps: { expandAll: true, keys: { label: 'name', value: 'key' } },
+      popupProps: { overlayClassName: 'multipleTreeSelectKeys' },
+    });
+    await mockDelay(200);
+    const multipleTreeSelectKeysTTreeItemDom = document.querySelector('.multipleTreeSelectKeys .t-tree__item');
+    expect(multipleTreeSelectKeysTTreeItemDom.textContent).toBe('tdesign-vue');
+    const multipleTreeSelectKeysTTreeItemNthChild2Dom = document.querySelector(
+      '.multipleTreeSelectKeys .t-tree__item:nth-child(2)',
+    );
+    expect(multipleTreeSelectKeysTTreeItemNthChild2Dom.textContent).toBe('tdesign-react');
+    const multipleTreeSelectKeysTTreeItemNthChild3Dom = document.querySelector(
+      '.multipleTreeSelectKeys .t-tree__item:nth-child(3)',
+    );
+    expect(multipleTreeSelectKeysTTreeItemNthChild3Dom.textContent).toBe('tdesign-web-react');
+    const multipleTreeSelectKeysTTreeItemLastChildDom = document.querySelector(
+      '.multipleTreeSelectKeys .t-tree__item:last-child',
+    );
+    expect(multipleTreeSelectKeysTTreeItemLastChildDom.textContent).toBe('tdesign-miniprogram');
+  });
+
+  it('props.treeProps: single tree select, trigger change event to check treeProps.keys', async () => {
+    const onChangeFn = vi.fn();
+    const wrapper = getTreeSelectKeysMount(
+      TreeSelect,
+      {
+        value: 1,
+        popupVisible: true,
+        treeProps: { expandAll: true, keys: { label: 'name', value: 'key' } },
+        popupProps: { overlayClassName: 'treePropsKeysSingle' },
+      },
+      { change: onChangeFn },
+    );
+    await mockDelay(200);
+    document.querySelector('.treePropsKeysSingle .t-tree__item:last-child').click();
+    await wrapper.vm.$nextTick();
+    expect(onChangeFn).toHaveBeenCalled();
+    expect(onChangeFn.mock.calls[0][0]).toBe(3);
+  });
+
+  it('props.treeProps: multiple tree select, trigger change event to check treeProps.keys', async () => {
+    const onChangeFn = vi.fn();
+    const wrapper = getTreeSelectKeysMount(
+      TreeSelect,
+      {
+        value: [1],
+        popupVisible: true,
+        multiple: true,
+        treeProps: { expandAll: true, keys: { label: 'name', value: 'key' } },
+        popupProps: { overlayClassName: 'treePropsKeysMultiple' },
+      },
+      { change: onChangeFn },
+    );
+    await mockDelay(200);
+    document.querySelector('.treePropsKeysMultiple .t-tree__item:last-child .t-checkbox__label').click();
+    await wrapper.vm.$nextTick();
+    expect(onChangeFn).toHaveBeenCalled();
+    expect(onChangeFn.mock.calls[0][0]).toEqual([1, 3]);
+  });
+
   it('props.value is equal to tdesign-vue', () => {
     const wrapper = mount({
       render() {
@@ -691,6 +835,7 @@ describe('TreeSelect Component', () => {
     getTreeSelectMultipleMount(TreeSelect, { valueDisplay: fn, value: 1, data: [{ label: 'tdesign-vue', value: 1 }] });
     expect(fn).toHaveBeenCalled();
     expect(fn.mock.calls[0][1].value).toEqual([{ label: 'tdesign-vue', value: 1 }]);
+    expect(fn.mock.calls[0][1].onClose).toBeTruthy();
   });
   it('slots.valueDisplay: a function with params', () => {
     const fn = vi.fn();
@@ -702,6 +847,7 @@ describe('TreeSelect Component', () => {
 
     expect(fn).toHaveBeenCalled();
     expect(fn.mock.calls[0][0].value).toEqual([{ label: 'tdesign-vue', value: 1 }]);
+    expect(fn.mock.calls[0][0].onClose).toBeTruthy();
   });
 
   it('props.valueType is equal object', () => {
@@ -722,7 +868,6 @@ describe('TreeSelect Component', () => {
       { focus: onFocusFn, blur: onBlurFn1 },
     );
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(100);
     expect(onFocusFn).toHaveBeenCalled();
     expect(onFocusFn.mock.calls[0][0].e.type).toBe('focus');
@@ -759,7 +904,6 @@ describe('TreeSelect Component', () => {
     const onChangeFn1 = vi.fn();
     const wrapper = getTreeSelectDefaultMount(TreeSelect, { treeProps: { expandAll: true } }, { change: onChangeFn1 });
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(200);
     document.querySelector('.t-tree__item:nth-child(3)').click();
     await wrapper.vm.$nextTick();
@@ -775,7 +919,6 @@ describe('TreeSelect Component', () => {
     const onChangeFn1 = vi.fn();
     const wrapper = getTreeSelectMultipleMount(TreeSelect, { treeProps: { expandAll: true } }, { change: onChangeFn1 });
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(200);
     document.querySelector('.t-tree__item:last-child .t-checkbox__label').click();
     await wrapper.vm.$nextTick();
@@ -792,7 +935,6 @@ describe('TreeSelect Component', () => {
     const onChangeFn1 = vi.fn();
     const wrapper = getTreeSelectMultipleMount(TreeSelect, { treeProps: { expandAll: true } }, { change: onChangeFn1 });
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(200);
     document.querySelector('.t-tree__item:first-child .t-checkbox__label').click();
     await wrapper.vm.$nextTick();
@@ -886,7 +1028,6 @@ describe('TreeSelect Component', () => {
       { 'input-change': onInputChangeFn1 },
     );
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(200);
     document.querySelector('.t-tree__item:first-child .t-checkbox__label').click();
     await wrapper.vm.$nextTick();
@@ -903,7 +1044,6 @@ describe('TreeSelect Component', () => {
       { 'popup-visible-change': onPopupVisibleChangeFn },
     );
     wrapper.find('.t-input').trigger('click');
-    await wrapper.vm.$nextTick();
     await mockDelay(200);
     expect(onPopupVisibleChangeFn).toHaveBeenCalled();
     expect(onPopupVisibleChangeFn.mock.calls[0][0]).toBe(true);

--- a/src/tree-select/_example/props.vue
+++ b/src/tree-select/_example/props.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- :keys="treeProps.keys" -->
   <t-tree-select
     :data="options"
     v-model="value"

--- a/src/tree-select/props.ts
+++ b/src/tree-select/props.ts
@@ -50,7 +50,7 @@ export default {
   defaultInputValue: {
     type: [String, Number] as PropType<TdTreeSelectProps['defaultInputValue']>,
   },
-  /** 用来定义 value / label 在 `data` 数据中对应的字段别名 */
+  /** 用来定义 `value / label / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }` */
   keys: {
     type: Object as PropType<TdTreeSelectProps['keys']>,
   },

--- a/src/tree-select/tree-select.md
+++ b/src/tree-select/tree-select.md
@@ -18,7 +18,7 @@ filterable | Boolean | false | 是否可搜索 | N
 inputProps | Object | - | 透传给 输入框 Input 组件的全部属性。TS 类型：`InputProps`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/tree-select/type.ts) | N
 inputValue | String / Number | - | 输入框的值。支持语法糖 `.sync`。TS 类型：`InputValue`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/tree-select/type.ts) | N
 defaultInputValue | String / Number | - | 输入框的值。非受控属性。TS 类型：`InputValue`，[Input API Documents](./input?tab=api)。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/tree-select/type.ts) | N
-keys | Object | - | 用来定义 value / label 在 `data` 数据中对应的字段别名。TS 类型：`TreeKeysType`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+keys | Object | - | 用来定义 `value / label / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }`。TS 类型：`TreeKeysType`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 label | String / Slot / Function | - | 左侧文本。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 loading | Boolean | false | 是否正在加载数据 | N
 loadingText | String / Slot / Function | - | 远程加载时显示的文字，支持自定义。如加上超链接。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -70,8 +70,9 @@ export default defineComponent({
           {!this.loading ? (
             <Tree
               ref="treeRef"
+              key={this.treeKey}
               props={{
-                key: this.treeKey,
+                keys: this.keys,
                 value: [...this.multipleChecked],
                 actived: this.singleActivated,
                 hover: true,

--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -72,7 +72,7 @@ export default defineComponent({
               ref="treeRef"
               key={this.treeKey}
               props={{
-                keys: this.keys,
+                keys: this.tKeys,
                 value: [...this.multipleChecked],
                 actived: this.singleActivated,
                 hover: true,

--- a/src/tree-select/type.ts
+++ b/src/tree-select/type.ts
@@ -76,7 +76,7 @@ export interface TdTreeSelectProps<
    */
   defaultInputValue?: InputValue;
   /**
-   * 用来定义 value / label 在 `data` 数据中对应的字段别名
+   * 用来定义 `value / label / children` 在 `data` 数据中对应的字段别名，示例：`{ value: 'key', label 'name', children: 'list' }`
    */
   keys?: TreeKeysType;
   /**


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(TreeSelect): 支持使用 `keys` 定义字段别名
- test(TreeSelect): 输出 `keys` 和 `treeProps.keys` 测试用例检测 

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
