### PR TITLE
fix(table): resolve colspan handling for multi-header

### DIFF
--- a/src/table/thead.tsx
+++ b/src/table/thead.tsx
@@ -77,17 +77,27 @@ export default defineComponent({
     // 单行表格合并
     const colspanSkipMap = computed(() => {
       const map: { [key: string]: boolean } = {};
-      const list = props.thList[0];
-      for (let i = 0, len = list.length; i < len; i++) {
-        const item = list[i];
-        if (item.colspan > 1) {
-          for (let j = i + 1; j < i + item.colspan; j++) {
-            if (list[j]) {
-              map[list[j].colKey] = true;
+
+      const processColumns = (columns: BaseTableColumns) => {
+        for (let i = 0, len = columns.length; i < len; i++) {
+          const item = columns[i];
+          if (item.colspan > 1) {
+            for (let j = i + 1; j < i + item.colspan; j++) {
+              if (columns[j]) {
+                map[columns[j].colKey] = true;
+              }
             }
           }
+          // 如果有子列，递归处理
+          if (item.children) {
+            processColumns(item.children);
+          }
         }
-      }
+      };
+
+      const list = props.thList[0];
+      processColumns(list);
+
       return map;
     });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. 多级表头下的表头通过colspan进行合并
2. 在thead.tsx下的colspanSkipMap函数下，增加children的处理逻辑

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Table): 多级表头下的通过colspan合并表头

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
