### PR TITLE
fix(upload): triggerButtonProps在theme为file-input下失效

### DIFF
--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -99,7 +99,7 @@ export default defineComponent({
       const getDefaultTrigger = () => {
         if (this.theme === 'file-input') {
           return (
-            <Button disabled={this.disabled} variant="outline" {...this.triggerButtonProps}>
+            <Button disabled={this.disabled} variant="outline" props={this.triggerButtonProps}>
               {this.triggerUploadText}
             </Button>
           );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. API属性，triggerButtonProps在theme为file-input下失效

<img width="962" alt="企业微信截图_08c93f8c-0197-4161-ad60-b669e32d37cd" src="https://user-images.githubusercontent.com/15922193/230865676-97e2c8ab-5926-47c0-9634-24ac1abf2230.png">

2. jsx需要把triggerButtonProps挂到props下

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): triggerButtonProps在theme为file-input下失效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
