### PR TITLE
fix/zhangpaopao/popup_plugin_type

### DIFF
--- a/src/popup/plugin.tsx
+++ b/src/popup/plugin.tsx
@@ -8,6 +8,7 @@ import { getClassPrefixMixins } from '../config-provider/config-receiver';
 import { renderTNodeJSX } from '../utils/render-tnode';
 import { getPopperPlacement, triggers } from './utils';
 import mixins from '../utils/mixins';
+import log from '../_common/js/log';
 
 import type { TNode, ClassName } from '../common';
 import type { TdPopupProps } from './type';
@@ -42,7 +43,11 @@ const Overlay = mixins(classPrefixMixins).extend({
     ...props,
     triggerEl: {
       validator(value) {
-        return value instanceof HTMLElement;
+        if (!(value instanceof HTMLElement)) {
+          log.warn('Popup', `Invalid value for prop "triggerEl": expected an HTMLElement, but got ${typeof value}.`);
+          return false;
+        }
+        return true;
       },
       required: true,
     },

--- a/src/table/hooks/useFixed.ts
+++ b/src/table/hooks/useFixed.ts
@@ -237,7 +237,7 @@ export default function useFixed(
         const th = thList[j] as HTMLElement;
         const colKey = th.dataset.colkey;
         if (!colKey) {
-          log.warn('TDesign Table', `${th.innerText} missing colKey. colKey is required for fixed column feature.`);
+          log.warn('Table', `${th.innerText} missing colKey. colKey is required for fixed column feature.`);
         }
         const obj = initialColumnMap.get(colKey || j);
         if (obj?.col?.fixed) {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复

### 💡 需求背景和解决方案

- fix popup's triggerEl prop type 
<img width="481" alt="企业微信截图_5c4eabe2-3cda-4ebd-a5b6-25f84fe47a28" src="https://github.com/Tencent/tdesign-vue/assets/26377630/3e87fe5d-936d-44f6-8e83-4e5266e6417f">

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): 修复`popupPlugin`用法的`triggerElement`参数的类型问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
