### PR TITLE
fix(loading): 函数式关闭全屏loading时，需要先判断全屏实例是否存在，避免实例已销毁情况的报错

### DIFF
--- a/src/loading/plugin.tsx
+++ b/src/loading/plugin.tsx
@@ -40,10 +40,8 @@ function produceLoading(props: boolean | TdLoadingProps): LoadingInstance {
   };
   // 全屏加载
   if (props === true) {
-    // 若存在已经创建的全屏实例则先hide
-    if (fullScreenLoadingInstance) {
-      destroyLoadingInstance();
-    }
+    // 若存在已经创建的全屏实例则不需要再创建
+    if (fullScreenLoadingInstance) return;
     fullScreenLoadingInstance = createLoading({
       fullscreen: true,
       loading: true,
@@ -51,12 +49,13 @@ function produceLoading(props: boolean | TdLoadingProps): LoadingInstance {
     });
     return fullScreenLoadingInstance;
   }
-  if (props === false) {
+  // 存在全屏实例时才执行销毁动作
+  if (props === false && fullScreenLoadingInstance) {
     // 销毁全屏实例
     destroyLoadingInstance();
     return;
   }
-  return createLoading(props);
+  return createLoading(props as TdLoadingProps);
 }
 
 export type LoadingPluginType = Vue.PluginObject<undefined> & LoadingMethod;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
问题：函数式关闭全屏loading时，若多次调用关闭函数则会报错
解决方案：卸载全屏loading实例时，需判断实例是否存在

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(loading): 修复多次调用关闭全屏函数时控制台报错问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
