### PR TITLE
[Checkbox] fix set value checked before options pushed, while checkbox UI is not checked

### DIFF
--- a/src/checkbox/checkbox.tsx
+++ b/src/checkbox/checkbox.tsx
@@ -111,6 +111,7 @@ export default defineComponent({
       if (parentDisabled !== undefined) {
         tDisabled.value = parentDisabled;
       }
+      tDisabled.value = disabled;
     };
 
     watch([checkboxStore], () => {
@@ -161,6 +162,9 @@ export default defineComponent({
       [data, label, storeKey],
       () => {
         if (!storeKey.value) return;
+        if (!tChecked.value && checkboxStore.value?.parentChecked?.includes(props.value)) {
+          tChecked.value = true;
+        }
         subscribeParentData(props.checkAll ? 'CHECK_ALL' : value.value);
       },
       { immediate: true },
@@ -174,7 +178,7 @@ export default defineComponent({
       if (props.readonly) return;
       const checked = !tChecked.value;
       setInnerChecked(checked, { e });
-      if (checkboxGroupData?.value.handleCheckboxChange) {
+      if (checkboxGroupData?.value.onCheckedChange) {
         checkboxGroupData.value.onCheckedChange({
           checked,
           checkAll: props.checkAll,

--- a/src/checkbox/store.ts
+++ b/src/checkbox/store.ts
@@ -36,6 +36,8 @@ export type ObserverListenerParams = {
 class CheckboxStore {
   observerMap: ObserverMap = {};
 
+  parentChecked: CheckboxGroupValue;
+
   parentExist: boolean;
 
   init() {
@@ -45,6 +47,7 @@ class CheckboxStore {
   updateChecked({
     checked, isCheckAll, oldChecked, indeterminate,
   }: UpdateCheckedData) {
+    this.parentChecked = checked;
     const changedChecked = oldChecked ? getChangedChecked(checked, oldChecked) : checked;
     const checkedParams: ObserverListenerParams = {
       parentChecked: checked,

--- a/src/hooks/useElementLazyRender.ts
+++ b/src/hooks/useElementLazyRender.ts
@@ -5,7 +5,7 @@ import observe from '../_common/js/utils/observe';
 
 export function useElementLazyRender(labelRef: Ref<HTMLElement>, lazyLoad: Ref<boolean>) {
   const ioObserver = ref<IntersectionObserver>();
-  const showElement = ref(true);
+  const showElement = ref(!lazyLoad.value);
 
   const handleLazyLoad = () => {
     if (!lazyLoad.value || !labelRef.value || ioObserver.value) return;

--- a/src/hooks/useElementLazyRender.ts
+++ b/src/hooks/useElementLazyRender.ts
@@ -5,7 +5,7 @@ import observe from '../_common/js/utils/observe';
 
 export function useElementLazyRender(labelRef: Ref<HTMLElement>, lazyLoad: Ref<boolean>) {
   const ioObserver = ref<IntersectionObserver>();
-  const showElement = ref(!lazyLoad.value);
+  const showElement = ref(true);
 
   const handleLazyLoad = () => {
     if (!lazyLoad.value || !labelRef.value || ioObserver.value) return;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://codesandbox.io/s/tdesign-vue-demo-forked-42rhg8?file=/src/demo.vue 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Checkbox): 修复提前设置某个选项的值在选中项 `CheckboxGorup.value` 里面，再放入选项到 `options` 中，选项呈现状态为非选中问题


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
