### PR TITLE
fix(DatePicker): 修复时间戳模式下props类型检测报错问题

### DIFF
--- a/src/date-picker/panel/ExtraContent.tsx
+++ b/src/date-picker/panel/ExtraContent.tsx
@@ -10,7 +10,8 @@ export default defineComponent({
     presetsPlacement: String as PropType<TdDatePickerProps['presetsPlacement']>,
     onPresetClick: Function,
     onConfirmClick: Function,
-    selectedValue: String as PropType<DateValue>,
+    // 支持时间戳模式：时间戳为Number类型
+    selectedValue: [String, Number] as PropType<DateValue>,
   },
   setup(props) {
     const showPanelFooter = computed(() => props.enableTimePicker || props.presets);


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2283 

### 💡 需求背景和解决方案
时间戳类型数据是Number类型，但是对selectedValue却断言只有String类型，补充对应的类型判断

### 📝 更新日志
补充对应的类型判断

- fix(DatePicker): 修复时间戳模式下控制台警告props类型错误的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] TypeScript 定义已补充或无须补充
- [√] Changelog 已提供或无须提供
