### PR TITLE
fix: 销毁前需要移除dialog创建的DOM

### DIFF
--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -225,6 +225,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
 
     destroySelf() {
       this.styleEl.parentNode?.removeChild?.(this.styleEl);
+      this.$el.parentNode?.removeChild?.(this.$el);          
     },
 
     storeUid(flag: boolean) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/Tencent/tdesign-vue/issues/2006
https://github.com/Tencent/tdesign-vue-next/pull/2242


### 💡 需求背景和解决方案
弹窗组件销毁前，务必删除自己相关的DOM，否则会有内存泄露

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TDiaglog): 在组件销毁前，清理组件创建的DOM

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
