### PR TITLE
feat(menu-item): 修正菜单项为a标签时的跳转行为与渲染样式

### DIFF
--- a/src/menu/menu-item-props.ts
+++ b/src/menu/menu-item-props.ts
@@ -18,7 +18,7 @@ export default {
   },
   /** 是否禁用菜单项展开/收起/跳转等功能 */
   disabled: Boolean,
-  /** 跳转链接 */
+  /** 跳转链接，菜单项渲染为a标签，当routerLink为true时将使用Router进行路由跳转 */
   href: {
     type: String,
     default: '',
@@ -33,6 +33,10 @@ export default {
   router: {
     type: Object as PropType<TdMenuItemProps['router']>,
   },
+  /**
+   * 菜单项内容是否渲染为使用Router进行跳转的a标签，当且仅当 Router 存在时，该 API 有效
+   */
+  routerLink: Boolean,
   /** 链接或路由跳转方式 */
   target: {
     type: String as PropType<TdMenuItemProps['target']>,

--- a/src/menu/menu-item.tsx
+++ b/src/menu/menu-item.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import {
   defineComponent, computed, inject, onMounted,
 } from '@vue/composition-api';
@@ -40,10 +41,10 @@ export default defineComponent({
       menu.select(props.value);
       ctx.emit('click');
 
-      if (props.to) {
+      if (props.to || (props.routerLink && props.href)) {
         const router = props.router || (ctx.root as Record<string, any>).$router;
         const methods: string = props.replace ? 'replace' : 'push';
-        router[methods](props.to).catch((err: Error) => {
+        router[methods](props.to || props.href).catch((err: Error) => {
           // vue-router 3.1.0+ push/replace cause NavigationDuplicated error
           // https://github.com/vuejs/vue-router/issues/2872
           // 当前path和目标path相同时，会抛出NavigationDuplicated的错误
@@ -76,6 +77,8 @@ export default defineComponent({
     };
   },
   render() {
+    const router = this.router || this.$router;
+
     const liContent = (
       <li
         v-ripple={(this.keepAnimation as Record<AnimationType, boolean>).ripple}
@@ -83,15 +86,30 @@ export default defineComponent({
         onClick={this.handleClick}
       >
         {renderTNodeJSX(this, 'icon')}
-        {this.href ? (
-          <a href={this.href} target={this.target} class={`${this.classPrefix}-menu__item-link`}>
+        {this.routerLink ? (
+          <a
+            href={this.href ? this.href : this.to ? (router as any)?.resolve(this.to).href : ''}
+            target={this.target}
+            class={`${this.classPrefix}-menu__item-link`}
+            onClick={(e: MouseEvent) => e.preventDefault()}
+          >
+            <span class={`${this.classPrefix}-menu__content`}>{renderContent(this, 'default', 'content')}</span>
+          </a>
+        ) : this.href ? (
+          <a
+            href={this.href}
+            target={this.target}
+            class={`${this.classPrefix}-menu__item-link`}
+            onClick={(e: MouseEvent) => this.disabled && e.preventDefault()}
+          >
             <span class={`${this.classPrefix}-menu__content`}>{renderContent(this, 'default', 'content')}</span>
           </a>
         ) : (
-          <span class={[`${this.classPrefix}-menu__content`]}>{renderContent(this, 'default', 'content')}</span>
+          <span class={`${this.classPrefix}-menu__content`}>{renderContent(this, 'default', 'content')}</span>
         )}
       </li>
     );
+
     // 菜单收起，且只有本身为一级菜单才需要显示 tooltip
     if (this.collapsed && /tmenu/i.test(this.$parent.$vnode?.tag)) {
       return (

--- a/src/menu/type.ts
+++ b/src/menu/type.ts
@@ -157,7 +157,7 @@ export interface TdMenuItemProps {
    */
   disabled?: boolean;
   /**
-   * 跳转链接
+   * 跳转链接，菜单项渲染为a标签，当routerLink为true时将使用Router进行路由跳转
    * @default ''
    */
   href?: string;
@@ -174,6 +174,10 @@ export interface TdMenuItemProps {
    * 路由对象。如果项目存在 Router，则默认使用 Router。
    */
   router?: Record<string, any>;
+  /**
+   * 菜单项内容是否渲染为使用Router进行跳转的a标签，当且仅当 Router 存在时，该 API 有效
+   */
+  routerLink?: boolean;
   /**
    * 链接或路由跳转方式
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
样式修改已在common仓库提PR https://github.com/Tencent/tdesign-common/pull/1506
vue-next仓库的PR https://github.com/Tencent/tdesign-vue-next/pull/3057
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(MenuItem): 新增API: routerLink，可指定菜单项渲染为Router控制跳转的a标签
- fix(MenuItem): 渲染为a标签时，a标签覆盖范围扩大至整个菜单项，而不是只有文本部分
- fix(MenuItem): 修复当菜单项渲染a标签并且menu在collapsed状态时，菜单项内区隐藏导致无法点击跳转的问题
- fix(MenuItem): 修复渲染为a标签时并在popup出现时，文本对齐与正常菜单项的位置不一致的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
