### PR TITLE
fix(Transfer): 修复设置pageSizeOptions时切换pageSize无法生效得问题

### DIFF
--- a/src/transfer/components/transfer-list.tsx
+++ b/src/transfer/components/transfer-list.tsx
@@ -89,9 +89,9 @@ export default mixins(keepAnimationMixins, classPrefixMixins).extend({
     return {
       filterValue: '', // 搜索框输入内容,
       // 用于兼容处理 Pagination 的非受控属性（非受控属性仅有 change 事件变化，无 props 变化，因此只需监听事件）
-      defaultCurrent: 1,
+      defaultCurrent: null,
       // 用于兼容处理 Pagination 的非受控属性
-      defaultPageSize: 0,
+      defaultPageSize: null,
       // 支持targetList 排序
       draggingIndex: null,
       dragoverIndex: null,
@@ -102,10 +102,10 @@ export default mixins(keepAnimationMixins, classPrefixMixins).extend({
     // this.defaultCurrent 属于分页组件抛出的事件参数，非受控的情况也会有该事件触发
     // this.pagination.defaultCurrent 为表格组件传入的非受控属性
     currentPage(): number {
-      return this.pagination?.current ?? this.defaultCurrent ?? this.pagination?.defaultCurrent;
+      return this.pagination?.current ?? this.defaultCurrent ?? this.pagination?.defaultCurrent ?? 1;
     },
     pageSize(): number {
-      return this.pagination?.pageSize ?? this.defaultPageSize ?? this.pagination?.defaultPageSize;
+      return this.pagination?.pageSize ?? this.defaultPageSize ?? this.pagination?.defaultPageSize ?? 10;
     },
     pageTotal(): number {
       return (this.filteredData && this.filteredData.length) || 0;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#3268 ](https://github.com/Tencent/tdesign-vue/issues/3268)

### 💡 需求背景和解决方案

transfer-list组件内会接收page得参数pageSizeOptions，但由于使用??语法得问题(只有null以及undefined时才会继续往右取值)，this.defaultPageSize又设置为0，所以computed的pageSize一直为0，所以把defaultPageSize初始值设置为null就正常了。defaultCurrent也是同理，会导致外部传进来的pagination.defaultCurrent一直无法生效，所以一并改正。


### 📝 更新日志

- fix(Transfer): 修复设置pageSizeOptions时切换pageSize无法生效得问题


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
