### PR TITLE
fix(TimePicker): fixed only support hh:mm format

### DIFF
--- a/src/time-picker/__tests__/index.test.jsx
+++ b/src/time-picker/__tests__/index.test.jsx
@@ -76,6 +76,14 @@ describe('TimePicker', () => {
       const panelNode = document.querySelector('.t-time-picker__panel');
       // format为HH:mm 只展示两列 即时分
       expect(panelNode.querySelectorAll('.t-time-picker__panel-body-scroll').length).toBe(2);
+
+      await wrapper.setProps({
+        popupProps: {
+          visible: true,
+        },
+        format: 'HH时mm分',
+      });
+      expect(panelNode.querySelectorAll('.t-time-picker__panel-body-scroll').length).toBe(2);
       panelNode.parentNode.removeChild(panelNode);
     });
 

--- a/src/time-picker/panel/single-panel.tsx
+++ b/src/time-picker/panel/single-panel.tsx
@@ -9,12 +9,7 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 
 import { panelColProps } from './props';
 import {
-  EPickerCols,
-  TWELVE_HOUR_FORMAT,
-  TIME_FORMAT,
-  AM,
-  PM,
-  MERIDIEM_LIST,
+  EPickerCols, TWELVE_HOUR_FORMAT, AM, PM, MERIDIEM_LIST,
 } from '../../_common/js/time-picker/const';
 import { closestLookup } from '../../_common/js/time-picker/utils';
 import { useConfig } from '../../hooks/useConfig';
@@ -27,6 +22,8 @@ const panelOffset = {
   top: 15,
   bottom: 21,
 };
+
+export const REGEX_FORMAT = /\[([^\]]+)]|Y{1,4}|M{1,4}|D{1,2}|d{1,4}|H{1,2}|h{1,2}|a|A|m{1,2}|s{1,2}|Z{1,2}|SSS/g;
 
 export default defineComponent({
   name: 'TTimePickerPanelCol',
@@ -82,22 +79,40 @@ export default defineComponent({
     );
 
     onMounted(() => {
-      const match = format.value.match(TIME_FORMAT);
-
-      const [, startCol, hourCol, minuteCol, secondCol, milliSecondCol, endCol] = match;
+      const match = format.value.match(REGEX_FORMAT);
       const {
         meridiem, hour, minute, second, milliSecond,
       } = EPickerCols;
 
-      const renderCol = [
-        startCol && meridiem,
-        hourCol && hour,
-        minuteCol && minute,
-        secondCol && second,
-        milliSecondCol && milliSecond,
-        endCol && meridiem,
-      ].filter((v) => !!v);
+      const renderCol: EPickerCols[] = [];
 
+      match.forEach((m) => {
+        switch (m) {
+          case 'H':
+          case 'HH':
+          case 'h':
+          case 'hh':
+            renderCol.push(hour);
+            break;
+          case 'a':
+          case 'A':
+            renderCol.push(meridiem);
+            break;
+          case 'm':
+          case 'mm':
+            renderCol.push(minute);
+            break;
+          case 's':
+          case 'ss':
+            renderCol.push(second);
+            break;
+          case 'SSS':
+            renderCol.push(milliSecond);
+            break;
+          default:
+            break;
+        }
+      });
       cols.value = renderCol;
     });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？
- [x] 日常 bug 修复

### 💡 需求背景和解决方案
目前time-picker  format仅支持 HH:mm:ss 这种格式化的使用，当 format 设置了 HH时mm分ss秒 这种格式时，选择器仅允许选择小时。

### 📝 更新日志

- fix(TimePicker):  修复format 仅支持 HH:mm:ss 格式的问题;


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
