### PR TITLE
fix(tag-input): prevent backspace event in readonly mode and add test

### DIFF
--- a/src/tag-input/__tests__/vitest-tag-input.test.jsx
+++ b/src/tag-input/__tests__/vitest-tag-input.test.jsx
@@ -210,7 +210,7 @@ describe('TagInput Component', () => {
     expect(wrapper.attributes('placeholder')).toBe('This is TagInput placeholder');
   });
 
-  it('props.readonly works fine', () => {
+  it('props.readonly works fine', async () => {
     // readonly default value is false
     const wrapper1 = mount({
       render() {
@@ -225,6 +225,7 @@ describe('TagInput Component', () => {
       },
     }).find('.t-input');
     expect(wrapper2.classes('t-is-readonly')).toBeTruthy();
+
     // readonly = false
     const wrapper3 = mount({
       render() {
@@ -232,6 +233,18 @@ describe('TagInput Component', () => {
       },
     }).find('.t-input');
     expect(wrapper3.classes('t-is-readonly')).toBeFalsy();
+    // readonly = false and able backspace
+    const onRemoveFnOn = vi.fn();
+    const wrapper4 = getTagInputValueMount(TagInput, { readonly: false }, { remove: onRemoveFnOn });
+    wrapper4.find('input').trigger('keydown.backspace');
+    await wrapper4.vm.$nextTick();
+    expect(onRemoveFnOn).toHaveBeenCalled();
+    // readonly = true and prevent backspace
+    const onRemoveFnUn = vi.fn();
+    const wrapper5 = getTagInputValueMount(TagInput, { readonly: true }, { remove: onRemoveFnUn });
+    wrapper5.find('input').trigger('keydown.backspace');
+    await wrapper5.vm.$nextTick();
+    expect(onRemoveFnUn).not.toHaveBeenCalled();
   });
 
   it('props.readonly: readonly TagInput does not need clearIcon', async () => {

--- a/src/tag-input/useTagList.tsx
+++ b/src/tag-input/useTagList.tsx
@@ -70,7 +70,7 @@ export default function useTagList(props: TdTagInputProps, context: SetupContext
   // 按下回退键，删除标签
   const onInputBackspaceKeyDown = (value: InputValue, p: { e: KeyboardEvent }) => {
     const { e } = p;
-    if (!tagValue.value || !tagValue.value.length) return;
+    if (!tagValue.value || !tagValue.value.length || readonly.value) return;
     // 回车键删除，输入框值为空时，才允许 Backspace 删除标签
     const isDelete = /(Backspace|NumpadDelete)/.test(e.code) || /(Backspace|NumpadDelete)/.test(e.key);
     if (!value && isDelete) {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(tag-input):修复在`readonly`模式下仍可以通过Backspace按键删除已选项的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
