### PR TITLE
fix(select): 修复 flattenOptions 方法分组扁平化问题及上下键切换功能

### DIFF
--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -451,9 +451,9 @@ export default defineComponent({
         nextTick(() => {
           const hoverDom = selectPanelRef.value?.$el.querySelector(
             `li.${classPrefix.value}-select-option.${classPrefix.value}-select-option__hover`,
-          );
+          ) as HTMLElement | null;
           if (hoverDom) {
-            const container = selectPanelRef.value.$el.parentNode;
+            const container = selectPanelRef.value.$el.parentNode as HTMLElement;
             const containerRect = container.getBoundingClientRect();
             const hoverDomRect = hoverDom.getBoundingClientRect();
             const offsetTop = hoverDomRect.top - containerRect.top + container.scrollTop;

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -428,6 +428,7 @@ export default defineComponent({
           count += 1;
           if (count >= displayOptionsLength) break;
         }
+        setHoverIntoView();
       };
       const arrowUpOption = () => {
         let count = 0;
@@ -443,6 +444,25 @@ export default defineComponent({
           count += 1;
           if (count >= displayOptionsLength) break;
         }
+        setHoverIntoView();
+      };
+      /** 让hover元素滚动到下拉面板视口 */
+      const setHoverIntoView = () => {
+        nextTick(() => {
+          const hoverDom = selectPanelRef.value?.$el.querySelector(
+            `li.${classPrefix.value}-select-option.${classPrefix.value}-select-option__hover`,
+          );
+          if (hoverDom) {
+            const container = selectPanelRef.value.$el.parentNode;
+            const containerRect = container.getBoundingClientRect();
+            const hoverDomRect = hoverDom.getBoundingClientRect();
+            const offsetTop = hoverDomRect.top - containerRect.top + container.scrollTop;
+            container.scrollTo({
+              top: offsetTop - (container.offsetHeight - hoverDom.offsetHeight * 2),
+              behavior: 'smooth',
+            });
+          }
+        });
       };
       if (displayOptionsLength === 0) return;
       const preventKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab'];

--- a/src/select/util.ts
+++ b/src/select/util.ts
@@ -42,7 +42,9 @@ export const getNewMultipleValue = (innerValue: SelectValue[], optionValue: Sele
 export const getAllSelectableOption = (options: TdOptionProps[]) => options.filter((option) => !option.disabled && !option.checkAll);
 
 /** 将 options 扁平化，拍扁所有 group */
-export const flattenOptions = (options: (TdOptionProps & { isCreated?: boolean })[]): SelectOption[] => options.reduce((acc, current) => {
-  acc.push((current as SelectOptionGroup).group ? flattenOptions((current as SelectOptionGroup).children) : current);
-  return acc;
-}, [] as SelectOption[]);
+export const flattenOptions = (options: (TdOptionProps & { isCreated?: boolean })[]): SelectOption[] => options.reduce(
+  (acc, current) => acc.concat(
+    (current as SelectOptionGroup).group ? flattenOptions((current as SelectOptionGroup).children) : [current],
+  ),
+    [] as SelectOption[],
+);


### PR DESCRIPTION
>> - 修复了 flattenOptions 函数未正确扁平化分组，导致在分组间切换时上下键无法正确切换的问题。
>> - 修复了上下键切换时，激活项未能滚动到下拉面板视口内的问题。


### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

 issue链接 ：https://github.com/Tencent/tdesign-vue/issues/3272


### 💡 需求背景和解决方案
需求背景： 展开下拉框后，用键盘的方向键向下选取，当选项数量多超出下拉面板有滚动条时，继续用方向键向下，下拉面板内容不会跟着滚动。
解决方案：在监听上下键事件的地方，加上滚动方法 setHoverIntoView，使键盘选取项滚动到下拉面板视口


### 📝 更新日志

- fix(Select): 修复分组状态下，通过上下键切换时下拉面板不会跟随滚动的问题
- fix(Select): 修复分组状态下，通过上下键切换时无法正确切换的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
