### PR TITLE
fix(Select): 修复valueType:object与keys同时设置时的绑定值错误

### DIFF
--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -161,8 +161,8 @@ export default defineComponent({
         const option = optionsMap.value.get(val) || oldValueMap.get(val);
         if (option) delete (option as any).index;
         return {
-          [valueOfKeys]: get(option, valueOfKeys),
-          [labelOfKeys]: get(option, labelOfKeys),
+          [valueOfKeys]: get(option, 'value'),
+          [labelOfKeys]: get(option, 'label'),
         };
       };
       const addCache = (val: SelectValue) => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

[#3576](https://github.com/Tencent/tdesign-vue/issues/3576)

### 💡 需求背景和解决方案

修复valueType:object与keys同时设置时的绑定值错误

### 📝 更新日志

- fix(Select): 修复valueType:object与keys同时设置时的绑定值错误

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
