### PR TITLE
fix(datepicker): fix single panel with enable-time-picker not available

### DIFF
--- a/src/date-picker/DatePickerPanel.tsx
+++ b/src/date-picker/DatePickerPanel.tsx
@@ -226,6 +226,7 @@ export default defineComponent({
       timePickerProps: props.timePickerProps,
       enableTimePicker: props.enableTimePicker,
       presetsPlacement: props.presetsPlacement,
+      popupVisible: props.popupVisible,
       onPanelClick,
       onCellClick,
       onJumperClick,

--- a/src/date-picker/DatePickerPanel.tsx
+++ b/src/date-picker/DatePickerPanel.tsx
@@ -32,7 +32,7 @@ export default defineComponent({
     timePickerProps: datePickerProps.timePickerProps,
     ...datePickerPanelProps,
   },
-  setup(props: TdDatePickerPanelProps, { emit }) {
+  setup(props: TdDatePickerPanelProps, { emit, attrs }) {
     const {
       cacheValue, value, year, month, time, onChange,
     } = useSingleValue(props);
@@ -226,7 +226,8 @@ export default defineComponent({
       timePickerProps: props.timePickerProps,
       enableTimePicker: props.enableTimePicker,
       presetsPlacement: props.presetsPlacement,
-      popupVisible: props.popupVisible,
+      // 该属性在单独使用此panel时无特别意义, 不应该暴露为props
+      popupVisible: (attrs?.popupVisible as Boolean) ?? true,
       onPanelClick,
       onCellClick,
       onJumperClick,

--- a/src/date-picker/DateRangePickerPanel.tsx
+++ b/src/date-picker/DateRangePickerPanel.tsx
@@ -374,6 +374,7 @@ export default defineComponent({
       enableTimePicker: props.enableTimePicker,
       presetsPlacement: props.presetsPlacement,
       panelPreselection: props.panelPreselection,
+      popupVisible: props.popupVisible,
       onPanelClick,
       onCellClick,
       onCellMouseEnter,

--- a/src/date-picker/DateRangePickerPanel.tsx
+++ b/src/date-picker/DateRangePickerPanel.tsx
@@ -35,7 +35,7 @@ export default defineComponent({
     panelPreselection: dateRangePickerProps.panelPreselection,
     ...dateRangePickerPanelProps,
   },
-  setup(props: TdDateRangePickerPanelProps, { emit }) {
+  setup(props: TdDateRangePickerPanelProps, { emit, attrs }) {
     const {
       value, year, month, time, cacheValue, isFirstValueSelected, onChange,
     } = useRangeValue(props);
@@ -374,7 +374,8 @@ export default defineComponent({
       enableTimePicker: props.enableTimePicker,
       presetsPlacement: props.presetsPlacement,
       panelPreselection: props.panelPreselection,
-      popupVisible: props.popupVisible,
+      // 该属性本身主要是联动父组件使用, 单独使用没有特别意义, 不应该暴露为props
+      popupVisible: (attrs?.popupVisible as Boolean) ?? true,
       onPanelClick,
       onCellClick,
       onCellMouseEnter,

--- a/src/date-picker/type.ts
+++ b/src/date-picker/type.ts
@@ -306,13 +306,6 @@ export interface TdDatePickerPanelProps
    */
   defaultTime?: string;
   /**
-   * 特殊受控属性，单独使用DatePickerPanel需要为true
-   */
-  popupVisible: {
-    type: Boolean;
-    default: true;
-  };
-  /**
    * 点击日期单元格时触发
    */
   onCellClick?: (context: { date: Date; e: MouseEvent }) => void;
@@ -374,13 +367,6 @@ export interface TdDateRangePickerPanelProps
    * @default ["00:00:00", "23:59:59"]
    */
   defaultTime?: string[];
-  /**
-   * 特殊受控属性，单独使用DateRangePickerPanel需要为true
-   */
-  popupVisible: {
-    type: Boolean;
-    default: true;
-  };
   /**
    * 点击日期单元格时触发
    */

--- a/src/date-picker/type.ts
+++ b/src/date-picker/type.ts
@@ -309,7 +309,7 @@ export interface TdDatePickerPanelProps
    * 特殊受控属性，单独使用DatePickerPanel需要为true
    */
   popupVisible: {
-    type: boolean;
+    type: Boolean;
     default: true;
   };
   /**
@@ -378,7 +378,7 @@ export interface TdDateRangePickerPanelProps
    * 特殊受控属性，单独使用DateRangePickerPanel需要为true
    */
   popupVisible: {
-    type: boolean;
+    type: Boolean;
     default: true;
   };
   /**

--- a/src/date-picker/type.ts
+++ b/src/date-picker/type.ts
@@ -306,6 +306,13 @@ export interface TdDatePickerPanelProps
    */
   defaultTime?: string;
   /**
+   * 特殊受控属性，单独使用DatePickerPanel需要为true
+   */
+  popupVisible: {
+    type: boolean;
+    default: true;
+  };
+  /**
    * 点击日期单元格时触发
    */
   onCellClick?: (context: { date: Date; e: MouseEvent }) => void;
@@ -367,6 +374,13 @@ export interface TdDateRangePickerPanelProps
    * @default ["00:00:00", "23:59:59"]
    */
   defaultTime?: string[];
+  /**
+   * 特殊受控属性，单独使用DateRangePickerPanel需要为true
+   */
+  popupVisible: {
+    type: boolean;
+    default: true;
+  };
   /**
    * 点击日期单元格时触发
    */


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [√] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#2279 

### 💡 需求背景和解决方案
组件单独使用的时候并没有传递popupVisible属性，本身在单独使用的时候并没有父组件为date-picker-panel & date-range-picker-panel传递该属性，导致在single-panel(time-picker/panel/single-panel.tsx)中handleScroll方法对props.isShowPanel判断结果为真，卷动无法继续运行

### 📝 更新日志
添加了popupVisible属性

- fix(date-picker): 修复单独的panel拎出来并且启用enable-time-picker时，时分秒无法双向绑定且无法滚动的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [√] 文档已补充或无须补充
- [√] 代码演示已提供或无须提供
- [√] TypeScript 定义已补充或无须补充
- [√] Changelog 已提供或无须提供
