### PR TITLE
fix(cascader): 动态加载在value-type为full时支持回显

### DIFF
--- a/src/cascader/_example/load.vue
+++ b/src/cascader/_example/load.vue
@@ -1,5 +1,16 @@
 <template>
-  <t-cascader v-model="value" :options="options" clearable :load="load" />
+  <t-space direction="vertical">
+    <t-cascader v-model="value" :options="options" clearable :load="load" @change="handleChange" />
+    <t-cascader
+      v-model="value1"
+      value-type="full"
+      clearable
+      :options="options"
+      :load="load"
+      :input-props="inputProps"
+      @change="handleChange1"
+    />
+  </t-space>
 </template>
 <script>
 export default {
@@ -18,6 +29,10 @@ export default {
         },
       ],
       value: '',
+      value1: ['1', '1-1.0', '1-1.0-1.1'],
+      inputProps: {
+        value: '选项1 / 选项1.1 / 选项1.1.1',
+      },
     };
   },
   methods: {
@@ -29,10 +44,12 @@ export default {
             nodes = [
               {
                 label: `${node.label}.1`,
+                value: `${node.value}-1.${node.level}`,
                 children: node.level < 1,
               },
               {
                 label: `${node.label}.2`,
+                value: `${node.value}-2.${node.level}`,
                 children: node.level < 1,
               },
             ];
@@ -40,6 +57,16 @@ export default {
           resolve(nodes);
         }, 1000);
       });
+    },
+    handleChange(value) {
+      console.log('value', value);
+    },
+    handleChange1(value, context) {
+      const { node } = context;
+      const path = node.getPath();
+      const labelPath = path.map((item) => item.label).join(' / ');
+      this.inputProps.value = labelPath;
+      console.log('value1', value);
     },
   },
 };

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -1,6 +1,5 @@
 import { PropType } from 'vue';
 import { defineComponent, computed } from '@vue/composition-api';
-import treeNode from '@common/js/tree/tree-node';
 import Item from './Item';
 import { TreeNode, CascaderContextType, CascaderValue } from '../interface';
 import CascaderProps from '../props';

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -1,7 +1,8 @@
 import { PropType } from 'vue';
 import { defineComponent, computed } from '@vue/composition-api';
+import treeNode from '@common/js/tree/tree-node';
 import Item from './Item';
-import { TreeNode, CascaderContextType } from '../interface';
+import { TreeNode, CascaderContextType, CascaderValue } from '../interface';
 import CascaderProps from '../props';
 import { usePrefixClass, useConfig } from '../../hooks/useConfig';
 import { useTNodeDefault } from '../../hooks/tnode';
