### PR TITLE
Fix the bug of textarea with maxlength can't input before limit

### DIFF
--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -123,18 +123,20 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
 
   methods: {
     adjustTextareaHeight() {
-      if (!this.$refs.refTextareaElem) return;
-      if (this.autosize === true) {
-        this.textareaStyle = calcTextareaHeight(this.$refs.refTextareaElem as HTMLTextAreaElement);
-      } else if (this.autosize && typeof this.autosize === 'object') {
-        this.textareaStyle = calcTextareaHeight(
-          this.$refs.refTextareaElem as HTMLTextAreaElement,
-          this.autosize?.minRows,
-          this.autosize?.maxRows,
-        );
-      } else if (this.$attrs.rows) {
-        this.textareaStyle = { height: 'auto', minHeight: 'auto' };
-      }
+      this.$nextTick(() => {
+        if (!this.$refs.refTextareaElem) return;
+        if (this.autosize === true) {
+          this.textareaStyle = calcTextareaHeight(this.$refs.refTextareaElem as HTMLTextAreaElement);
+        } else if (this.autosize && typeof this.autosize === 'object') {
+          this.textareaStyle = calcTextareaHeight(
+            this.$refs.refTextareaElem as HTMLTextAreaElement,
+            this.autosize?.minRows,
+            this.autosize?.maxRows,
+          );
+        } else if (this.$attrs.rows) {
+          this.textareaStyle = { height: 'auto', minHeight: 'auto' };
+        }
+      });
     },
     /**
      * Provide a method to calculate the height of textArea component after DOM mounted

--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -170,16 +170,21 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
     inputValueChangeHandle(e: InputEvent) {
       const { target } = e;
       let val = (target as HTMLInputElement).value;
-      if (this.maxlength) {
-        val = limitUnicodeMaxLength(val, Number(this.maxlength));
+      if (!this.isComposing) {
+        if (this.maxlength) {
+          val = limitUnicodeMaxLength(val, Number(this.maxlength));
+        }
+        if (this.maxcharacter && this.maxcharacter >= 0) {
+          const stringInfo = getCharacterLength(val, this.maxcharacter);
+          val = typeof stringInfo === 'object' && stringInfo.characters;
+        }
       }
-      if (this.maxcharacter && this.maxcharacter >= 0) {
-        const stringInfo = getCharacterLength(val, this.maxcharacter);
-        val = typeof stringInfo === 'object' && stringInfo.characters;
-      }
+
       this.$emit('input', val);
-      // 中文输入时不触发 onChange
-      !this.isComposing && this.emitEvent('change', val, { e });
+      // 中文输入结束才触发 onChange
+      if (!this.isComposing) {
+        this.emitEvent('change', val, { e });
+      }
 
       this.$nextTick(() => this.setInputValue(val));
       this.adjustTextareaHeight();


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
#3041 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
#3041 
-->

### 💡 需求背景和解决方案
**背景**：用户提出issue,反馈设置maxlength后，windows自带输入法，当输入中文时所输入字符还没有达到最大长度也会没法输入。

**问题描述**：textarea公共组件做输入字符限制时，每次 input 事件触发时剪切输入值以符合最大长度。这种剪切假设了所有字符将键入的同时变成结果字符，也就是说，如果用户正在输入一个长拼音字符序列（比如汉字的拼音），但还没有选择对应的汉字结果，输入就会被提前剪切，因为拼音可能会超过最大长度。

**解决方案**：用户在构词状态时不应该设置输入限制和字符剪切，而是等完成后。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): 修复设置`maxlength`后，在windows自带输入法中，中文时不到最大长度也会自动覆盖之前已输入内容的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
