### PR TITLE
fix(radio): the checked state also triggers the change event

### DIFF
--- a/src/radio/__tests__/vitest-radio.test.jsx
+++ b/src/radio/__tests__/vitest-radio.test.jsx
@@ -145,7 +145,7 @@ describe('Radio Component', () => {
     expect(onChangeFn.mock.calls[0][0]).toBe(true);
     expect(onChangeFn.mock.calls[0][1].e.type).toBe('click');
   });
-  it('events.change: checked value is true, without allowUncheck, click radio and trigger change', async () => {
+  it('events.change: checked value is true, without allowUncheck, click radio and can not trigger change', async () => {
     const onChangeFn = vi.fn();
     const wrapper = mount({
       render() {
@@ -154,9 +154,7 @@ describe('Radio Component', () => {
     });
     wrapper.find('.t-radio__label').trigger('click');
     await wrapper.vm.$nextTick();
-    expect(onChangeFn).toHaveBeenCalled();
-    expect(onChangeFn.mock.calls[0][0]).toBe(true);
-    expect(onChangeFn.mock.calls[0][1].e.type).toBe('click');
+    expect(onChangeFn).not.toHaveBeenCalled();
   });
 
   it('events.click works fine', async () => {

--- a/src/radio/radio.tsx
+++ b/src/radio/radio.tsx
@@ -94,6 +94,9 @@ export default mixins(Vue as VueConstructor<RadioParentInjectInstance>, classPre
     checkRadio(e: MouseEvent) {
       const tChecked = this.getChecked();
       const allowUncheck = this.allowUncheck || this.radioGroup?.allowUncheck;
+
+      if (tChecked && !allowUncheck) return;
+
       if (this.radioGroup) {
         const value = tChecked && allowUncheck ? undefined : this.value;
         this.radioGroup.handleRadioChange(value, { e });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

fix #2995 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Radio): 处理选中状态也会触发 `change` 事件的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
