### PR TITLE
fix(table): fix resizable table width problems

### DIFF
--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -93,7 +93,6 @@ export default defineComponent({
       updateColumnFixedShadow,
       getThWidthList,
       updateThWidthList,
-      setRecalculateColWidthFuncRef,
       addTableResizeObserver,
     } = useFixed(props, context, finalColumns, {
       paginationAffixRef,
@@ -121,11 +120,13 @@ export default defineComponent({
     } = usePagination(props, context);
 
     // 列宽拖拽逻辑
-    const columnResizeParams = useColumnResize(tableContentRef, refreshTable, getThWidthList, updateThWidthList);
-    const {
-      resizeLineRef, resizeLineStyle, recalculateColWidth, setEffectColMap,
-    } = columnResizeParams;
-    setRecalculateColWidthFuncRef(recalculateColWidth);
+    const columnResizeParams = useColumnResize({
+      isWidthOverflow,
+      tableContentRef,
+      getThWidthList,
+      updateThWidthList,
+    });
+    const { resizeLineRef, resizeLineStyle, setEffectColMap } = columnResizeParams;
 
     const dynamicBaseTableClasses = computed(() => [
       tableClasses.value,

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -155,7 +155,7 @@ export default defineComponent({
       return (bottomRect?.height || 0) + (paginationRect?.height || 0);
     });
 
-    const columnResizable = computed(() => props.allowResizeColumnWidth === undefined ? props.resizable : props.allowResizeColumnWidth);
+    const columnResizable = computed(() => props.allowResizeColumnWidth ?? props.resizable);
 
     watch(tableElmRef, () => {
       setUseFixedTableElmRef(tableElmRef.value);

--- a/src/table/base-table.tsx
+++ b/src/table/base-table.tsx
@@ -88,6 +88,7 @@ export default defineComponent({
       rowAndColFixedPosition,
       setData,
       refreshTable,
+      setTableElmWidth,
       emitScrollEvent,
       setUseFixedTableElmRef,
       updateColumnFixedShadow,
@@ -125,6 +126,7 @@ export default defineComponent({
       tableContentRef,
       getThWidthList,
       updateThWidthList,
+      setTableElmWidth,
     });
     const { resizeLineRef, resizeLineStyle, setEffectColMap } = columnResizeParams;
 
@@ -175,18 +177,9 @@ export default defineComponent({
         props.onLeafColumnsChange?.(spansAndLeafNodes.value.leafColumns);
         // Vue3 do not need next line
         context.emit('LeafColumnsChange', spansAndLeafNodes.value.leafColumns);
+        setEffectColMap(spansAndLeafNodes.value.leafColumns, null);
       },
       { immediate: true },
-    );
-
-    watch(
-      thList,
-      () => {
-        setEffectColMap(thList.value[0], null);
-      },
-      {
-        immediate: true,
-      },
     );
 
     const onFixedChange = () => {
@@ -488,9 +481,10 @@ export default defineComponent({
       log.warn('Table', 'allowResizeColumnWidth is going to be deprecated, please use resizable instead.');
     }
 
-    if (this.columnResizable && this.tableLayout === 'auto') {
-      log.warn('Table', 'table-layout can not be `auto` for resizable column table, set `table-layout: fixed` please.');
-    }
+    // already support resize column for table-layout: auto
+    // if (this.columnResizable && this.tableLayout === 'auto') {
+    //   log.warn('Table', 'table-layout can not be `auto` for resizable column table, set `table-layout: fixed` please.');
+    // }
 
     const translate = `translate(0, ${this.virtualConfig.scrollHeight.value}px)`;
     const virtualStyle = {

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -1,34 +1,61 @@
+/**
+ * important info: only resize happened, th width calculating allowed
+ * 验证场景：吸顶表头调整列宽、列数量发生变化、表格未超出、表格已超出
+ */
 import { ref, Ref, reactive } from '@vue/composition-api';
 import isNumber from 'lodash/isNumber';
-import { RecalculateColumnWidthFunc } from '../interface';
 import { BaseTableCol, TableRowData } from '../type';
-import setThWidthListByColumnDrag from '../../_common/js/table/set-column-width-by-drag';
-import recalculateColumnWidth from '../../_common/js/table/recalculate-column-width';
+import { calculateColumnWidth } from '../../_common/js/table/column-resize';
+import { on, off } from '../../utils/dom';
 
 const DEFAULT_MIN_WIDTH = 80;
 const DEFAULT_MAX_WIDTH = 600;
+// 当离右边框的距离不超过 8 时，显示拖拽图标
+const distance = 8;
 
-export default function useColumnResize(
-  tableContentRef: Ref<HTMLDivElement>,
-  refreshTable: () => void,
-  getThWidthList: () => { [colKeys: string]: number },
-  updateThWidthList: (data: { [colKeys: string]: number }) => void,
-) {
+export default function useColumnResize(params: {
+  isWidthOverflow: Ref<boolean>;
+  tableContentRef: Ref<HTMLDivElement>;
+  getThWidthList: (type?: 'default' | 'calculate') => { [colKeys: string]: number };
+  updateThWidthList: (data: { [colKey: string]: number }) => void;
+}) {
+  const {
+    isWidthOverflow, tableContentRef, getThWidthList, updateThWidthList,
+  } = params;
   const resizeLineRef = ref<HTMLDivElement>();
-  const notCalculateWidthCols = ref<string[]>([]);
   const effectColMap = ref<{ [colKey: string]: any }>({});
+  const originalSelectStart = document.onselectstart;
+  const originalDragStart = document.ondragstart;
+
+  const getSiblingResizableCol = (nodes: BaseTableCol<TableRowData>[], index: number, type: 'prev' | 'next') => {
+    let i = index;
+    while (nodes[i] && nodes[i].resizable === false) {
+      if (type === 'next') {
+        i += 1;
+      } else {
+        i -= 1;
+      }
+    }
+    return nodes[i];
+  };
 
   // 递归查找列宽度变化后，受影响的相关列
   const setEffectColMap = (nodes: BaseTableCol<TableRowData>[], parent: BaseTableCol<TableRowData> | null) => {
     if (!nodes) return;
     nodes.forEach((n, index) => {
-      const parentPrevCol = parent ? effectColMap.value[parent.colKey].prev : nodes[index + 1];
-      const parentNextCol = parent ? effectColMap.value[parent.colKey].next : nodes[index - 1];
-      const prev = index === 0 ? parentPrevCol : nodes[index - 1];
-      const next = index === nodes.length - 1 ? parentNextCol : nodes[index + 1];
+      const prevNode = getSiblingResizableCol(nodes, index - 1, 'prev');
+      const nextNode = getSiblingResizableCol(nodes, index + 1, 'next');
+      const parentPrevCol = parent ? effectColMap.value[parent.colKey].prev : nextNode;
+      const parentNextCol = parent ? effectColMap.value[parent.colKey].next : prevNode;
+      const prev = index === 0 ? parentPrevCol : prevNode;
+      const next = index === nodes.length - 1 ? parentNextCol : nextNode;
       effectColMap.value[n.colKey] = {
         prev,
         next,
+        current: {
+          prevSibling: getSiblingResizableCol(nodes, index - 1, 'prev'),
+          nextSibling: getSiblingResizableCol(nodes, index + 1, 'next'),
+        },
       };
       setEffectColMap(n.children, n);
     });
@@ -38,7 +65,8 @@ export default function useColumnResize(
     isDragging: false,
     draggingCol: null as HTMLElement,
     draggingStart: 0,
-    effectCol: null as 'next' | 'prev' | null,
+    // 列宽调整类型：影响右侧列宽度、影响左侧列宽度、或者仅影响自身
+    effectCol: 'next' as 'next' | 'prev',
   };
 
   const resizeLineStyle = reactive({
@@ -48,67 +76,51 @@ export default function useColumnResize(
     bottom: '0',
   });
 
-  const setNotCalculateWidthCols = (colKeys: string[]) => {
-    notCalculateWidthCols.value = colKeys;
-  };
-
-  // 表格列宽拖拽事件
-  // 只在表头显示拖拽图标
+  // 频繁事件，仅用于计算是否在表头显示拖拽鼠标形态
   const onColumnMouseover = (e: MouseEvent, col: BaseTableCol<TableRowData>) => {
-    if (!resizeLineRef.value) return;
-
+    // calculate mouse cursor before drag start
+    if (!resizeLineRef.value || resizeLineParams.isDragging) return;
     const target = (e.target as HTMLElement).closest('th');
     const targetBoundRect = target.getBoundingClientRect();
-    if (!resizeLineParams.isDragging) {
-      // 当离右边框的距离不超过 8 时，显示拖拽图标
-      const distance = 8;
-      if (targetBoundRect.right - e.pageX <= distance) {
-        const colResizable = col.resizable ?? true;
+    if (targetBoundRect.right - e.pageX <= distance) {
+      const colResizable = col.resizable ?? true;
+      if (colResizable) {
+        target.style.cursor = 'col-resize';
+        resizeLineParams.draggingCol = target;
+        resizeLineParams.effectCol = 'next';
+        return;
+      }
+    } else if (e.pageX - targetBoundRect.left <= distance) {
+      const prevEl = target.previousElementSibling;
+      if (prevEl) {
+        const effectPrevCol = effectColMap.value[col.colKey].prev;
+        const colResizable = effectPrevCol.resizable ?? true;
         if (colResizable) {
           target.style.cursor = 'col-resize';
-          resizeLineParams.draggingCol = target;
-          resizeLineParams.effectCol = 'next';
+          resizeLineParams.draggingCol = prevEl as HTMLElement;
+          resizeLineParams.effectCol = 'prev';
           return;
         }
-      } else if (e.pageX - targetBoundRect.left <= distance) {
-        const prevEl = target.previousElementSibling;
-        if (prevEl) {
-          const effectPrevCol = effectColMap.value[col.colKey].prev;
-          const colResizable = effectPrevCol.resizable ?? true;
-          if (colResizable) {
-            target.style.cursor = 'col-resize';
-            resizeLineParams.draggingCol = prevEl as HTMLElement;
-            resizeLineParams.effectCol = 'prev';
-            return;
-          }
-        }
       }
-      // 重置记录值
-      target.style.cursor = '';
-      resizeLineParams.draggingCol = null;
-      resizeLineParams.effectCol = null;
     }
+    // 重置记录值
+    target.style.cursor = '';
+    resizeLineParams.draggingCol = null;
+    resizeLineParams.effectCol = null;
+  };
+
+  const getMinMaxColWidth = (col: BaseTableCol<TableRowData>, effectPrevCol: BaseTableCol<TableRowData>) => {
+    const targetCol = resizeLineParams.effectCol === 'next' ? col : effectPrevCol;
+    const propMinWidth = isNumber(targetCol.minWidth) ? targetCol.minWidth : parseInt(targetCol.minWidth || '0', 10);
+    return {
+      minColWidth: Math.max(targetCol.resize?.minWidth || DEFAULT_MIN_WIDTH, propMinWidth),
+      maxColWidth: targetCol.resize?.maxWidth || DEFAULT_MAX_WIDTH,
+    };
   };
 
   // 调整表格列宽
   const onColumnMousedown = (e: MouseEvent, col: BaseTableCol<TableRowData>) => {
-    // 非 resize 的点击，不做处理
     if (!resizeLineParams.draggingCol) return;
-
-    const getMinMaxColWidth = (col: BaseTableCol<TableRowData>, effectPrevCol: BaseTableCol<TableRowData>) => {
-      let targetCol = null;
-      if (resizeLineParams.effectCol === 'next') {
-        targetCol = col;
-      } else {
-        targetCol = effectPrevCol;
-      }
-      const propMinWidth = isNumber(targetCol.minWidth) ? targetCol.minWidth : parseFloat(targetCol.minWidth);
-      return {
-        minColWidth: Math.max(targetCol.resize?.minWidth || DEFAULT_MIN_WIDTH, propMinWidth || DEFAULT_MIN_WIDTH),
-        maxColWidth: targetCol.resize?.maxWidth || DEFAULT_MAX_WIDTH,
-      };
-    };
-
     const target = resizeLineParams.draggingCol;
     const targetBoundRect = target.getBoundingClientRect();
     const tableBoundRect = tableContentRef.value?.getBoundingClientRect();
@@ -133,93 +145,57 @@ export default function useColumnResize(
       resizeLineStyle.bottom = `${parent.bottom - tableBoundRect.bottom}px`;
     }
 
-    // 拖拽时鼠标可能会超出 table 范围，需要给 document 绑定拖拽相关事件
+    // 结束拖拽，更新列宽。拖拽时鼠标可能会超出 table 范围，需要给 document 绑定拖拽相关事件；
     const onDragEnd = () => {
-      if (resizeLineParams.isDragging) {
-        // 结束拖拽，更新列宽
-        let width = Math.ceil(parseInt(resizeLineStyle.left, 10) - colLeft) || 0;
-        // 为了避免精度问题，导致 width 宽度超出 [minColWidth, maxColWidth] 的范围，需要对比目标宽度和最小/最大宽度
-        if (width <= minColWidth) {
-          width = minColWidth;
-        } else if (width >= maxColWidth) {
-          width = maxColWidth;
-        }
-        // 更新列宽
-        if (resizeLineParams.effectCol === 'next') {
-          setThWidthListByColumnDrag<BaseTableCol<TableRowData>>(
-            col,
-            width,
-            effectNextCol,
-            { getThWidthList, DEFAULT_MIN_WIDTH },
-            (updateMap, notCalculateCols) => {
-              updateThWidthList(updateMap);
-              setNotCalculateWidthCols(notCalculateCols);
-            },
-          );
-        } else if (resizeLineParams.effectCol === 'prev') {
-          setThWidthListByColumnDrag<BaseTableCol<TableRowData>>(
-            effectPrevCol,
-            width,
-            col,
-            { getThWidthList, DEFAULT_MIN_WIDTH },
-            (updateMap, notCalculateCols) => {
-              updateThWidthList(updateMap);
-              setNotCalculateWidthCols(notCalculateCols);
-            },
-          );
-        }
+      if (!resizeLineParams.isDragging) return;
+      const moveDistance = resizeLinePos - parseFloat(resizeLineStyle.left) || 0;
+      /**
+       * 计算列宽
+       *  - 若表格宽度已经超出，存在横向滚动，则直接改变表格总宽度
+       *  - 操作边框右侧，改变当前列和上一列；若上一列禁用宽度调整，则改变表格总宽度
+       *  - 操作边框左侧，改变当前列和下一列；若下一列禁用宽度调整，则改变表格总宽度
+       */
+      const thWidthList = getThWidthList('calculate');
+      const currentCol = effectColMap.value[col.colKey].current;
+      const currentSibling = resizeLineParams.effectCol === 'next' ? currentCol.prevSibling : currentCol.nextSibling;
+      const { newThWidthList } = calculateColumnWidth({
+        moveDistance,
+        thWidthList,
+        effectType: resizeLineParams.effectCol,
+        currentCol: col.resizable !== false ? col : currentSibling,
+        effectNextCol,
+        effectPrevCol,
+        isWidthOverflow: isWidthOverflow.value,
+      });
+      updateThWidthList(newThWidthList);
 
-        // 恢复设置
-        resizeLineParams.isDragging = false;
-        resizeLineParams.draggingCol = null;
-        resizeLineParams.effectCol = null;
-        target.style.cursor = '';
-        resizeLineStyle.display = 'none';
-        resizeLineStyle.left = '0';
-        document.removeEventListener('mousemove', onDragOver);
-        document.removeEventListener('mouseup', onDragEnd);
-        document.onselectstart = null;
-        document.ondragstart = null;
-      }
-
-      refreshTable();
+      // 恢复设置
+      resizeLineParams.isDragging = false;
+      resizeLineParams.draggingCol = null;
+      resizeLineParams.effectCol = null;
+      target.style.cursor = '';
+      resizeLineStyle.display = 'none';
+      resizeLineStyle.left = '0';
+      off(document, 'mouseup', onDragEnd);
+      off(document, 'mousemove', onDragOver);
+      document.onselectstart = originalSelectStart;
+      document.ondragstart = originalDragStart;
     };
 
+    // 注意前后两列最小和最大宽度限制
     const onDragOver = (e: MouseEvent) => {
-      // 计算新的列宽，新列宽不得小于最小列宽
       if (resizeLineParams.isDragging) {
         const left = resizeLinePos + e.x - resizeLineParams.draggingStart;
         resizeLineStyle.left = `${Math.min(Math.max(left, minResizeLineLeft), maxResizeLineLeft)}px`;
       }
     };
 
-    document.addEventListener('mouseup', onDragEnd);
-    document.addEventListener('mousemove', onDragOver);
+    on(document, 'mouseup', onDragEnd);
+    on(document, 'mousemove', onDragOver);
 
     // 禁用鼠标的选中文字和拖放
     document.onselectstart = () => false;
     document.ondragstart = () => false;
-  };
-
-  const recalculateColWidth: RecalculateColumnWidthFunc = (
-    columns: BaseTableCol<TableRowData>[],
-    thWidthList: { [colKey: string]: number },
-    tableLayout: string,
-    tableElmWidth: number,
-  ): void => {
-    recalculateColumnWidth<BaseTableCol<TableRowData>>(
-      columns,
-      thWidthList,
-      tableLayout,
-      tableElmWidth,
-      notCalculateWidthCols.value,
-      (widthMap) => {
-        updateThWidthList(widthMap);
-        if (notCalculateWidthCols.value.length) {
-          notCalculateWidthCols.value = [];
-        }
-      },
-    );
   };
 
   return {
@@ -227,7 +203,6 @@ export default function useColumnResize(
     resizeLineStyle,
     onColumnMouseover,
     onColumnMousedown,
-    recalculateColWidth,
     setEffectColMap,
   };
 }

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -502,7 +502,7 @@ export default function useFixed(
     { immediate: true },
   );
 
-  const refreshTable = debounce(() => {
+  const refreshTable = () => {
     updateTableWidth();
     updateFixedHeader();
     updateThWidthListHandler();
@@ -511,11 +511,11 @@ export default function useFixed(
       updateFixedStatus();
       updateColumnFixedShadow(tableContentRef.value, { skipScrollLimit: true });
     }
-  }, 30);
-
-  const onResize = () => {
-    refreshTable();
   };
+
+  const onResize = debounce(() => {
+    refreshTable();
+  }, 30);
 
   let resizeObserver: ResizeObserver = null;
   function addTableResizeObserver(tableElement: HTMLDivElement) {
@@ -524,6 +524,10 @@ export default function useFixed(
     off(window, 'resize', onResize);
     resizeObserver = new window.ResizeObserver(() => {
       refreshTable();
+      const timer = setTimeout(() => {
+        refreshTable();
+        clearTimeout(timer);
+      }, 250);
     });
     resizeObserver.observe(tableElement);
     tableRef.value = tableElement;

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -125,7 +125,7 @@ export default function useFixed(
   const isFixedRightColumn = ref(false);
   const isFixedLeftColumn = ref(false);
 
-  const columnResizable = computed(() => resizable.value || allowResizeColumnWidth.value || false);
+  const columnResizable = computed(() => allowResizeColumnWidth.value ?? resizable.value ?? false);
 
   // 没有表头吸顶，没有虚拟滚动，则不需要表头宽度计算
   const notNeedThWidthList = computed(
@@ -417,9 +417,6 @@ export default function useFixed(
   };
 
   const updateThWidthListHandler = () => {
-    if (columnResizable.value) {
-      recalculateColWidth.value(finalColumns.value, thWidthList.value, tableLayout.value, tableElmWidth.value);
-    }
     if (notNeedThWidthList.value) return;
     const timer = setTimeout(() => {
       updateTableWidth();
@@ -524,7 +521,12 @@ export default function useFixed(
     }
   }, 30);
 
-  const onResize = refreshTable;
+  const onResize = () => {
+    refreshTable();
+    if (columnResizable.value) {
+      recalculateColWidth.value(finalColumns.value, thWidthList.value, tableLayout.value, tableElmWidth.value);
+    }
+  };
 
   let resizeObserver: ResizeObserver = null;
   function addTableResizeObserver(tableElement: HTMLDivElement) {
@@ -533,6 +535,9 @@ export default function useFixed(
     off(window, 'resize', onResize);
     resizeObserver = new window.ResizeObserver(() => {
       refreshTable();
+      if (columnResizable.value) {
+        recalculateColWidth.value(finalColumns.value, thWidthList.value, tableLayout.value, tableElmWidth.value);
+      }
     });
     resizeObserver.observe(tableElement);
     tableRef.value = tableElement;

--- a/src/table/hooks/usePagination.tsx
+++ b/src/table/hooks/usePagination.tsx
@@ -59,7 +59,6 @@ export default function usePagination(props: TdBaseTableProps, context: SetupCon
             props: pagination.value,
             on: {
               change: (pageInfo: PageInfo) => {
-                props.pagination?.onChange?.(pageInfo);
                 innerPagination.value = pageInfo;
                 updateDataSourceAndPaginate(pageInfo.current, pageInfo.pageSize);
                 // Vue3 ignore this line

--- a/src/table/interface.ts
+++ b/src/table/interface.ts
@@ -68,13 +68,3 @@ export interface FixedColumnInfo {
 
 // 固定表头和固定列 具体的固定位置（left/top/right/bottom）
 export type RowAndColFixedPosition = Map<string | number, FixedColumnInfo>;
-
-// 允许修改列宽时，重新计算各列宽度的函数声明
-export interface RecalculateColumnWidthFunc {
-  (
-    columns: BaseTableCol<TableRowData>[],
-    thWidthList: { [colKey: string]: number },
-    tableLayout: string,
-    tableElmWidth: number,
-  ): void;
-}

--- a/src/table/tbody.tsx
+++ b/src/table/tbody.tsx
@@ -130,7 +130,7 @@ export default defineComponent({
     // eslint-disable-next-line
     const renderEmpty = (h: CreateElement, columns: TableBodyProps['columns']) => {
       // 小于 100 属于异常宽度，不显示
-      const showEmptyText = Boolean(this.tableWidth && this.tableWidth > 100);
+      const showEmptyText = Boolean(this.tableWidth && this.tableWidth > 100) || process.env.NODE_ENV === 'test';
       return (
         <tr class={[this.tableBaseClass.emptyRow, { [this.tableFullRowClasses.base]: this.isWidthOverflow }]}>
           <td colspan={columns.length}>

--- a/src/table/tbody.tsx
+++ b/src/table/tbody.tsx
@@ -129,6 +129,8 @@ export default defineComponent({
   render(h) {
     // eslint-disable-next-line
     const renderEmpty = (h: CreateElement, columns: TableBodyProps['columns']) => {
+      // 小于 100 属于异常宽度，不显示
+      const showEmptyText = Boolean(this.tableWidth && this.tableWidth > 100);
       return (
         <tr class={[this.tableBaseClass.emptyRow, { [this.tableFullRowClasses.base]: this.isWidthOverflow }]}>
           <td colspan={columns.length}>
@@ -136,7 +138,7 @@ export default defineComponent({
               class={[this.tableBaseClass.empty, { [this.tableFullRowClasses.innerFullRow]: this.isWidthOverflow }]}
               style={this.isWidthOverflow ? { width: `${this.tableWidth}px` } : {}}
             >
-              {this.renderTNode('empty') || this.t(this.global.empty)}
+              {showEmptyText ? this.renderTNode('empty') || this.t(this.global.empty) : ''}
             </div>
           </td>
         </tr>

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -31,8 +31,6 @@ export interface TheadProps {
   };
   thList?: BaseTableCol<TableRowData>[][];
   columnResizeParams?: {
-    resizeLineRef: HTMLDivElement;
-    resizeLineStyle: Object;
     onColumnMouseover: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
     onColumnMousedown: (e: MouseEvent, col: BaseTableCol<TableRowData>) => void;
   };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 列宽调整功能，修复添加 `resizable` 属性后，在 Dialog 组件中宽度计算问题，并非提前设置好的 column.width，[issue#2116](https://github.com/Tencent/tdesign-vue/issues/2116)
- fix(Table): 列宽调整功能，修复 `column.resizable=false` 在某些场景下无效问题，[issue#1765](https://github.com/Tencent/tdesign-vue/issues/1765)
- fix(Table): 列宽调整功能，在自定义列数量场景，表格宽度未能根据列数自适应，[issue#1861](https://github.com/Tencent/tdesign-vue/issues/1861)
- fix(Table): 列宽调整功能，修复宽度计算的各类问题，[issue#1663](https://github.com/Tencent/tdesign-vue/issues/1663)
- fix(Table): 空数据功能，修复空表格在 Dialog 组件中，文本显示位置不正确问题，[issue#2082](https://github.com/Tencent/tdesign-vue/issues/2082)
- fix(Table): 分页功能，修复 `pagination.onChange` 被调用两次问题，[issue#2066](https://github.com/Tencent/tdesign-vue/issues/2066)

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
