### PR TITLE
feat(Form): support right required mark

### DIFF
--- a/src/form/_usage/props.json
+++ b/src/form/_usage/props.json
@@ -12,6 +12,21 @@
     "options": []
   },
   {
+    "name": "requiredMarkPosition",
+    "type": "enum",
+    "defaultValue": "left",
+    "options": [
+      {
+        "label": "left",
+        "value": "left"
+      },
+      {
+        "label": "right",
+        "value": "right"
+      }
+    ]
+  },
+  {
     "name": "labelAlign",
     "type": "enum",
     "defaultValue": "right",

--- a/src/form/form-item.tsx
+++ b/src/form/form-item.tsx
@@ -118,6 +118,8 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
         `${this.componentName}__label`,
         {
           [`${this.componentName}__label--required`]: this.needRequiredMark,
+          [`${this.componentName}__label--required-right`]:
+            this.needRequiredMark && this.requiredMarkPosition === 'right',
           [`${this.componentName}__label--top`]: this.getLabelContent() && (labelAlign === 'top' || !labelWidth),
           [`${this.componentName}__label--left`]: labelAlign === 'left' && labelWidth,
           [`${this.componentName}__label--right`]: labelAlign === 'right' && labelWidth,
@@ -173,6 +175,9 @@ export default mixins(getConfigReceiverMixins<FormItemConstructor, FormConfig>('
       const requiredMark = this.$props.requiredMark ?? this.form.requiredMark ?? this.global.requiredMark;
       const isRequired = this.innerRules.filter((rule) => rule.required).length > 0;
       return requiredMark || (requiredMark ?? isRequired);
+    },
+    requiredMarkPosition(): string {
+      return this.form.requiredMarkPosition ?? 'left';
     },
     innerRules(): FormRule[] {
       const parent = this.form;

--- a/src/form/form.en-US.md
+++ b/src/form/form.en-US.md
@@ -1,7 +1,6 @@
 :: BASE_DOC ::
 
 ## API
-
 ### Form Props
 
 name | type | default | description | required
@@ -11,12 +10,13 @@ data | Object | {} | Typescript：`FormData` | N
 disabled | Boolean | undefined | \- | N
 errorMessage | Object | - | Typescript：`FormErrorMessage` | N
 formControlledComponents | Array | - | Typescript：`Array<string>` | N
-id | String | undefined | native id attribute of the form，which supports being used in conjunction with non-form buttons through the form attribute to trigger form events | N
+id | String | undefined |  native id attribute of the form，which supports being used in conjunction with non-form buttons through the form attribute to trigger form events | N
 labelAlign | String | right | options: left/right/top | N
 labelWidth | String / Number | '100px' | \- | N
 layout | String | vertical | options: vertical/inline | N
 preventSubmitDefault | Boolean | true | \- | N
 requiredMark | Boolean | true | \- | N
+requiredMarkPosition | String | left | Display position of required symbols。options: left/right | N
 resetType | String | empty | options: empty/initial | N
 rules | Object | - | Typescript：`FormRules<FormData>` `type FormRules<T extends Data = any> = { [field in keyof T]?: Array<FormRule> }`。[see more ts definition](https://github.com/Tencent/tdesign-vue/tree/develop/src/form/type.ts) | N
 scrollToFirstError | String | - | options: ''/smooth/auto | N

--- a/src/form/form.md
+++ b/src/form/form.md
@@ -3,7 +3,6 @@
 <!-- 可在这里自行添加 demo 展示 -->
 
 ## API
-
 ### Form Props
 
 名称 | 类型 | 默认值 | 描述 | 必传
@@ -19,6 +18,7 @@ labelWidth | String / Number | '100px' | 可以整体设置label标签宽度，�
 layout | String | vertical | 表单布局，有两种方式：纵向布局 和 行内布局。可选项：vertical/inline | N
 preventSubmitDefault | Boolean | true | 是否阻止表单提交默认事件（表单提交默认事件会刷新页面），设置为 `true` 可以避免刷新 | N
 requiredMark | Boolean | true | 是否显示必填符号（*），默认显示 | N
+requiredMarkPosition | String | left | 表单必填符号（*）显示位置。可选项：left/right | N
 resetType | String | empty | 重置表单的方式，值为 empty 表示重置表单为空，值为 initial 表示重置表单数据为初始值。可选项：empty/initial | N
 rules | Object | - | 表单字段校验规则。TS 类型：`FormRules<FormData>` `type FormRules<T extends Data = any> = { [field in keyof T]?: Array<FormRule> }`。[详细类型定义](https://github.com/Tencent/tdesign-vue/tree/develop/src/form/type.ts) | N
 scrollToFirstError | String | - | 表单校验不通过时，是否自动滚动到第一个校验不通过的字段，平滑滚动或是瞬间直达。值为空则表示不滚动。可选项：''/smooth/auto | N

--- a/src/form/props.ts
+++ b/src/form/props.ts
@@ -66,6 +66,15 @@ export default {
     type: Boolean,
     default: undefined,
   },
+  /** 表单必填符号（*）显示位置 */
+  requiredMarkPosition: {
+    type: String as PropType<TdFormProps['requiredMarkPosition']>,
+    default: 'left' as TdFormProps['requiredMarkPosition'],
+    validator(val: TdFormProps['requiredMarkPosition']): boolean {
+      if (!val) return true;
+      return ['left', 'right'].includes(val);
+    },
+  },
   /** 重置表单的方式，值为 empty 表示重置表单为空，值为 initial 表示重置表单数据为初始值 */
   resetType: {
     type: String as PropType<TdFormProps['resetType']>,

--- a/src/form/type.ts
+++ b/src/form/type.ts
@@ -60,6 +60,11 @@ export interface TdFormProps<FormData extends Data = Data> {
    */
   requiredMark?: boolean;
   /**
+   * 表单必填符号（*）显示位置
+   * @default left
+   */
+  requiredMarkPosition?: 'left' | 'right';
+  /**
    * 重置表单的方式，值为 empty 表示重置表单为空，值为 initial 表示重置表单数据为初始值
    * @default empty
    */


### PR DESCRIPTION
VueNext栈的同步修改
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
- https://github.com/Tencent/tdesign-vue-next/pull/5223
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Form): 新增`requiredMarkPosition`，用于支持定义必填符号的位置

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充
- [ ] Changelog 已提供或无须提供
