### PR TITLE
fix(select): fix select keys props has content not work 

### DIFF
--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -7,7 +7,7 @@ import {
   ref, Ref, computed, onBeforeUpdate, ComponentInternalInstance, watch,
 } from '@vue/composition-api';
 import { VNode } from 'vue';
-import { get } from 'lodash-es';
+import { get, omit } from 'lodash-es';
 import { getVNodeComponentName, getVueComponentName } from '../../utils/helper';
 import Option from '../option';
 import OptionGroup from '../optionGroup';
@@ -40,8 +40,9 @@ export default function useSelectOptions(
     const innerOptions: UniOption[] = props.options?.map((option) => {
       const getFormatOption = (option: TdOptionProps) => {
         const { value, label, disabled } = keys.value;
+        const restOption = omit(option, [value, label, disabled]) as Partial<TdOptionProps>;
         const res = {
-          ...option,
+          ...restOption,
           index: dynamicIndex,
           label: get(option, label),
           value: get(option, value),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next/issues/5088

### 💡 需求背景和解决方案

1. 需要解决的问题
在Select 组件中使用 keys 属性时，如果使用了content 作为自定义字段名，会和内置 content 属性冲突，导致失效

2. 解决办法
在解析 options 配置并且初始化innerOptions 的时候，去除掉自定义 keys 相关属性的透传

### 📝 更新日志

- fix(Select): keys 属性配置 content 作为 value 时不生效问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
