### PR TITLE
fix(radio): 选项内容变化后样式问题修复

### DIFF
--- a/src/radio/group.tsx
+++ b/src/radio/group.tsx
@@ -92,7 +92,12 @@ export default mixins(classPrefixMixins).extend({
   mounted() {
     this.calcBarStyle();
     const observer = new MutationObserver(this.calcBarStyle);
-    observer.observe(this.$el, { childList: true, attributes: true, subtree: true });
+    observer.observe(this.$el, {
+      childList: true,
+      attributes: true,
+      subtree: true,
+      characterData: true,
+    });
     this.observer = observer;
     this.addKeyboardListeners();
   },
@@ -137,7 +142,7 @@ export default mixins(classPrefixMixins).extend({
       emitEvent<Parameters<TdRadioGroupProps['onChange']>>(this, 'change', value, context);
     },
 
-    calcDefaultBarStyle(): void {
+    calcDefaultBarStyle() {
       const defaultNode = this.$el.cloneNode(true);
       const div = document.createElement('div');
       div.setAttribute('style', 'position: absolute; visibility: hidden;');
@@ -146,8 +151,8 @@ export default mixins(classPrefixMixins).extend({
 
       const defaultCheckedRadio: HTMLElement = div.querySelector(this.checkedClassName);
       const { offsetWidth, offsetLeft } = defaultCheckedRadio;
-      this.barStyle = { width: `${offsetWidth}px`, left: `${offsetLeft}px` };
       document.body.removeChild(div);
+      return { offsetWidth, offsetLeft };
     },
     calcBarStyle(): void {
       if (this.variant === 'outline') return;
@@ -155,13 +160,17 @@ export default mixins(classPrefixMixins).extend({
       const checkedRadio: HTMLElement = this.$el.querySelector(this.checkedClassName);
       if (!checkedRadio) return;
 
-      const { offsetWidth, offsetLeft } = checkedRadio;
+      let { offsetWidth, offsetLeft } = checkedRadio;
       // current node is not rendered，fallback to default render
       if (!offsetWidth) {
-        this.calcDefaultBarStyle();
-      } else {
-        this.barStyle = { width: `${offsetWidth}px`, left: `${offsetLeft}px` };
+        const { offsetWidth: width, offsetLeft: left } = this.calcDefaultBarStyle();
+        offsetWidth = width;
+        offsetLeft = left;
       }
+      const width = `${offsetWidth}px`;
+      const left = `${offsetLeft}px`;
+      if (this.barStyle.width === width && this.barStyle.left === left) return;
+      this.barStyle = { width, left };
     },
   },
 });


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue/issues/2930

### 💡 需求背景和解决方案

1. 要解决的具体问题
radio button组建label变化时，选中的背景色没有同步变化
2. 列出最终的 API 实现和用法
```
const observer = new MutationObserver(this.calcBarStyle);
observer.observe(this.$el, {
  childList: true,
  attributes: true,
  subtree: true,
  // 新增参数，监听字符串变化
  characterData: true,
});
```

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(radio): 选项内容变化后样式问题修复

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
