### PR TITLE
fix(select-input): allowInput is true and cannot be entered in multiple selection cases

### DIFF
--- a/src/select-input/useMultiple.tsx
+++ b/src/select-input/useMultiple.tsx
@@ -112,8 +112,8 @@ export default function useMultiple(props: TdSelectInputProps, context: SetupCon
         scopedSlots={slots}
         props={tagInputProps}
         on={{
-          'input-change': onInputChange,
           ...newListeners,
+          'input-change': onInputChange,
           change: onTagInputChange,
           clear: p.onInnerClear,
           // [Important Info]: SelectInput.blur is not equal to TagInput, example: click popup panel


### PR DESCRIPTION
fix(select-input): allowInput is true and cannot be entered in multiple selection cases

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#2336 

### 💡 需求背景和解决方案

<img width="841" alt="image" src="https://github.com/Tencent/tdesign-vue/assets/44251941/3fc9a3ed-5e03-4e62-954c-a16ccec4c275">


### 📝 更新日志

* fix(select-input): 修复多选情况下设置allowInput为true无法输入的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
