### PR TITLE
fix(message): 修改创建MessageList实例的判断条件

### DIFF
--- a/src/message/plugin.tsx
+++ b/src/message/plugin.tsx
@@ -70,7 +70,9 @@ const MessageFunction = (props: MessageOptions): Promise<MessageInstance> => {
     instanceMap.set(attachDom, {});
   }
   const p = instanceMap.get(attachDom)[placement];
-  if (!p) {
+
+  // attachDom被清空(如attachDom.innerHtml='')，p也会存在，需要判断下dom包含关系
+  if (!p || !attachDom.contains(p.$el)) {
     const instance = new MessageList({
       propsData: {
         zIndex: options.zIndex,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue/issues/2415

复现代码
```
<template>
<div>
  <div class="message-wrap" ref='mss'>
      111
  </div>
  <t-space>
    <t-button variant="outline" @click="closeFunc"> 自由控制关闭时机（{{ msg ? '关闭' : '打开' }}） </t-button>
  </t-space>
  </div>
</template>

<script>
export default {
  data() {
    return {
      msg: null,
    };
  },
  
  methods: {
    // 自由控制关闭时机
    closeFunc() {
        this.$message.closeAll()
        if(this.msg) {
          this.$refs.mss.innerHTML = ''
        }
        this.msg = this.$message.info({
          attach:'.message-wrap',
          content: '调用关闭函数关闭信息提示框',
          duration: 0,
          zIndex: 1001,
        });
    },
  },
};
</script>
```

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
message的attachDom被清空(如attachDom.innerHtml='')，之前的缓存实例也会存在，需要判断下dom包含关系


### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(message): message通过命令调用时，attach所在Dom被清空后，新的message无法显示问题修复

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
