### PR TITLE
fix(Select): 增加option cache，避免搜索过滤时optionsList为空导致选中选项显示异常

### DIFF
--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -28,6 +28,7 @@ export default function useSelectOptions(
 ) {
   // 内部 options 记录
   const options = ref<UniOption[]>([]);
+  const optionsCache = ref<UniOption[]>([]);
 
   // 指向当前 slots 数组，用来判断 slot 是否被更新
   let innerSlotRecord: VNode[] = null;
@@ -113,7 +114,7 @@ export default function useSelectOptions(
 
   const optionsMap = computed(() => {
     const res = new Map<SelectValue, TdOptionProps>();
-    optionsList.value.forEach((option: TdOptionProps) => {
+    optionsCache.value.concat(optionsList.value).forEach((option: TdOptionProps) => {
       res.set(option.value, option);
     });
     return res;
@@ -154,5 +155,6 @@ export default function useSelectOptions(
     options,
     optionsMap,
     optionsList,
+    optionsCache,
   };
 }

--- a/src/select/util.ts
+++ b/src/select/util.ts
@@ -4,20 +4,18 @@ import {
   SelectOption, SelectOptionGroup, SelectValue, TdOptionProps, TdSelectProps,
 } from './type';
 
-export const getSingleContent = (value: TdSelectProps['value'], options: SelectOption[]): string => {
-  for (const option of options) {
-    if ((option as TdOptionProps).value === value) {
-      // 保底使用 value 作为显示
-      return option?.label || String((option as TdOptionProps).value);
-    }
-  }
-  return value !== undefined && value !== null ? String(value) : undefined;
+export const getSingleContent = (
+  value: TdSelectProps['value'],
+  optionsMap: Map<SelectValue<SelectOption>, TdOptionProps>,
+): string => {
+  const option = optionsMap.get(value);
+  return option?.label || value?.toString();
 };
 
-export const getMultipleContent = (value: SelectValue[], options: SelectOption[]) => {
+export const getMultipleContent = (value: SelectValue[], optionsMap: Map<SelectValue<SelectOption>, TdOptionProps>) => {
   const res: string[] = [];
   for (const iterator of value) {
-    const resLabel = getSingleContent(iterator, options);
+    const resLabel = getSingleContent(iterator, optionsMap);
     if (resLabel) {
       res.push(resLabel);
     }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#3405](https://github.com/Tencent/tdesign-vue/issues/3405)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

增加option cache，避免搜索过滤时optionsList为空导致选中选项显示异常；修改基本参照vue-next端处理。

### 📝 更新日志

- fix(Select): 修复搜索过滤选项列表时选中值显示错误问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
