### PR TITLE
[+] 销毁前需要移除dialog创建的DOM

### DIFF
--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -209,6 +209,7 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
   beforeDestroy() {
     this.addKeyboardEvent(false);
     this.destroySelf();
+    this.destroySelfStyle();
   },
 
   directives: {
@@ -219,12 +220,16 @@ export default mixins(ActionMixin, getConfigReceiverMixins<Vue, DialogConfig>('d
     clearStyleFunc() {
       clearTimeout(this.timer);
       this.timer = setTimeout(() => {
-        this.destroySelf();
+        this.destroySelfStyle();
       }, 150);
     },
 
-    destroySelf() {
+    destroySelfStyle() {
       this.styleEl.parentNode?.removeChild?.(this.styleEl);
+    },
+
+    destroySelf() {
+      this.$el.parentNode?.removeChild?.(this.$el);
     },
 
     storeUid(flag: boolean) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

1.  https://github.com/Tencent/tdesign-vue/issues/2006
2. https://github.com/Tencent/tdesign-vue-next/pull/2242

### 💡 需求背景和解决方案


1. 在Dialog组件销毁后，没有正确的对DOM元素进行销毁，导致内存泄露
解决方案：
在beforeDestroy函数中，对创建的DOM元素进行销毁

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Dialog): 修复Dialog组件销毁后，没有销毁DOM，导致内存泄漏

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
