### PR TITLE
fix(textarea): `autosize` doesn't work in Firefox

### DIFF
--- a/src/textarea/calcTextareaHeight.ts
+++ b/src/textarea/calcTextareaHeight.ts
@@ -4,8 +4,8 @@
 type RowsType = number | null;
 
 type ResultType = {
-  height?: string,
-  minHeight?: string
+  height?: string;
+  minHeight?: string;
 };
 
 let hiddenTextarea: HTMLTextAreaElement;
@@ -15,7 +15,7 @@ const HIDDEN_TEXTAREA_STYLE = `
   max-height:none !important;
   height:0 !important;
   visibility:hidden !important;
-  overflow:hidden !important;
+  overflow-y:hidden !important;
   position:absolute !important;
   z-index:-1000 !important;
   top:0 !important;
@@ -45,25 +45,20 @@ function calculateNodeStyling(targetElement: HTMLTextAreaElement) {
   const style = window.getComputedStyle(targetElement);
 
   const boxSizing = style.getPropertyValue('box-sizing')
-  || style.getPropertyValue('-moz-box-sizing')
-  || style.getPropertyValue('-webkit-box-sizing');
+    || style.getPropertyValue('-moz-box-sizing')
+    || style.getPropertyValue('-webkit-box-sizing');
 
-  const paddingSize = (
-    parseFloat(style.getPropertyValue('padding-bottom'))
-    + parseFloat(style.getPropertyValue('padding-top'))
-  );
+  const paddingSize = parseFloat(style.getPropertyValue('padding-bottom')) + parseFloat(style.getPropertyValue('padding-top'));
 
-  const borderSize = (
-    parseFloat(style.getPropertyValue('border-bottom-width'))
-    + parseFloat(style.getPropertyValue('border-top-width'))
-  );
+  const borderSize = parseFloat(style.getPropertyValue('border-bottom-width')) + parseFloat(style.getPropertyValue('border-top-width'));
 
-  const sizingStyle = SIZING_PROPS
-    .map((name) => `${name}:${style.getPropertyValue(name)}`)
-    .join(';');
+  const sizingStyle = SIZING_PROPS.map((name) => `${name}:${style.getPropertyValue(name)}`).join(';');
 
   return {
-    sizingStyle, paddingSize, borderSize, boxSizing,
+    sizingStyle,
+    paddingSize,
+    borderSize,
+    boxSizing,
   };
 }
 
@@ -78,10 +73,7 @@ export default function calcTextareaHeight(
   }
 
   const {
-    paddingSize,
-    borderSize,
-    boxSizing,
-    sizingStyle,
+    paddingSize, borderSize, boxSizing, sizingStyle,
   } = calculateNodeStyling(targetElement);
 
   hiddenTextarea.setAttribute('style', `${sizingStyle};${HIDDEN_TEXTAREA_STYLE}`);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
解决与此 [pr](https://github.com/Tencent/tdesign-vue-next/pull/4104) 相同的问题。

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Textarea): `autosize` 在 `Firefox` 中不生效。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
