### PR TITLE
fix(tag): allow title rendering without max-width restriction

### DIFF
--- a/src/tag/__tests__/vitest-tag.test.jsx
+++ b/src/tag/__tests__/vitest-tag.test.jsx
@@ -216,6 +216,16 @@ describe('Tag Component', () => {
     });
   });
 
+  it('props.title without max-width', () => {
+    const title = 'This is a title';
+    const wrapper = mount({
+      render() {
+        return <Tag title={title} content={'This is a content'}></Tag>;
+      },
+    });
+    const span = wrapper.find('.t-tag > span');
+    expect(span.attributes('title')).toBe(title);
+  });
   it('props.title is equal to This is a long tag', () => {
     const wrapper = mount({
       render() {

--- a/src/tag/tag.tsx
+++ b/src/tag/tag.tsx
@@ -100,10 +100,6 @@ export default mixins(getConfigReceiverMixins<Vue, TagConfig>('tag'), getGlobalI
       return style;
     },
     renderTitle(tagContent: string) {
-      if (!this.maxWidth) {
-        return undefined;
-      }
-
       const vProps = (this.$vnode.componentOptions.propsData as TdTagProps) || {};
       if (Reflect.has(vProps, 'title')) {
         return vProps.title || undefined;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

from https://github.com/Tencent/tdesign-vue-next/issues/5411

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Tag): 未设置 `max-width` 导致无法渲染 `title` 属性的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
