### PR TITLE
fix(input-adornment): fix render empty string prepend and append

### DIFF
--- a/src/input-adornment/input-adornment.tsx
+++ b/src/input-adornment/input-adornment.tsx
@@ -15,6 +15,7 @@ export default mixins(classPrefixMixins).extend({
     renderAddon(h: CreateElement, type: string, addon: string | Function | undefined): JsxNode {
       let addonNode: JsxNode;
       const isContentNode = isString(addon) || isNumber(addon);
+      if (!addon) return null;
 
       if (this.$scopedSlots[type]) {
         if (this.$scopedSlots[type](null).length === 1 && this.$scopedSlots[type](null)[0].text) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/2356
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(InputAdornment): 修复prepend或append为空字符串时仍然渲染节点的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
