### PR TITLE
fix(tag-input): select使用筛选时删除filterWords偶尔会删除已选值

### DIFF
--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -204,7 +204,7 @@ export default defineComponent({
             this.setTInputValue(val, { ...context, trigger: 'input' });
           },
           enter: this.onInputEnter,
-          keydown: this.onInputBackspaceKeyUp,
+          keyup: this.onInputBackspaceKeyUp,
           mouseenter: (context: { e: MouseEvent }) => {
             this.addHover(context);
             this.scrollToRightOnEnter();

--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -66,12 +66,8 @@ export default defineComponent({
     } = useTagScroll(props);
     // handle tag add and remove
     const {
-      tagValue, onInnerEnter, onInputBackspaceKeyUp, clearAll, renderLabel, onClose,
-    } = useTagList(
-      props,
-      context,
-      getDragProps,
-    );
+      tagValue, onInnerEnter, onInputBackspaceKeyUp, onInputBackspaceKeyDown, clearAll, renderLabel, onClose,
+    } = useTagList(props, context, getDragProps);
 
     const { CloseCircleFilledIcon } = useGlobalIcon({ CloseCircleFilledIcon: TdCloseCircleFilledIcon });
 
@@ -146,6 +142,7 @@ export default defineComponent({
       onInputEnter,
       onInnerEnter,
       onInputBackspaceKeyUp,
+      onInputBackspaceKeyDown,
       renderLabel,
       onWheel,
       scrollToRightOnEnter,
@@ -205,6 +202,7 @@ export default defineComponent({
           },
           enter: this.onInputEnter,
           keyup: this.onInputBackspaceKeyUp,
+          keydown: this.onInputBackspaceKeyDown,
           mouseenter: (context: { e: MouseEvent }) => {
             this.addHover(context);
             this.scrollToRightOnEnter();

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -58,8 +58,12 @@ export default function useTagList(props: TdTagInputProps, context: SetupContext
     context.emit('enter', newValue, enterEventParams);
   };
 
-  // 按下回退键，删除标签
   const onInputBackspaceKeyUp = (value: InputValue, p: { e: KeyboardEvent }) => {
+    if (!tagValue.value || !tagValue.value.length) return;
+    oldInputValue.value = value;
+  };
+  // 按下回退键，删除标签
+  const onInputBackspaceKeyDown = (value: InputValue, p: { e: KeyboardEvent }) => {
     const { e } = p;
     if (!tagValue.value || !tagValue.value.length) return;
     // 回车键删除，输入框值为空时，才允许 Backspace 删除标签
@@ -147,6 +151,7 @@ export default function useTagList(props: TdTagInputProps, context: SetupContext
     onClose,
     onInnerEnter,
     onInputBackspaceKeyUp,
+    onInputBackspaceKeyDown,
     renderLabel,
   };
 }

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -58,7 +58,7 @@ export default function useTagList(props: TdTagInputProps, context: SetupContext
     context.emit('enter', newValue, enterEventParams);
   };
 
-  const onInputBackspaceKeyUp = (value: InputValue, p: { e: KeyboardEvent }) => {
+  const onInputBackspaceKeyUp = (value: InputValue) => {
     if (!tagValue.value || !tagValue.value.length) return;
     oldInputValue.value = value;
   };


### PR DESCRIPTION
fix #2261

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
- https://github.com/Tencent/tdesign-vue/issues/2261
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志
- fix(TagInput): 修复基于`TagInput`的组件使用筛选时删除关键词时会删除已选值的问题
<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
