### PR TITLE
fix(dialog): incorrect node attachment when `mode = "normal"`

### DIFF
--- a/src/config-provider/config-receiver.ts
+++ b/src/config-provider/config-receiver.ts
@@ -2,7 +2,7 @@ import Vue, { VueConstructor } from 'vue';
 import { mergeWith } from 'lodash-es';
 import { GlobalIconConfig } from 'tdesign-icons-vue';
 import { defaultGlobalConfig } from './context';
-import { GlobalConfigProvider, AnimationType } from './type';
+import { GlobalConfigProvider, AnimationType, AttachNodeComponent } from './type';
 
 import type { AttachNode } from '../common';
 
@@ -206,7 +206,7 @@ export function getClassPrefixMixins(componentName: string) {
 }
 
 // 用于非 composition api 的组件使用来自 config provider注入的 attach 使用
-export function getAttachConfigMixins(componentName: string) {
+export function getAttachConfigMixins(componentName: AttachNodeComponent) {
   return (Vue as VueConstructor<ConfigComponent>).extend({
     name: 'TAttachProvider',
     inject: {
@@ -215,16 +215,16 @@ export function getAttachConfigMixins(componentName: string) {
       },
     },
     methods: {
-      globalAttach(): AttachNode | null {
+      globalAttach(): AttachNode {
         const globalConfigAttach = this.globalConfig?.attach;
 
         if (typeof globalConfigAttach === 'string') {
           return globalConfigAttach;
         }
 
-        const validComponents = ['imageViewer', 'drawer', 'dialog', 'popup'];
+        const validComponents: AttachNodeComponent[] = ['imageViewer', 'drawer', 'dialog', 'popup'];
         if (globalConfigAttach && typeof globalConfigAttach === 'object' && validComponents.includes(componentName)) {
-          return globalConfigAttach[componentName as keyof typeof globalConfigAttach] as AttachNode;
+          return globalConfigAttach[componentName];
         }
 
         return 'body';

--- a/src/config-provider/config-receiver.ts
+++ b/src/config-provider/config-receiver.ts
@@ -218,7 +218,7 @@ export function getAttachConfigMixins(componentName: AttachNodeComponent) {
       globalAttach(): AttachNode {
         const globalConfigAttach = this.globalConfig?.attach;
 
-        if (typeof globalConfigAttach === 'string') {
+        if (typeof globalConfigAttach === 'string' || typeof globalConfigAttach === 'function') {
           return globalConfigAttach;
         }
 

--- a/src/config-provider/config-receiver.ts
+++ b/src/config-provider/config-receiver.ts
@@ -215,9 +215,19 @@ export function getAttachConfigMixins(componentName: string) {
       },
     },
     methods: {
-      globalAttach(): AttachNode {
-        // @ts-ignore
-        return this.globalConfig?.attach?.[componentName] || this.globalConfig?.attach || 'body';
+      globalAttach(): AttachNode | null {
+        const globalConfigAttach = this.globalConfig?.attach;
+
+        if (typeof globalConfigAttach === 'string') {
+          return globalConfigAttach;
+        }
+
+        const validComponents = ['imageViewer', 'drawer', 'dialog', 'popup'];
+        if (globalConfigAttach && typeof globalConfigAttach === 'object' && validComponents.includes(componentName)) {
+          return globalConfigAttach[componentName as keyof typeof globalConfigAttach] as AttachNode;
+        }
+
+        return 'body';
       },
     },
   });

--- a/src/config-provider/config-receiver.ts
+++ b/src/config-provider/config-receiver.ts
@@ -222,12 +222,7 @@ export function getAttachConfigMixins(componentName: AttachNodeComponent) {
           return globalConfigAttach;
         }
 
-        const validComponents: AttachNodeComponent[] = ['imageViewer', 'drawer', 'dialog', 'popup'];
-        if (globalConfigAttach && typeof globalConfigAttach === 'object' && validComponents.includes(componentName)) {
-          return globalConfigAttach[componentName];
-        }
-
-        return 'body';
+        return globalConfigAttach?.[componentName] || 'body';
       },
     },
   });

--- a/src/config-provider/type.ts
+++ b/src/config-provider/type.ts
@@ -12,6 +12,8 @@ import { MessageOptions } from '../message';
 import { ImageProps } from '../image';
 import { TNode, SizeEnum, AttachNode } from '../common';
 
+export type AttachNodeComponent = 'imageViewer' | 'drawer' | 'dialog' | 'popup';
+
 export interface GlobalConfigProvider {
   /**
    * 警告全局配置
@@ -26,9 +28,10 @@ export interface GlobalConfigProvider {
    */
   animation?: Partial<Record<'include' | 'exclude', Array<AnimationType>>>;
   /**
-   * null
+   * 组件挂载节点
+   * @default document.body
    */
-  attach?: AttachNode | { imageViewer?: AttachNode; popup?: AttachNode; dialog?: AttachNode; drawer?: AttachNode };
+  attach?: AttachNode | { [key in AttachNodeComponent]?: AttachNode };
   /**
    * 自动填充组件全局配置
    */

--- a/src/dialog/dialog.tsx
+++ b/src/dialog/dialog.tsx
@@ -153,7 +153,7 @@ export default mixins(
       return !this.isFullScreen ? { width: getCSSValue(this.width), ...this.dialogStyle } : { ...this.dialogStyle }; // width全屏模式不生效;
     },
     computedAttach(): AttachNode {
-      return this.showInAttachedElement ? undefined : this.attach || this.globalAttach();
+      return this.showInAttachedElement || this.isNormal ? undefined : this.attach || this.globalAttach();
     },
   },
 

--- a/test/snap/__snapshots__/csr.test.js.snap
+++ b/test/snap/__snapshots__/csr.test.js.snap
@@ -35868,7 +35868,80 @@ exports[`csr snapshot test > csr test ./src/config-provider/_example/dialog.vue 
     data-v-6be7f270=""
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-default t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                Title
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body"
+            >
+              Would you like to be my friends？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-outline t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    cancel
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    confirm
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br
     data-v-6be7f270=""
   />
@@ -35876,7 +35949,92 @@ exports[`csr snapshot test > csr test ./src/config-provider/_example/dialog.vue 
     data-v-6be7f270=""
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-info t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-info-circle-filled t-is-info"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 23a11 11 0 100-22 11 11 0 000 22zM11 8.5v-2h2v2h-2zm2 1.5v7.5h-2V10h2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                confirm
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              Would you like to be my friends？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-outline t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    cancel
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    confirm
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br
     data-v-6be7f270=""
   />
@@ -35884,7 +36042,92 @@ exports[`csr snapshot test > csr test ./src/config-provider/_example/dialog.vue 
     data-v-6be7f270=""
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-warning t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-error-circle-filled t-is-warning"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 1a11 11 0 110 22 11 11 0 010-22zm-1 13h2V6.5h-2V14zm2 1.5h-2v2h2v-2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                confirm
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              Would you like to be my friends？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-outline t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    cancel
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-warning t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    confirm
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br
     data-v-6be7f270=""
   />
@@ -35892,7 +36135,92 @@ exports[`csr snapshot test > csr test ./src/config-provider/_example/dialog.vue 
     data-v-6be7f270=""
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-danger t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-error-circle-filled t-is-error"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 1a11 11 0 110 22 11 11 0 010-22zm-1 13h2V6.5h-2V14zm2 1.5h-2v2h2v-2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                confirm
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              Would you like to be my friends？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-outline t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    cancel
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-danger t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    confirm
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br
     data-v-6be7f270=""
   />
@@ -35900,7 +36228,92 @@ exports[`csr snapshot test > csr test ./src/config-provider/_example/dialog.vue 
     data-v-6be7f270=""
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-success t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-check-circle-filled t-is-success"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 23a11 11 0 100-22 11 11 0 000 22zM7.5 10.59l3 3 6-6L17.91 9l-7.41 7.41L6.09 12l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+                confirm
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              Would you like to be my friends？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-outline t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    cancel
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-success t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    confirm
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
 </div>
 `;
 
@@ -44786,22 +45199,363 @@ exports[`csr snapshot test > csr test ./src/dialog/_example/icon.vue 1`] = `
   <transition-stub
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+      style="display: none;"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-info t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-info-circle-filled t-is-info"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 23a11 11 0 100-22 11 11 0 000 22zM11 8.5v-2h2v2h-2zm2 1.5v7.5h-2V10h2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                下单确认
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              信息已全部保存，是否确认下单？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    取消
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    确认
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br />
   <transition-stub
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-warning t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-error-circle-filled t-is-warning"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 1a11 11 0 110 22 11 11 0 010-22zm-1 13h2V6.5h-2V14zm2 1.5h-2v2h2v-2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                温馨提示
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              系统重启后会短暂影响页面访问，确认重启吗？
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    取消
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    确认
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br />
   <transition-stub
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-danger t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-error-circle-filled t-is-error"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 1a11 11 0 110 22 11 11 0 010-22zm-1 13h2V6.5h-2V14zm2 1.5h-2v2h2v-2z"
+                    fill="currentColor"
+                  />
+                </svg>
+                推送失败
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              请检查推送数据是否符合要求
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    取消
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    确认
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br />
   <transition-stub
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-success t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                <svg
+                  class="t-icon t-icon-check-circle-filled t-is-success"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M12 23a11 11 0 100-22 11 11 0 000 22zM7.5 10.59l3 3 6-6L17.91 9l-7.41 7.41L6.09 12l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+                操作成功
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body t-dialog__body__icon"
+            >
+              是否前往查看订单列表
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    取消
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    确认
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
   <br />
   <button
     class="t-button t-button--variant-base t-button--theme-primary"
@@ -44897,7 +45651,85 @@ exports[`csr snapshot test > csr test ./src/dialog/_example/modal.vue 1`] = `
   <transition-stub
     duration="300"
     name="t-dialog-zoom__vue"
-  />
+  >
+    <div
+      class="t-dialog__ctx"
+      style="display: none;"
+    >
+      <div
+        class=""
+      >
+        <div
+          class=""
+        >
+          <div
+            class="t-dialog t-dialog__modal-default t-dialog--default"
+          >
+            <div
+              class="t-dialog__header"
+            >
+              <div
+                class="t-dialog__header-content"
+              >
+                普通对话框-不可拖拽
+              </div>
+              <span
+                class="t-dialog__close"
+              >
+                <svg
+                  class="t-icon t-icon-close"
+                  fill="none"
+                  height="1em"
+                  viewBox="0 0 24 24"
+                  width="1em"
+                >
+                  <path
+                    d="M7.05 5.64L12 10.59l4.95-4.95 1.41 1.41L13.41 12l4.95 4.95-1.41 1.41L12 13.41l-4.95 4.95-1.41-1.41L10.59 12 5.64 7.05l1.41-1.41z"
+                    fill="currentColor"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="t-dialog__body"
+            >
+              <div>
+                <div>
+                  对话框内容
+                </div>
+              </div>
+            </div>
+            <div
+              class="t-dialog__footer"
+            >
+              <div>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-default t-dialog__cancel"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    取消
+                  </span>
+                </button>
+                <button
+                  class="t-button t-button--variant-base t-button--theme-primary t-dialog__confirm"
+                  type="button"
+                >
+                  <span
+                    class="t-button__text"
+                  >
+                    确认
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </transition-stub>
 </div>
 `;
 


### PR DESCRIPTION
chore(config-provider): improve globalAttach method to handle string and object types

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
当前：当 `<t-dialog header="Title" body="Would you like to be my friends？" mode="normal" theme="default" visible />` 时，会将 dialog 会挂载在`body` 下。
预期：应该默认跟随之前的文档结构不变。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(dialog): 修复当 mode 为 "normal" 时不正确的节点附件

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
