### PR TITLE
fix(alert): close属性同步为closeBtn，close即将废弃

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,11 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
-  "cSpell.words": ["tdesign", "popconfirm", "swiper", "cascader"]
+  "cSpell.words": [
+    "cascader",
+    "popconfirm",
+    "swiper",
+    "tdesign",
+    "vnode"
+  ]
 }

--- a/src/alert/__tests__/index.test.jsx
+++ b/src/alert/__tests__/index.test.jsx
@@ -23,10 +23,10 @@ describe('Alert', () => {
       expect(wrapper.find('.t-alert__description').text()).toBe('text');
     });
 
-    it(':close', () => {
+    it(':closeBtn', () => {
       const wrapper = mount({
         render() {
-          return <Alert close>text</Alert>;
+          return <Alert closeBtn>text</Alert>;
         },
       });
       const close = wrapper.find('.t-alert__close');
@@ -178,7 +178,7 @@ describe('Alert', () => {
       const wrapper = mount({
         render() {
           return (
-            <Alert close onClose={fn}>
+            <Alert closeBtn onClose={fn}>
               text
             </Alert>
           );

--- a/src/alert/alert.en-US.md
+++ b/src/alert/alert.en-US.md
@@ -1,17 +1,19 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Alert Props
 
 name | type | default | description | required
 -- | -- | -- | -- | --
-close | String / Boolean / Slot / Function | false | Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+close | String / Boolean / Slot / Function | false | Deprecated, use closeBtn instead.Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+closeBtn | String / Boolean / Slot / Function | false | Close button. Value "true" show the close button. Value "False" hide close button. Value type string display as is. Use TNode to custom the close trigger.Typescript：`string \| boolean \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 default | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 icon | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 maxLine | Number | 0 | \- | N
 message | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 operation | Slot / Function | - | Typescript：`TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
-theme | String | info | options：success/info/warning/error | N
+theme | String | info | options: success/info/warning/error | N
 title | String / Slot / Function | - | Typescript：`string \| TNode`。[see more ts definition](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 onClose | Function |  | Typescript：`(context: { e: MouseEvent }) => void`<br/> | N
 onClosed | Function |  | Typescript：`(context: { e: TransitionEvent }) => void`<br/> | N

--- a/src/alert/alert.md
+++ b/src/alert/alert.md
@@ -1,11 +1,13 @@
 :: BASE_DOC ::
 
 ## API
+
 ### Alert Props
 
-名称 | 类型 | 默认值 | 说明 | 必传
+名称 | 类型 | 默认值 | 描述 | 必传
 -- | -- | -- | -- | --
-close | String / Boolean / Slot / Function | false | 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+close | String / Boolean / Slot / Function | false | 即将废弃，请使用 closeBtn 属性。关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
+closeBtn | String / Boolean / Slot / Function | false | 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮。TS 类型：`string \| boolean \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 default | String / Slot / Function | - | 内容，同 message。TS 类型：`string \| TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 icon | Slot / Function | - | 图标。TS 类型：`TNode`。[通用类型定义](https://github.com/Tencent/tdesign-vue/blob/develop/src/common.ts) | N
 maxLine | Number | 0 | 内容显示最大行数，超出的内容会折叠收起，用户点击后再展开。值为 0 表示不折叠 | N

--- a/src/alert/props.ts
+++ b/src/alert/props.ts
@@ -2,16 +2,20 @@
 
 /**
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
- * updated at 2021-11-19 10:44:26
  * */
 
 import { TdAlertProps } from './type';
 import { PropType } from 'vue';
 
 export default {
-  /** 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮 */
+  /** 即将废弃，请使用 closeBtn 属性。关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮 */
   close: {
     type: [String, Boolean, Function] as PropType<TdAlertProps['close']>,
+    default: false,
+  },
+  /** 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮 */
+  closeBtn: {
+    type: [String, Boolean, Function] as PropType<TdAlertProps['closeBtn']>,
     default: false,
   },
   /** 内容，同 message */
@@ -40,6 +44,7 @@ export default {
     type: String as PropType<TdAlertProps['theme']>,
     default: 'info' as TdAlertProps['theme'],
     validator(val: TdAlertProps['theme']): boolean {
+      if (!val) return true;
       return ['success', 'info', 'warning', 'error'].includes(val);
     },
   },

--- a/src/alert/type.ts
+++ b/src/alert/type.ts
@@ -2,17 +2,21 @@
 
 /**
  * 该文件为脚本自动生成文件，请勿随意修改。如需修改请联系 PMC
- * updated at 2021-11-19 10:44:26
  * */
 
 import { TNode } from '../common';
 
 export interface TdAlertProps {
   /**
-   * 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮
+   * 即将废弃，请使用 closeBtn 属性。关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮
    * @default false
    */
   close?: string | boolean | TNode;
+  /**
+   * 关闭按钮。值为 true 则显示默认关闭按钮；值为 false 则不显示按钮；值类型为 string 则直接显示；值类型为 Function 则可以自定关闭按钮
+   * @default false
+   */
+  closeBtn?: string | boolean | TNode;
   /**
    * 内容，同 message
    */
@@ -51,4 +55,4 @@ export interface TdAlertProps {
    * 告警提示框关闭动画结束后触发
    */
   onClosed?: (context: { e: TransitionEvent }) => void;
-};
+}


### PR DESCRIPTION
closes #3630

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue/issues/3630

### 💡 需求背景和解决方案

增加closeBtn，先保留close，逐渐过渡。

### 📝 更新日志

- fix(alert): close属性同步为closeBtn，close即将废弃

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
