### PR TITLE
[Table] fix sibling column resizable does not work

### DIFF
--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -203,7 +203,20 @@ export default function useColumnResize(params: {
     });
     return tableWidth;
   };
-
+  const getSiblingColCanResizable = (
+    newThWidthList: { [key: string]: number },
+    effectNextCol: BaseTableCol,
+    distance: number,
+    index: number,
+  ) => {
+    let isWidthAbnormal = true;
+    if (effectNextCol) {
+      const { minColWidth, maxColWidth } = getMinMaxColWidth(effectNextCol);
+      const targetNextColWidth = newThWidthList[effectNextCol.colKey] + distance;
+      isWidthAbnormal = targetNextColWidth < minColWidth || targetNextColWidth > maxColWidth;
+    }
+    return !(isWidthAbnormal || isWidthOverflow.value || index === leafColumns.value.length - 1);
+  };
   const getOtherResizeInfo = (
     col: BaseTableCol<TableRowData>,
     effectPrevCol: BaseTableCol,
@@ -250,13 +263,14 @@ export default function useColumnResize(params: {
        */
       const thWidthList = getThWidthList('calculate');
       const currentCol = effectColMap.value[col.colKey]?.current;
-      const currentSibling = resizeLineParams.effectCol === 'next' ? currentCol.prevSibling : currentCol.nextSibling;
+      const currentSibling = resizeLineParams.effectCol === 'next' ? currentCol.nextSibling : currentCol.prevSibling;
       // 多行表头，列宽为最后一层的宽度，即叶子结点宽度
       const newThWidthList = { ...thWidthList };
       // 当前列不允许修改宽度，就调整相邻列的宽度
       const tmpCurrentCol = col.resizable !== false ? col : currentSibling;
-      // 是否允许调整相邻列宽：列宽未超出时，且并非是最后一列（最后一列的右侧拉伸会认为是表格整体宽度调整）
-      const canResizeSiblingColWidth = !(isWidthOverflow.value || index === leafColumns.value.length - 1);
+      // 是否允许调整后一列的列宽：列宽未超出时，满足后一列设置的最大最小值时且并非是最后一列（最后一列的右侧拉伸会认为是表格整体宽度调整）
+      const rightCol = resizeLineParams.effectCol === 'next' ? currentCol.nextSibling : col;
+      const canResizeSiblingColWidth = getSiblingColCanResizable(newThWidthList, rightCol, moveDistance, index);
 
       if (resizeLineParams.effectCol === 'next') {
         // 右侧激活态的固定列，需特殊调整

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -186,13 +186,20 @@ export default function useColumnResize(params: {
     };
   };
 
-  const getFixedToLeftResizeInfo = (targetBoundRect: DOMRect, tableBoundRect: DOMRect) => {
-    const resizeLinePos = targetBoundRect.left - tableBoundRect.left;
+  const getFixedToLeftResizeInfo = (
+    target: HTMLElement,
+    col: BaseTableCol,
+    targetBoundRect: DOMRect,
+    tableBoundRect: DOMRect,
+  ) => {
+    const targetIsSameAsCol = target.dataset.colkey === col.colKey;
+    const resizeLinePos = targetBoundRect.left - tableBoundRect.left + targetBoundRect.width;
     const colLeft = targetBoundRect.left - tableBoundRect.left;
+    const { minColWidth, maxColWidth } = getMinMaxColWidth(col);
     return {
       resizeLinePos,
-      minResizeLineLeft: colLeft,
-      maxResizeLineLeft: colLeft,
+      minResizeLineLeft: colLeft + (targetIsSameAsCol ? minColWidth : targetBoundRect.width),
+      maxResizeLineLeft: colLeft + (targetIsSameAsCol ? maxColWidth : targetBoundRect.width),
     };
   };
 
@@ -218,13 +225,14 @@ export default function useColumnResize(params: {
     return !(isWidthAbnormal || isWidthOverflow.value || index === leafColumns.value.length - 1);
   };
   const getOtherResizeInfo = (
+    target: HTMLElement,
     col: BaseTableCol<TableRowData>,
     effectPrevCol: BaseTableCol,
     targetBoundRect: DOMRect,
     tableBoundRect: DOMRect,
   ) => effectPrevCol
     ? getNormalResizeInfo(col, effectPrevCol, targetBoundRect, tableBoundRect)
-    : getFixedToLeftResizeInfo(targetBoundRect, tableBoundRect);
+    : getFixedToLeftResizeInfo(target, col, targetBoundRect, tableBoundRect);
 
   // 调整表格列宽
   const onColumnMousedown = (e: MouseEvent, col: BaseTableCol<TableRowData>, index: number) => {
@@ -236,7 +244,7 @@ export default function useColumnResize(params: {
     const effectPrevCol = effectColMap.value[col.colKey]?.prev;
     const { resizeLinePos, minResizeLineLeft, maxResizeLineLeft } = isColRightFixActive(col)
       ? getFixedToRightResizeInfo(target, col, effectNextCol, targetBoundRect, tableBoundRect)
-      : getOtherResizeInfo(col, effectNextCol, targetBoundRect, tableBoundRect);
+      : getOtherResizeInfo(target, col, effectPrevCol, targetBoundRect, tableBoundRect);
 
     // 开始拖拽，记录下鼠标起始位置
     resizeLineParams.isDragging = true;

--- a/src/table/hooks/useColumnResize.ts
+++ b/src/table/hooks/useColumnResize.ts
@@ -193,8 +193,8 @@ export default function useColumnResize(params: {
     tableBoundRect: DOMRect,
   ) => {
     const targetIsSameAsCol = target.dataset.colkey === col.colKey;
-    const resizeLinePos = targetBoundRect.left - tableBoundRect.left + targetBoundRect.width;
     const colLeft = targetBoundRect.left - tableBoundRect.left;
+    const resizeLinePos = colLeft + targetBoundRect.width;
     const { minColWidth, maxColWidth } = getMinMaxColWidth(col);
     return {
       resizeLinePos,

--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -162,6 +162,7 @@ export default defineComponent({
           const resizeColumnListener = this.resizable || !canDragSort
             ? {
               mousedown: (e: MouseEvent) => {
+                e.stopPropagation();
                 this.columnResizeParams?.onColumnMousedown?.(e, col, index);
                 if (!canDragSort) {
                   const timer = setTimeout(() => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 💡 需求背景和解决方案
问题如下：

1. 左侧固定列单列设置fixed和resizable=false时，固定列与相邻列之间仍然能够在拖动调整列宽时出现辅助线
2. 表头中两列之间相交处拖动调整列宽时，鼠标拖动其实位置在相交处的左侧和右侧对列宽调整限制不一致
如下图所示，在鼠标起始位置在相交处右侧时，左侧列的列宽限制被按照右侧列的min-width,max-width属性值进行处理
<img width="405" alt="image" src="https://user-images.githubusercontent.com/22291419/231992062-0d8c75e0-0b24-42d0-aa9a-13746215fcc3.png">

修复内容如下：

1. 传参值由effectNextCol改成effectPrevCol
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/22291419/231992931-c86c72f5-6476-40b9-ba30-421196c79981.png">
2. 通过dataset.colkey === col.colkey判断鼠标拖动起始位置是否在相交线的左侧，根据起始位置在左侧还是右侧进行不同处理
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/22291419/231993670-97a4a95d-73d4-460b-b9d3-dcd5b9f41786.png">


### 📝 更新日志

1. 左侧固定列单列设置fixed和resizable=false时，固定列与相邻resizable=true的列之间在拖动调整列宽时不出现辅助线
2. 表头中两列之间相交处拖动调整列宽时，鼠标拖动起始位置在相交处的左侧和右侧时不影响辅助线能够拖动的最左侧和最右侧的位置

- fix(table): 修复table组件在开启固定列单列resizable禁用时，相邻resizable启用的列列宽调整范围与预期不一致的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
