### PR TITLE
fix(upload): 修复禁用态表单对upload组件无效问题

### DIFF
--- a/src/hooks/useFormDisabled.ts
+++ b/src/hooks/useFormDisabled.ts
@@ -6,7 +6,7 @@ export default function useFormDisabled() {
     let { parent } = currentInstance;
     while (parent) {
       if (parent.proxy.$options.name === 'TForm') {
-        return parent.props.disabled;
+        return parent.props.disabled as boolean;
       }
       parent = parent.parent;
     }

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -1,5 +1,6 @@
 import { computed, defineComponent, SetupContext } from '@vue/composition-api';
 import { UploadIcon } from 'tdesign-icons-vue';
+import useFormDisabled from '../hooks/useFormDisabled';
 import props from './props';
 import NormalFile from './themes/normal-file';
 import DraggerFile from './themes/dragger-file';
@@ -19,6 +20,7 @@ export default defineComponent({
 
   setup(props: UploadProps, context: SetupContext) {
     const uploadData = useUpload(props, context);
+    const { formDisabled } = useFormDisabled();
 
     const {
       localeConfig,
@@ -36,13 +38,15 @@ export default defineComponent({
       onDragFileChange,
     } = uploadData;
 
+    const disabled = computed<boolean>(() => formDisabled.value || innerDisabled.value);
+
     const commonDisplayFileProps = computed<CommonDisplayFileProps>(() => ({
       files: uploadValue.value,
       toUploadFiles: toUploadFiles.value,
       displayFiles: displayFiles.value,
       theme: props.theme,
       placeholder: props.placeholder,
-      disabled: innerDisabled.value,
+      disabled: disabled.value,
       tips: props.tips,
       status: props.status,
       sizeOverLimitMessage: sizeOverLimitMessage.value,
@@ -95,14 +99,14 @@ export default defineComponent({
       const getDefaultTrigger = () => {
         if (this.theme === 'file-input') {
           return (
-            <Button disabled={this.innerDisabled} variant="outline" {...this.triggerButtonProps}>
+            <Button disabled={this.disabled} variant="outline" {...this.triggerButtonProps}>
               {this.triggerUploadText}
             </Button>
           );
         }
         return (
           <Button
-            disabled={this.innerDisabled}
+            disabled={this.disabled}
             variant="outline"
             icon={() => <UploadIcon />}
             props={this.triggerButtonProps}
@@ -220,7 +224,7 @@ export default defineComponent({
         <input
           ref="inputRef"
           type="file"
-          disabled={this.innerDisabled}
+          disabled={this.disabled}
           onChange={this.onNormalFileChange}
           multiple={this.multiple}
           accept={this.accept}


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2184 

### 💡 需求背景和解决方案

禁用态的表单(disabled)对upload组件无效，即form组件disabled为true，里面upload组件没有变为禁用状态，还是可以上传

### 📝 更新日志

- fix(upload): 修复禁用态的表单对upload组件无效问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
