### PR TITLE
fix(textarea): value绑定值时，autosize时无法输入中文问题

### DIFF
--- a/src/textarea/textarea.tsx
+++ b/src/textarea/textarea.tsx
@@ -1,5 +1,6 @@
 import Vue, { VueConstructor } from 'vue';
 import isFunction from 'lodash/isFunction';
+import merge from 'lodash/merge';
 import { getUnicodeLength, limitUnicodeMaxLength } from '../_common/js/utils/helper';
 import { getPropsApiByEvent, getCharacterLength } from '../utils/helper';
 import calcTextareaHeight from './calcTextareaHeight';
@@ -7,6 +8,7 @@ import { renderTNodeJSX } from '../utils/render-tnode';
 import { ClassName } from '../common';
 import { getClassPrefixMixins } from '../config-provider/config-receiver';
 import mixins from '../utils/mixins';
+import setStyle from '../_common/js/utils/set-style';
 
 import props from './props';
 import type { TextareaValue } from './type';
@@ -116,6 +118,13 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
     value: {
       handler() {
         this.$nextTick(() => this.adjustTextareaHeight());
+      },
+      immediate: true,
+    },
+    textareaStyle: {
+      handler(val) {
+        const { style } = this.$attrs;
+        setStyle(this.$refs.refTextareaElem as HTMLTextAreaElement, merge(style, val));
       },
       immediate: true,
     },
@@ -265,7 +274,6 @@ export default mixins(Vue as VueConstructor<Textarea>, classPrefixMixins).extend
           {...{ attrs: { ...this.$attrs, ...this.inputAttrs }, on: inputEvents }}
           value={this.value}
           class={classes}
-          style={this.textareaStyle}
           ref="refTextareaElem"
         ></textarea>
         {textTips || limitText ? (


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#3049 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
因为中文输入中时，拼音不会触发change时间，当textareaStyle改变，textarea渲染时value值并没有改变，导致不能输入中文。
参考vue-next中textarea的做法，使用setStyle方法来控制textareaStyle

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(textarea): value绑定值时，autosize时无法输入中文问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
