### PR TITLE
fix: alert opacity style when closed

### DIFF
--- a/src/alert/alert.tsx
+++ b/src/alert/alert.tsx
@@ -160,7 +160,8 @@ export default mixins(getConfigReceiverMixins<Vue, AlertConfig>('alert'), getGlo
     },
 
     handleCloseEnd(e: TransitionEvent) {
-      if (e.propertyName === 'opacity') {
+      // 只有当前 Alert DOM 元素 opacity 变化时才触发，防止自定义子元素影响
+      if (e.propertyName === 'opacity' && e.target === this.$el) {
         this.visible = false;
         this.$emit('closed', { e });
         if (this.onClosed) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

https://stackblitz.com/edit/sxrzm5?file=src%2Fdemo.vue

<img width="1698" alt="image" src="https://github.com/Tencent/tdesign-vue/assets/7600149/b211da3b-9311-408b-ac48-91636fb065a6">

现有判断会导致子元素 opacity 变化结束时（比如 link hover 颜色变化后）也触发 Alert 的隐藏关闭逻辑。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Alert): 修复内部自定义元素透明度变化，意外导致 Alert 隐藏的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
