### PR TITLE
feat(tabs): support tab-panel content lazy load

### DIFF
--- a/src/tabs/__tests__/index.test.jsx
+++ b/src/tabs/__tests__/index.test.jsx
@@ -71,6 +71,72 @@ describe('Tabs', () => {
       });
       expect(wrapper.element).toMatchSnapshot();
     });
+    it(':destroyOnHide', async () => {
+      const wrapper = mount({
+        data() {
+          return {
+            currentTab: 1,
+          };
+        },
+        render() {
+          return (
+            <Tabs value={this.currentTab}>
+              <TabPanel class="tab-panel-1" value={1} label={'1'} destroyOnHide={true}>
+                1
+              </TabPanel>
+              <TabPanel class="tab-panel-2" value={2} label={'2'} destroyOnHide={true}>
+                2
+              </TabPanel>
+            </Tabs>
+          );
+        },
+      });
+
+      expect(wrapper.find('.tab-panel-1').text()).toBe('1');
+      expect(() => wrapper.get('.tab-panel-2')).toThrowError();
+
+      wrapper.setData({ currentTab: 2 });
+      await Vue.nextTick();
+      expect(() => wrapper.get('.tab-panel-1')).toThrowError();
+      expect(wrapper.find('.tab-panel-2').text()).toBe('2');
+    });
+
+    it(':lazy', async () => {
+      const wrapper = mount({
+        data() {
+          return {
+            currentTab: 1,
+          };
+        },
+        render() {
+          return (
+            <Tabs value={this.currentTab}>
+              <TabPanel class="tab-panel-1" lazy value={1} label={'1'} destroyOnHide={false}>
+                1
+              </TabPanel>
+              <TabPanel class="tab-panel-2" lazy value={2} label={'2'} destroyOnHide={false}>
+                2
+              </TabPanel>
+            </Tabs>
+          );
+        },
+      });
+
+      const displayNoneStyle = 'display: none;';
+
+      expect(wrapper.find('.tab-panel-1').attributes().style).toBeFalsy();
+      expect(() => wrapper.get('.tab-panel-2')).toThrowError();
+
+      wrapper.setData({ currentTab: 2 });
+      await Vue.nextTick();
+      expect(wrapper.find('.tab-panel-1').attributes().style).toBe(displayNoneStyle);
+      expect(wrapper.find('.tab-panel-2').attributes().style).toBeFalsy();
+
+      wrapper.setData({ currentTab: 1 });
+      await Vue.nextTick();
+      expect(wrapper.find('.tab-panel-1').attributes().style).toBeFalsy();
+      expect(wrapper.find('.tab-panel-2').attributes().style).toBe(displayNoneStyle);
+    });
   });
 
   // test events

--- a/src/tabs/tab-panel-props.ts
+++ b/src/tabs/tab-panel-props.ts
@@ -36,4 +36,9 @@ export default {
   },
   /** 点击删除按钮时触发 */
   onRemove: Function as PropType<TdTabPanelProps['onRemove']>,
+  /** 标签内容是否延迟渲染 */
+  lazy: {
+    type: Boolean,
+    default: false,
+  },
 };

--- a/src/tabs/tab-panel.tsx
+++ b/src/tabs/tab-panel.tsx
@@ -18,6 +18,12 @@ export default mixins(Vue as VueConstructor<TabPanel>, classPrefixMixins).extend
 
   props: { ...props },
 
+  data() {
+    return {
+      loaded: false,
+    };
+  },
+
   inject: {
     parent: { default: null },
   },
@@ -25,7 +31,13 @@ export default mixins(Vue as VueConstructor<TabPanel>, classPrefixMixins).extend
   computed: {
     active(): boolean {
       const { value } = this.parent || {};
-      return this.value === value;
+      const result = this.value === value;
+
+      if (result) {
+        this.loaded = true;
+      }
+
+      return result;
     },
   },
 
@@ -41,12 +53,16 @@ export default mixins(Vue as VueConstructor<TabPanel>, classPrefixMixins).extend
   },
 
   render() {
-    const { destroyOnHide, active } = this;
+    const {
+      destroyOnHide, active, lazy, loaded,
+    } = this;
+
     if (destroyOnHide && !active) return null;
-    return (
+
+    return !lazy || loaded ? (
       <div class={this.componentName} v-show={active}>
         {renderContent(this, 'default', 'panel')}
       </div>
-    );
+    ) : null;
   },
 });

--- a/src/tabs/tab-panel.tsx
+++ b/src/tabs/tab-panel.tsx
@@ -57,12 +57,12 @@ export default mixins(Vue as VueConstructor<TabPanel>, classPrefixMixins).extend
       destroyOnHide, active, lazy, loaded,
     } = this;
 
-    if (destroyOnHide && !active) return null;
+    if ((destroyOnHide && !active) || (lazy && !loaded)) return null;
 
-    return !lazy || loaded ? (
+    return (
       <div class={this.componentName} v-show={active}>
         {renderContent(this, 'default', 'panel')}
       </div>
-    ) : null;
+    );
   },
 });

--- a/src/tabs/tabs.md
+++ b/src/tabs/tabs.md
@@ -41,6 +41,7 @@ panel | String / Slot / Function | - | 用于自定义选项卡面板内容。TS
 removable | Boolean | false | 当前选项卡是否允许移除 | N
 value | String / Number | - | 选项卡的值，唯一标识。TS 类型：`TabValue` | N
 onRemove | Function |  | TS 类型：`(options: { value: TabValue; e: MouseEvent }) => void`<br/>点击删除按钮时触发 | N
+lazy | Boolean | false | 标签内容是否延迟渲染 | N
 
 ### TabPanel Events
 

--- a/src/tabs/type.ts
+++ b/src/tabs/type.ts
@@ -57,7 +57,7 @@ export interface TdTabsProps {
    * 删除选项卡时触发
    */
   onRemove?: (options: { value: TabValue; index: number; e: MouseEvent }) => void;
-};
+}
 
 export interface TdTabPanelProps {
   /**
@@ -95,6 +95,10 @@ export interface TdTabPanelProps {
    * 点击删除按钮时触发
    */
   onRemove?: (options: { value: TabValue; e: MouseEvent }) => void;
-};
+  /**
+   * 标签是否延迟渲染
+   */
+  lazy?: Boolean;
+}
 
 export type TabValue = string | number;


### PR DESCRIPTION
re #2666

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

re #2666 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(tabs): 支持tab-panel内容懒加载

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
