### PR TITLE
fix(tree): tree 组件，解决 watch 回调时间过迟的问题

### DIFF
--- a/src/tree/hooks/useTreeStore.ts
+++ b/src/tree/hooks/useTreeStore.ts
@@ -1,9 +1,7 @@
 import pick from 'lodash/pick';
 import { TreeStore } from '../../_common/js/tree/tree-store';
-import { watch } from '../adapt';
 import {
   TreeProps,
-  TreeNodeValue,
   TypeValueMode,
   TypeEventState,
   TypeTreeNodeModel,
@@ -21,7 +19,6 @@ export default function useTreeStore(state: TypeTreeState) {
     filter,
   });
 
-  const { refProps } = state;
   const [tValue] = state.vmValue;
   const [tActived] = state.vmActived;
   const [tExpanded] = state.vmExpanded;
@@ -137,6 +134,7 @@ export default function useTreeStore(state: TypeTreeState) {
 
   const rebuild = (list: TreeProps['data']) => {
     store.reload(list || []);
+    store.refreshNodes();
     // 初始化选中状态
     if (Array.isArray(tValue.value)) {
       store.setChecked(tValue.value);
@@ -185,33 +183,10 @@ export default function useTreeStore(state: TypeTreeState) {
   // 设置初始化状态
   state.setStore(store);
 
-  // 配置属性监听
-  // tValue 就是 refProps.value
-  watch(tValue, (nVal: TreeNodeValue[]) => {
-    store.replaceChecked(nVal);
-  });
-  // tExpanded 就是 refProps.expanded
-  watch(tExpanded, (nVal: TreeNodeValue[]) => {
-    store.replaceExpanded(nVal);
-  });
-  // tActived 就是 refProps.actived
-  watch(tActived, (nVal: TreeNodeValue[]) => {
-    store.replaceActived(nVal);
-  });
-  watch(refProps.data, (list) => {
-    rebuild(list);
-  });
-  watch(refProps.filter, (nVal, previousVal) => {
-    checkFilterExpand(nVal, previousVal);
-  });
-  watch(refProps.keys, (keys) => {
-    store.setConfig({
-      keys,
-    });
-  });
-
   return {
     store,
+    rebuild,
+    checkFilterExpand,
     updateStoreConfig,
     updateExpanded,
     expandFilterPath,

--- a/src/tree/tree.tsx
+++ b/src/tree/tree.tsx
@@ -96,11 +96,11 @@ export default defineComponent({
       componentName,
       state,
       store,
-      rebuild,
-      checkFilterExpand,
       treeClasses,
       treeContentRef,
 
+      rebuild,
+      checkFilterExpand,
       updateStoreConfig,
       setActived,
       setExpanded,

--- a/src/tree/tree.tsx
+++ b/src/tree/tree.tsx
@@ -42,6 +42,31 @@ export default defineComponent({
     ...props,
   },
 
+  watch: {
+    // 实测发现，composition api 中的 refsProps watch ，回调时间迟于 $nextTick 回调
+    // 因此改为在这里绑定属性监听，实测这里的 watch 回调，早于 $nextTick 回调发生
+    data(list) {
+      this.rebuild(list);
+    },
+    value(nVal: TreeNodeValue[]) {
+      this.store.replaceChecked(nVal);
+    },
+    expanded(nVal: TreeNodeValue[]) {
+      this.store.replaceExpanded(nVal);
+    },
+    actived(nVal: TreeNodeValue[]) {
+      this.store.replaceActived(nVal);
+    },
+    filter(nVal, previousVal) {
+      this.checkFilterExpand(nVal, previousVal);
+    },
+    keys(keys) {
+      this.store.setConfig({
+        keys,
+      });
+    },
+  },
+
   setup(props, context) {
     const { t, global } = useConfig('tree');
     const classPrefix = usePrefixClass();
@@ -50,7 +75,9 @@ export default defineComponent({
     // 用于 hooks 传递数据
     const { state } = useTreeState(props, context);
     const { treeContentRef, isScrolling } = state;
-    const { store, updateStoreConfig } = useTreeStore(state);
+    const {
+      store, updateStoreConfig, rebuild, checkFilterExpand,
+    } = useTreeStore(state);
 
     useDragHandle(state);
     const { setActived, setExpanded, setChecked } = useTreeAction(state);
@@ -69,6 +96,8 @@ export default defineComponent({
       componentName,
       state,
       store,
+      rebuild,
+      checkFilterExpand,
       treeClasses,
       treeContentRef,
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue/issues/2870

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
实际测试发现，重构后，composition api 提供的 watch 事件，回调发生事件迟于 nextTick。
导致 data 设置后，在 nextTick 无法取得变更数据。

暂时无法查明回调被推迟的实际原因，先改为直接使用 vue 组件的 watch 方法。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tree): 解决 watch 回调时间过迟的问题
- test(tree): 补充该问题对应的单元测试

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
