### PR TITLE
fix(input-number): limiting the input of numbers exceeding the range does not trigger the blur event

### DIFF
--- a/src/input-number/useInputNumber.tsx
+++ b/src/input-number/useInputNumber.tsx
@@ -187,6 +187,11 @@ export default function useInputNumber(props: TdInputNumberProps, context: Setup
    * 2. 处理未输入完成的数字；如：2e/2+/2.等
    * 3. 格式化数字/数字小数点
    */
+  const emitBlur = (value: InputNumberValue, ctx: { e: FocusEvent }) => {
+    props.onBlur?.(value, ctx);
+    context.emit('blur', value, ctx);
+  };
+
   const handleBlur = (value: string, ctx: { e: FocusEvent }) => {
     const {
       largeNumber, max, min, decimalPlaces,
@@ -200,10 +205,12 @@ export default function useInputNumber(props: TdInputNumberProps, context: Setup
       });
       if (r === 'below-minimum') {
         setTValue(min, { type: 'blur', e: ctx.e });
+        emitBlur(min, ctx);
         return;
       }
       if (r === 'exceed-maximum') {
         setTValue(max, { type: 'blur', e: ctx.e });
+        emitBlur(max, ctx);
         return;
       }
     }
@@ -215,8 +222,7 @@ export default function useInputNumber(props: TdInputNumberProps, context: Setup
     if (newValue !== tValue.value) {
       setTValue(newValue, { type: 'blur', e: ctx.e });
     }
-    props.onBlur?.(newValue, ctx);
-    context.emit('blur', newValue, ctx);
+    emitBlur(newValue, ctx);
   };
 
   const handleFocus = (value: string, ctx: { e: FocusEvent }) => {
@@ -231,7 +237,7 @@ export default function useInputNumber(props: TdInputNumberProps, context: Setup
       ArrowUp: handleAdd,
       ArrowDown: handleReduce,
     };
-    const code = e.code || e.key;
+    const code = (e.code || e.key) as keyof typeof keyEvent;
     if (keyEvent[code] !== undefined) {
       keyEvent[code](e);
     }


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

#3397 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(InputNumber): 限制输入超过范围外的数字未触发 `blur` 事件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
