### PR TITLE
fix: fix messagePlugin instance error

### DIFF
--- a/src/message/messageList.tsx
+++ b/src/message/messageList.tsx
@@ -40,13 +40,14 @@ export const MessageList = mixins(classPrefixMixins).extend({
   },
   methods: {
     add(msg: MessageOptions): number {
+      const key = getUniqueId();
       const mg = {
         ...msg,
-        key: getUniqueId(),
+        key,
         placement: this.placement,
       };
       this.list.push(mg);
-      return this.list.length - 1;
+      return key;
     },
     remove(index: number) {
       this.list.splice(index, 1);
@@ -73,6 +74,11 @@ export const MessageList = mixins(classPrefixMixins).extend({
         'close-btn-click': () => this.remove(index),
         'duration-end': () => this.remove(index),
       };
+    },
+    getMessageInstance(key: string) {
+      const index = this.list.findIndex((msgOption) => msgOption.key === key);
+      if (index === -1) return null;
+      return this.$children[index];
     },
   },
   render(): VNode {

--- a/src/message/plugin.tsx
+++ b/src/message/plugin.tsx
@@ -71,6 +71,8 @@ const MessageFunction = (props: MessageOptions): Promise<MessageInstance> => {
   }
   const p = instanceMap.get(attachDom)[placement];
 
+  let messageKey: number | null = null;
+
   // attachDom被清空(如attachDom.innerHtml='')，p也会存在，需要判断下dom包含关系
   if (!p || !attachDom.contains(p.$el)) {
     const instance = new MessageList({
@@ -79,18 +81,18 @@ const MessageFunction = (props: MessageOptions): Promise<MessageInstance> => {
         placement: options.placement,
       },
     }).$mount();
-    instance.add(options);
+    messageKey = instance.add(options);
     instanceMap.get(attachDom)[placement] = instance;
     attachDom.appendChild(instance.$el);
   } else {
-    p.add(options);
+    messageKey = p.add(options);
   }
   // 返回最新消息的 Element
   return new Promise((resolve) => {
     const ins = instanceMap.get(attachDom)[placement];
     ins.$nextTick(() => {
       const msg: Array<MessageInstance> = ins.$children;
-      resolve(msg[msg.length - 1]);
+      resolve(messageKey ? ins.getMessageInstance(messageKey) : msg[msg.length - 1]);
     });
   });
 };


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

#3488 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

在多次调用messagePlugin方法的场景下，它返回的promise中的实例总是指向最后一次调用的实例。

修复方式：
1. 在message被添加的时候，生成一个随机的key
2. 在plugin resolve的时候，根据生成的key获取对应的实例

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 修复连续调用messagePlugin时，返回的实例不正确的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
