### PR TITLE
Fix table 20230411

### DIFF
--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -203,7 +203,20 @@ export default function useColumnResize(params: {
     });
     return tableWidth;
   };
-
+  const getSiblingColCanResizable = (
+    newThWidthList: { [key: string]: number },
+    effectNextCol: BaseTableCol,
+    distance: number,
+    index: number,
+  ) => {
+    let isWidthAbnormal = true;
+    if (effectNextCol) {
+      const { minColWidth, maxColWidth } = getMinMaxColWidth(effectNextCol);
+      const targetNextColWidth = newThWidthList[effectNextCol.colKey] + distance;
+      isWidthAbnormal = targetNextColWidth < minColWidth || targetNextColWidth > maxColWidth;
+    }
+    return !(isWidthAbnormal || isWidthOverflow.value || index === leafColumns.value.length - 1);
+  };
   const getOtherResizeInfo = (
     col: BaseTableCol<TableRowData>,
     effectPrevCol: BaseTableCol,
@@ -250,13 +263,14 @@ export default function useColumnResize(params: {
        */
       const thWidthList = getThWidthList('calculate');
       const currentCol = effectColMap.value[col.colKey]?.current;
-      const currentSibling = resizeLineParams.effectCol === 'next' ? currentCol.prevSibling : currentCol.nextSibling;
+      const currentSibling = resizeLineParams.effectCol === 'next' ? currentCol.nextSibling : currentCol.prevSibling;
       // 多行表头，列宽为最后一层的宽度，即叶子结点宽度
       const newThWidthList = { ...thWidthList };
       // 当前列不允许修改宽度，就调整相邻列的宽度
       const tmpCurrentCol = col.resizable !== false ? col : currentSibling;
-      // 是否允许调整相邻列宽：列宽未超出时，且并非是最后一列（最后一列的右侧拉伸会认为是表格整体宽度调整）
-      const canResizeSiblingColWidth = !(isWidthOverflow.value || index === leafColumns.value.length - 1);
+      // 是否允许调整后一列的列宽：列宽未超出时，满足后一列设置的最大最小值时且并非是最后一列（最后一列的右侧拉伸会认为是表格整体宽度调整）
+      const rightCol = resizeLineParams.effectCol === 'next' ? currentCol.nextSibling : col;
+      const canResizeSiblingColWidth = getSiblingColCanResizable(newThWidthList, rightCol, moveDistance, index);
 
       if (resizeLineParams.effectCol === 'next') {
         // 右侧激活态的固定列，需特殊调整

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -162,6 +162,7 @@ export default defineComponent({
           const resizeColumnListener = this.resizable || !canDragSort
             ? {
               mousedown: (e: MouseEvent) => {
+                e.stopPropagation();
                 this.columnResizeParams?.onColumnMousedown?.(e, col, index);
                 if (!canDragSort) {
                   const timer = setTimeout(() => {

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -163,7 +163,9 @@ export default defineComponent({
             ? {
               mousedown: (e: MouseEvent) => {
                 e.stopPropagation();
-                this.columnResizeParams?.onColumnMousedown?.(e, col, index);
+                if (this.resizable) {
+                  this.columnResizeParams?.onColumnMousedown?.(e, col, index);
+                }
                 if (!canDragSort) {
                   const timer = setTimeout(() => {
                     const thList = this.theadRef.querySelectorAll('th');
@@ -172,7 +174,9 @@ export default defineComponent({
                   }, 10);
                 }
               },
-              mousemove: (e: MouseEvent) => this.columnResizeParams?.onColumnMouseover?.(e, col),
+              mousemove: (e: MouseEvent) => {
+                this.resizable && this.columnResizeParams?.onColumnMouseover?.(e, col);
+              },
             }
             : {};
           const content = isFunction(col.ellipsisTitle) ? col.ellipsisTitle(h, { col, colIndex: index }) : undefined;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

1. vue 1.2.5版本组件库的table组件，在固定列生效且存在可横向滚动的滚动条时，当开启列拖拽宽度后拖拽使横向滚动条消失，此时拖拽某一列横向不超过后一列时，后一列宽度可以被无限缩小，min-width和max-width不生效
2. 修复table组件中开启左侧列固定并且固定列配置resizable=false时，拖动此固定列相邻非固定列列宽时控制台报错的问题
![image](https://user-images.githubusercontent.com/22291419/231410892-a41d7c56-2308-4a5b-a6c5-6c3fa4c7814e.png)
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/22291419/231410949-d1d47507-3afa-47e3-9b47-d67c1be8cec6.png">

3. 修复table组件在开启多级表头时点击子表头后控制台报错的问题
![image](https://user-images.githubusercontent.com/22291419/231409191-a6c9fd22-8b0a-4443-b68f-f24fb8946a99.png)

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/22291419/231408640-53f56529-56c0-4f50-bb2a-41b8d45d2cb4.png">


### 💡 需求背景和解决方案

1. 通过判断控制canResizeSiblingColWidth的值，判断逻辑新增后一列宽度与min-width和max-width的关系
2. 在左侧有列固定且resizable=false这种情况时进行异常处理不允许拖动相邻列左侧使其能调整宽度
3. 表头点击时禁止冒泡，防止重复触发列鼠标事件导致报错

### 📝 更新日志

- fix(Table): 列宽调整功能，修复即使 `resizable=false` 时，也会显示拖拽调整列宽图标和辅助线问题
- fix(Table): 列宽调整功能，修复开启左侧列固定并且固定列配置 `resizable=false` 时，拖动此固定列相邻非固定列列宽时控制台报错的问题
- fix(Table): 列宽调整功能，修复在拖拽任意列宽使表格横向滚动条消失之后列宽无法正常调整的问题
- fix(Table): 列宽调整功能，修复开启多级表头时点击子表头后控制台报错的问题


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
