### PR TITLE
fix(upload): integrate form disabled state into upload component

### DIFF
--- a/src/upload/hooks/useUpload.ts
+++ b/src/upload/hooks/useUpload.ts
@@ -2,6 +2,7 @@ import {
   ref, computed, toRefs, SetupContext,
 } from '@vue/composition-api';
 import { merge } from 'lodash-es';
+import useFormDisabled from '../../hooks/useFormDisabled';
 import {
   SizeLimitObj,
   TdUploadProps,
@@ -57,10 +58,11 @@ export default function useUpload(props: TdUploadProps, context: SetupContext) {
   const xhrReq = ref<{ files: UploadFile[]; xhrReq: XMLHttpRequest }[]>([]);
   const toUploadFiles = ref<UploadFile[]>([]);
   const sizeOverLimitMessage = ref('');
+  const { formDisabled } = useFormDisabled();
 
   const localeConfig = computed(() => merge({}, global.value, props.locale));
-  // TODO: Form 表单控制上传组件是否禁用
-  const innerDisabled = computed(() => props.disabled);
+
+  const innerDisabled = computed(() => formDisabled.value || props.disabled);
 
   const tipsClasses = `${classPrefix.value}-upload__tips ${classPrefix.value}-size-s`;
   const errorClasses = [tipsClasses].concat(`${classPrefix.value}-upload__tips-error`);

--- a/src/upload/upload.tsx
+++ b/src/upload/upload.tsx
@@ -1,6 +1,5 @@
 import { computed, defineComponent, SetupContext } from '@vue/composition-api';
 import { UploadIcon as TdUploadIcon } from 'tdesign-icons-vue';
-import useFormDisabled from '../hooks/useFormDisabled';
 import props from './props';
 import NormalFile from './themes/normal-file';
 import DraggerFile from './themes/dragger-file';
@@ -22,7 +21,6 @@ export default defineComponent({
 
   setup(props: UploadProps, context: SetupContext) {
     const uploadData = useUpload(props, context);
-    const { formDisabled } = useFormDisabled();
 
     const {
       localeConfig,
@@ -41,7 +39,8 @@ export default defineComponent({
       onPasteFileChange,
     } = uploadData;
 
-    const tDisabled = computed<boolean>(() => formDisabled.value || innerDisabled.value);
+    const tDisabled = computed<boolean>(() => innerDisabled.value);
+
     const icons = useGlobalIcon({
       UploadIcon: TdUploadIcon,
     });


### PR DESCRIPTION
close #3524 close #3523
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(upload): 为上传组件增加表单禁用状态支持

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
