### PR TITLE
fix(popup): ignore mouseenter when destroyOnClose is true and is leaving

### DIFF
--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -57,6 +57,8 @@ export default mixins(classPrefixMixins).extend({
       mouseInRange: false,
       /** mark popup as clicked when mousedown, reset after mouseup */
       contentClicked: false,
+      /** is popup leaving */
+      isLeaving: false,
     };
   },
   computed: {
@@ -316,6 +318,10 @@ export default mixins(classPrefixMixins).extend({
       }
     },
     onMouseEnter() {
+      if (this.destroyOnClose && this.isLeaving) {
+        // 如果 popup 在关闭的时候会被销毁，那在它消失的过程中，不响应鼠标进入事件，因为否则不会触发 mouseleave
+        return;
+      }
       this.mouseInRange = true;
       this.handleOpen({});
     },
@@ -344,6 +350,13 @@ export default mixins(classPrefixMixins).extend({
       if (this.visible) {
         this.updatePopper();
       }
+    },
+    onLeave() {
+      this.isLeaving = true;
+    },
+    onAfterLeave() {
+      this.isLeaving = false;
+      this.destroyPopper();
     },
     preventClosing(preventing: boolean) {
       const parent = (this as any).popup;
@@ -441,7 +454,8 @@ export default mixins(classPrefixMixins).extend({
           appear
           onBeforeEnter={this.onBeforeEnter}
           onAfterEnter={this.onAfterEnter}
-          onAfterLeave={this.destroyPopper}
+          onLeave={this.onLeave}
+          onAfterLeave={this.onAfterLeave}
         >
           {overlay}
         </transition>


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Tencent/tdesign-vue/issues/2897

### 💡 需求背景和解决方案

问题背景：

Popup 在 destroyOnClose 的值为 true 的时候，在 pupup 逐渐消失的过程中如果鼠标 hover 上去，popup 将再也不会出现。

解决方案：

如果 destroyOnClose 的值为 true ，那让 popup 在渐变消失的过程中，不再响应鼠标进入事件。

```typescript
    onMouseEnter() {
      if (this.destroyOnClose && this.isLeaving) {
        // 如果 popup 在关闭的时候会被销毁，那在它消失的过程中，不响应鼠标进入事件，因为否则不会触发 mouseleave
        return;
      }
      this.mouseInRange = true;
      this.handleOpen({});
    },
```

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(popup): ignore mouseenter when destroyOnClose is true and is leaving

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
