### PR TITLE
fix(input-adornment): fix render  prepend and append slot

### DIFF
--- a/src/input-adornment/input-adornment.tsx
+++ b/src/input-adornment/input-adornment.tsx
@@ -15,7 +15,7 @@ export default mixins(classPrefixMixins).extend({
     renderAddon(h: CreateElement, type: string, addon: string | Function | undefined): JsxNode {
       let addonNode: JsxNode;
       const isContentNode = isString(addon) || isNumber(addon);
-      if (!addon) return null;
+      if (!this.$scopedSlots[type] && isString(addon) && !addon) return null;
 
       if (this.$scopedSlots[type]) {
         if (this.$scopedSlots[type](null).length === 1 && this.$scopedSlots[type](null)[0].text) {

--- a/src/select/option.tsx
+++ b/src/select/option.tsx
@@ -183,7 +183,8 @@ export default defineComponent({
     const {
       classes, mouseEvent, labelText, title,
     } = this;
-    const optionChild = renderContent(this, 'default', 'content') || <span>{labelText}</span>;
+    const selfDefinedContent = renderContent(this, 'default', 'content');
+    const optionChild = selfDefinedContent || <span>{labelText}</span>;
     const titleText = title || labelText;
     if (this.hasLazyLoadHolder) {
       return (
@@ -220,7 +221,7 @@ export default defineComponent({
             {optionChild}
           </t-checkbox>
         ) : (
-          <span>{optionChild}</span>
+          optionChild
         )}
       </li>
     );


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/2438
- https://github.com/Tencent/tdesign-vue-next/issues/2926
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(InputAdornment): 修复1.3.4中修复空字符串导致插槽没有正常渲染的问题
- feat(Select): 优化选项结构 移除多余的span节点


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
