### PR TITLE
perf(select): `group` title  not exist still renders children

### DIFF
--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -50,7 +50,7 @@ export default function useSelectOptions(
         dynamicIndex += 1;
         return res;
       };
-      if ((option as SelectOptionGroup).group && (option as SelectOptionGroup).children) {
+      if ((option as SelectOptionGroup).children) {
         return {
           ...option,
           children: (option as SelectOptionGroup).children.map((child) => getFormatOption(child)),
@@ -124,7 +124,7 @@ export default function useSelectOptions(
     const res: TdOptionProps[] = [];
     const getOptionsList = (options: TdOptionProps[]) => {
       options.forEach((option) => {
-        if ((option as SelectOptionGroup).group) {
+        if ((option as SelectOptionGroup).children) {
           getOptionsList((option as SelectOptionGroup).children);
         } else {
           res.push(option);

--- a/src/select/option-group-props.ts
+++ b/src/select/option-group-props.ts
@@ -13,6 +13,5 @@ export default {
   /** 分组别名 */
   label: {
     type: String,
-    default: '',
   },
 };

--- a/src/select/optionGroup.tsx
+++ b/src/select/optionGroup.tsx
@@ -44,7 +44,7 @@ export default defineComponent({
     const children: ScopedSlotReturnValue = renderTNode('default');
     return (
       <li class={this.classes}>
-        <div class={`${this.componentName}-option-group__header`}>{this.label}</div>
+        {(this.label ?? false) && <div class={`${this.componentName}-option-group__header`}>{this.label}</div>}
         {children}
       </li>
     );

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -269,7 +269,7 @@ export default defineComponent({
                 } & OptionsType,
               index,
             ) => {
-              if (item.group) {
+              if (item.children) {
                 return (
                   <t-option-group label={item.group} divider={item.divider}>
                     {this.renderOptionsContent(item.children)}


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
当在分组的情况下，
如不想显示分组的标题只想显示分割线，则可以通过只传入 `divider: true,` 而不传 `group：“xx” 字段即可实现`。
![image](https://github.com/user-attachments/assets/77048cfa-5115-469d-a824-0ca62743fe81)



<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- perf(select): 可以使在 `group` 标题不存在的时候仍能正确渲染

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
