### PR TITLE
feat(cascader): support scroll to first selected node

### DIFF
--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed } from '@vue/composition-api';
+import { defineComponent, computed, nextTick } from '@vue/composition-api';
 import omit from 'lodash/omit';
 import Panel from './components/Panel';
 import SelectInput, {
@@ -10,9 +10,7 @@ import FakeArrow from '../common-components/fake-arrow';
 import props from './props';
 
 import { useCascaderContext } from './hooks';
-import {
-  CascaderValue, TdSelectInputProps, TdCascaderProps,
-} from './interface';
+import { CascaderValue, TdSelectInputProps, TdCascaderProps } from './interface';
 import { useConfig, usePrefixClass, useCommonClassName } from '../hooks/useConfig';
 import { PopupVisibleChangeContext } from '../popup';
 import { closeIconClickEffect, handleRemoveTagEffect } from './core/effect';
@@ -69,6 +67,25 @@ export default defineComponent({
       };
     });
 
+    const updateScrollTop = (content: HTMLDivElement) => {
+      const cascaderMenuList = content.querySelectorAll(`.${COMPONENT_NAME.value}__menu`);
+      cascaderMenuList.forEach((menu: HTMLDivElement) => {
+        const firstSelectedNode: HTMLDivElement = menu?.querySelector(`.${classPrefix.value}-is-selected`);
+        if (!firstSelectedNode || !menu) return;
+
+        const { paddingBottom } = getComputedStyle(firstSelectedNode);
+        const { marginBottom } = getComputedStyle(menu);
+        const elementBottomHeight = parseInt(paddingBottom, 10) + parseInt(marginBottom, 10);
+
+        const updateValue = firstSelectedNode.offsetTop
+          - menu.offsetTop
+          - (menu.clientHeight - firstSelectedNode.clientHeight)
+          + elementBottomHeight;
+        // eslint-disable-next-line no-param-reassign
+        menu.scrollTop = updateValue;
+      });
+    };
+
     return {
       COMPONENT_NAME,
       overlayClassName,
@@ -83,6 +100,7 @@ export default defineComponent({
       cascaderContext,
       emit,
       valueDisplayParams,
+      updateScrollTop,
     };
   },
   render() {
@@ -148,6 +166,7 @@ export default defineComponent({
             loading: this.loading,
             status: this.status,
             tips: this.tips,
+            updateScrollTop: this.updateScrollTop,
             suffixIcon: () => renderSuffixIcon(),
             popupProps: {
               ...(this.popupProps as TdCascaderProps['popupProps']),

--- a/src/cascader/cascader.tsx
+++ b/src/cascader/cascader.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, computed, nextTick } from '@vue/composition-api';
+import { defineComponent, computed } from '@vue/composition-api';
 import omit from 'lodash/omit';
 import Panel from './components/Panel';
 import SelectInput, {

--- a/src/popup/popup.tsx
+++ b/src/popup/popup.tsx
@@ -211,7 +211,7 @@ export default mixins(classPrefixMixins).extend({
 
     // popup弹出第一次初始化暴露事件
     popupMounted() {
-      // 用于select定位事件
+      // 用于下拉组件定位事件
       const overlayEl = this.$refs?.overlay as HTMLElement;
       if (overlayEl) {
         this.updateScrollTop?.(overlayEl);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Cascader): 支持打开菜单时滚动到首个已选项所在节点

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