@@ -25,7 +26,9 @@ export default defineComponent({
     const renderTNodeJSXDefault = useTNodeDefault();
     const COMPONENT_NAME = usePrefixClass('cascader');
     const { global } = useConfig('cascader');
-    const { valueType, cascaderValue, treeStore } = props.cascaderContext;
+    const {
+      valueType, cascaderValue, treeStore, multiple,
+    } = props.cascaderContext;
     const { config } = treeStore;
 
     const panels = computed(() => getPanels(props.cascaderContext.treeNodes));
@@ -36,8 +39,9 @@ export default defineComponent({
     };
 
     // 异步加载回显时默认触发第一个值
-    if (config.load && valueType === 'full' && (cascaderValue as Array<string | number>).length > 0) {
-      const firstExpandNode = treeStore.nodes.find((node: TreeNode) => node.value === cascaderValue[0]);
+    if (config.load && valueType === 'full' && (cascaderValue as Array<CascaderValue>).length > 0) {
+      const firstValue = multiple ? cascaderValue[0][0] : cascaderValue[0];
+      const firstExpandNode = treeStore.nodes.find((node: TreeNode) => node.value === firstValue);
       handleExpand(firstExpandNode, 'click');
     }
 

--- a/src/cascader/components/Panel.tsx
+++ b/src/cascader/components/Panel.tsx
@@ -25,6 +25,8 @@ export default defineComponent({
     const renderTNodeJSXDefault = useTNodeDefault();
     const COMPONENT_NAME = usePrefixClass('cascader');
     const { global } = useConfig('cascader');
+    const { valueType, cascaderValue, treeStore } = props.cascaderContext;
+    const { config } = treeStore;
 
     const panels = computed(() => getPanels(props.cascaderContext.treeNodes));
 
@@ -32,6 +34,12 @@ export default defineComponent({
       const { trigger: propsTrigger, cascaderContext } = props;
       expendClickEffect(propsTrigger, trigger, node, cascaderContext);
     };
+
+    // 异步加载回显时默认触发第一个值
+    if (config.load && valueType === 'full' && (cascaderValue as Array<string | number>).length > 0) {
+      const firstExpandNode = treeStore.nodes.find((node: TreeNode) => node.value === cascaderValue[0]);
+      handleExpand(firstExpandNode, 'click');
+    }
 
     return {
       global,

--- a/src/cascader/hooks.ts
+++ b/src/cascader/hooks.ts
@@ -120,11 +120,39 @@ export const useCascaderContext = (props: TdCascaderProps) => {
     treeStore.replaceChecked(getTreeValue(value));
   };
 
+  // 根据已有的值异步加载子树
+  const loadChildrenByValue = () => {
+    const { value, multiple } = props;
+    const { treeStore } = statusContext;
+    // 异步加载时子级回显
+    if (value instanceof Array) {
+      // 单选
+      if (!multiple && value.length > treeStore.expandedMap.size) {
+        const expanded = value.slice(0, treeStore.expandedMap.size + 1);
+        treeStore.setExpanded(expanded);
+      }
+      // 多选, 展开选择了第一个数组的列
+      // todo 目前只是展开选择了第一个数组的列，其他选中的半选状态没有处理，且在取消时由于没有节点，数据会被误删除
+      if (multiple) {
+        if (value.length > 0) {
+          // 处理第一个数组的值
+          const firstValue = value[0] as Array<string | number>;
+          if (firstValue.length > treeStore.expandedMap.size) {
+            treeStore.setExpanded(firstValue.slice(0, treeStore.expandedMap.size + 1));
+          }
+        }
+        // 加载时给所有的选中列表重新设置value，以刷新已选择的值
+        const lastValues = value.map((item: Array<string | number>) => item[item.length - 1]);
+        treeStore.setChecked(lastValues);
+      }
+    }
+  };
+
   watch(
     () => props.options,
     () => {
       const {
-        options, keys = {}, checkStrictly, lazy, load, valueMode, value, valueType,
+        options, keys = {}, checkStrictly, lazy, load, valueMode,
       } = props;
       const { treeStore } = statusContext;
 
@@ -147,11 +175,7 @@ export const useCascaderContext = (props: TdCascaderProps) => {
             nextTick(() => {
               store.refreshNodes();
               updatedTreeNodes();
-              // 异步加载时子级回显
-              if (load && valueType === 'full' && (value as Array<string | number>).length > store.expandedMap.size) {
-                const expanded = (value as Array<string | number>).slice(0, store.expandedMap.size + 1);
-                store.setExpanded(expanded);
-              }
+              loadChildrenByValue();
             });
           },
         });

--- a/src/cascader/hooks.ts
+++ b/src/cascader/hooks.ts
@@ -52,6 +52,7 @@ export const useContext = (
         showAllLevels,
         minCollapsedNum,
         valueType,
+        value,
       } = props;
       return {
         value: statusContext.scopeVal,
@@ -68,6 +69,7 @@ export const useContext = (
         minCollapsedNum,
         valueType,
         visible: innerPopupVisible.value,
+        cascaderValue: value,
         ...statusContext,
         setTreeNodes: (nodes: TreeNode[]) => {
           statusContext.treeNodes = nodes;
@@ -122,7 +124,7 @@ export const useCascaderContext = (props: TdCascaderProps) => {
     () => props.options,
     () => {
       const {
-        options, keys = {}, checkStrictly, lazy, load, valueMode,
+        options, keys = {}, checkStrictly, lazy, load, valueMode, value, valueType,
       } = props;
       const { treeStore } = statusContext;
 
@@ -145,6 +147,11 @@ export const useCascaderContext = (props: TdCascaderProps) => {
             nextTick(() => {
               store.refreshNodes();
               updatedTreeNodes();
+              // 异步加载时子级回显
+              if (load && valueType === 'full' && (value as Array<string | number>).length > store.expandedMap.size) {
+                const expanded = (value as Array<string | number>).slice(0, store.expandedMap.size + 1);
+                store.setExpanded(expanded);
+              }
             });
           },
         });

--- a/src/cascader/interface.tsx
+++ b/src/cascader/interface.tsx
@@ -32,6 +32,7 @@ export interface CascaderContextType
   inputVal: TdSelectInputProps['inputValue'];
   setInputVal: (val: TdSelectInputProps['inputValue']) => void;
   setExpend: (val: TreeNodeValue[]) => void;
+  cascaderValue: CascaderValue;
 }
 
 export { TreeNode } from '../_common/js/tree/tree-node';


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题：cascader组件的动态加载模式不支持回显
解决方案：使用动态模式时，如果valueType为full，且value不为空时，下拉框首次弹出时支持自动选择已有的值和加载子列表

https://user-images.githubusercontent.com/16223845/224270087-196e6909-32f4-46b9-b13f-cd9b0a269e0a.mov



### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

-fix(cascader): 动态加载模式支持回显

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
