### PR TITLE
fix(textarea): 公共组件当初始处于隐藏状态再次可视后未做高度再计算的问题

### DIFF
--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -86,7 +86,19 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
     },
   },
   mounted() {
-    this.adjustTextareaHeight();
+    const textareaElem = this.$refs.refTextareaElem as HTMLInputElement;
+    if (textareaElem) {
+      textareaElem.addEventListener('transitionend', this.adjustTextareaHeight);
+    } else {
+      this.adjustTextareaHeight();
+    }
+  },
+
+  beforeDestroy() {
+    const textareaElem = this.$refs.refTextareaElem as HTMLInputElement;
+    if (textareaElem) {
+      textareaElem.removeEventListener('transitionend', this.adjustTextareaHeight);
+    }
   },
 
   watch: {

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -111,18 +111,20 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
 
   methods: {
     adjustTextareaHeight() {
-      if (!this.$refs.refTextareaElem) return;
-      if (this.autosize === true) {
-        this.textareaStyle = calcTextareaHeight(this.$refs.refTextareaElem as HTMLTextAreaElement);
-      } else if (this.autosize && typeof this.autosize === 'object') {
-        this.textareaStyle = calcTextareaHeight(
-          this.$refs.refTextareaElem as HTMLTextAreaElement,
-          this.autosize?.minRows,
-          this.autosize?.maxRows,
-        );
-      } else if (this.$attrs.rows) {
-        this.textareaStyle = { height: 'auto', minHeight: 'auto' };
-      }
+      this.$nextTick(() => {
+        if (!this.$refs.refTextareaElem) return;
+        if (this.autosize === true) {
+          this.textareaStyle = calcTextareaHeight(this.$refs.refTextareaElem as HTMLTextAreaElement);
+        } else if (this.autosize && typeof this.autosize === 'object') {
+          this.textareaStyle = calcTextareaHeight(
+            this.$refs.refTextareaElem as HTMLTextAreaElement,
+            this.autosize?.minRows,
+            this.autosize?.maxRows,
+          );
+        } else if (this.$attrs.rows) {
+          this.textareaStyle = { height: 'auto', minHeight: 'auto' };
+        }
+      });
     },
     emitEvent(name: string, value: string | number, context: object) {
       this.$emit(name, value, context);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。

-->
- #2809 
### 💡 需求背景和解决方案
需求背景：
使用者提出issue，反馈t-textarea公共组件存在高度计算问题，经定位，该组件已知存在两个问题
1. 没有在任何组件中嵌套的情况：当使用该组件时，如果v-model初始绑定的值是固定值(而不是异步赋的值，比如通过接口请求或者使用宏任务模拟的赋值)，比如v-model绑定的值是value，在data中为value赋了很长的初始值，此时会存在issue中提到的这个问题，但是如果初始值不是固定值是后期通过接口请求或者宏任务模拟赋的值，则不会存在这个问题。
2. 当该组件在部分组件内嵌套使用时，比如t-collapse-panel中，则初始时该组件并没机会通过计算获得高度，而面板再次被展开该组件再次可视后，组件内并没有针对这种场景做高度的重新计算，因此该组件的响应式高度在此场景下失效。

解决方案：
针对问题1：需要确保高度的计算是在DOM挂载完成后进行
针对问题2：仅通过在mounted中和监听value值的变动时做高度响应式计算是不够的，还需要考虑这种初始时该组件处于“隐藏”再次可视的情况。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): 修复组件初始处于隐藏状态，可视后未做高度再计算的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
