### PR TITLE
style(tree-select & tag-input): use text-overflow ellipsis when tag text exceeds width

### DIFF
--- a/src/tree-select/tree-select.tsx
+++ b/src/tree-select/tree-select.tsx
@@ -161,7 +161,6 @@ export default defineComponent({
               size: this.size,
             },
             tagProps: {
-              maxWidth: 300,
               ...(this.tagProps as TdTreeSelectProps['tagProps']),
             },
             label: this.renderLabel,


### PR DESCRIPTION
tree-select & tag-input 组件 tag 文本超出宽度默认使用文本溢出省略号展示

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#3183 

### 💡 需求背景和解决方案

tree-select组件如下：
<img width="898" alt="image" src="https://github.com/Tencent/tdesign-vue/assets/44251941/8b581929-8c07-484c-8648-23e9fa7023b9">

tag-input 组件如下:
<img width="555" alt="image" src="https://github.com/Tencent/tdesign-vue/assets/44251941/9c0c8d95-3551-4181-921e-6f76e8160f41">


### 📝 更新日志


- style(tree-select & tag-input): use text-overflow ellipsis when tag text exceeds width

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
