### PR TITLE
feat(form): add `status` and `tips` rendering in `form-item` component

### DIFF
--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -482,6 +482,8 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
 
   render(): VNode {
     const helpNode = renderTNodeJSX(this, 'help');
+    const tipsNode = renderTNodeJSX(this, 'tips');
+
     return (
       <div class={this.classes}>
         {this.getLabel()}
@@ -491,6 +493,9 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
             {this.getSuffixIcon()}
           </div>
           {helpNode && <div class={`${this.classPrefix}-input__help`}>{helpNode}</div>}
+          {tipsNode && (
+            <div class={[`${this.componentName}-tips`, `${this.classPrefix}-tips`, this.statusClass]}>{tipsNode}</div>
+          )}
           {this.extraNode}
         </div>
       </div>

--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -131,6 +131,7 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
           ? [this.commonStatusClassName.success, `${this.componentName}--success-border`].join(' ')
           : this.commonStatusClassName.success;
       }
+      if (this.status) return this.statusClass;
       const list = this.errorList;
       if (!list.length) return;
       const type = list[0].type || 'error';
@@ -183,6 +184,11 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
     },
     errorMessages(): FormErrorMessage {
       return this.form.errorMessage ?? this.global.errorMessage;
+    },
+    statusClass(): string {
+      return `${this.classPrefix}-is-${this.$props.status || 'default'} ${
+        this.$props.status === 'success' ? `${this.componentName}--success-border` : ''
+      }`;
     },
   },
 

--- a/src/form/form.en-US.md
+++ b/src/form/form.en-US.md
@@ -60,7 +60,7 @@ name | String | - | \- | N
 requiredMark | Boolean | undefined | \- | N
 rules | Array | - | Typescript：`Array<FormRule>` | N
 showErrorMessage | Boolean | undefined | \- | N
-status | String | - | Typescript：`'error' \| 'warning' \| 'success' \| 'validating'` | N
+status | String | - | Typescript：`'error' \| 'warning' \| 'success' | N
 statusIcon | Boolean / Slot / Function | undefined | Typescript：`boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 successBorder | Boolean | false | \- | N
 tips | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N

--- a/src/form/form.md
+++ b/src/form/form.md
@@ -62,7 +62,7 @@ name | String | - | 表单字段名称 | N
 requiredMark | Boolean | undefined | 是否显示必填符号（*），优先级高于 Form.requiredMark | N
 rules | Array | - | 表单字段校验规则。TS 类型：`Array<FormRule>` | N
 showErrorMessage | Boolean | undefined | 校验不通过时，是否显示错误提示信息，优先级高于 `Form.showErrorMessage` | N
-status | String | - | 校验状态，可在需要完全自主控制校验状态时使用。TS 类型：`'error' \| 'warning' \| 'success' \| 'validating'` | N
+status | String | - | 校验状态，可在需要完全自主控制校验状态时使用。TS 类型：`'error' \| 'warning' \| 'success' | N
 statusIcon | Boolean / Slot / Function | undefined | 校验状态图标，值为 `true` 显示默认图标，默认图标有 成功、失败、警告 等，不同的状态图标不同。`statusIcon` 值为 `false`，不显示图标。`statusIcon` 值类型为渲染函数，则可以自定义右侧状态图标。优先级高级 Form 的 statusIcon。TS 类型：`boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 successBorder | Boolean | false | 是否显示校验成功的边框，默认不显示 | N
 tips | String / Slot / Function | - | 自定义提示内容，样式跟随 `status` 变动，可在需要完全自主控制校验规则时使用。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N

--- a/src/form/type.ts
+++ b/src/form/type.ts
@@ -172,7 +172,7 @@ export interface TdFormItemProps {
    * 校验状态，可在需要完全自主控制校验状态时使用
    * @default ''
    */
-  status?: 'error' | 'warning' | 'success' | 'validating';
+  status?: 'error' | 'warning' | 'success';
   /**
    * 校验状态图标，值为 `true` 显示默认图标，默认图标有 成功、失败、警告 等，不同的状态图标不同。`statusIcon` 值为 `false`，不显示图标。`statusIcon` 值类型为渲染函数，则可以自定义右侧状态图标。优先级高级 Form 的 statusIcon
    */


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

SYNC: https://github.com/Tencent/tdesign-vue-next/pull/5008

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
1. 当前没有实现的 `status` 和 `tips` 功能
2.  移除 `status`  中的 `'validating'` 属性

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->
![image](https://github.com/user-attachments/assets/37486983-05be-4713-acf5-84ec1460f667)

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(form): `form-item` 新增 `status` 和 `tips` API

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
