### PR TITLE
fix(table): 修改判断表格滚动条的条件，修复ie下scrollHeight和clientHeight不相等导致表头出现滚动条问题

### DIFF
--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -353,8 +353,8 @@ export default function useFixed(
   const updateFixedHeader = () => {
     const timer = setTimeout(() => {
       if (!tableContentRef.value) return;
-      isFixedHeader.value = tableContentRef.value.scrollHeight > tableContentRef.value.clientHeight;
-      isWidthOverflow.value = tableContentRef.value.scrollWidth > tableContentRef.value.clientWidth;
+      isFixedHeader.value = tableContentRef.value.scrollHeight - tableContentRef.value.clientHeight >= scrollbarWidth.value;
+      isWidthOverflow.value = tableContentRef.value.scrollWidth - tableContentRef.value.clientWidth >= scrollbarWidth.value;
       const pos = tableContentRef.value.getBoundingClientRect();
       virtualScrollHeaderPos.value = {
         top: pos.top,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：在ie下，表格没有出现滚动条时scrollHeight比clientHeight多处一个像素
解决方案：修改判断是否存在滚动条的条件，以scrollHeight(scrollwidth)与clientHeight(clientWidth)的差值大于或等于滚动条的值为判断条件

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
