### PR TITLE
fix(Select): return complete option when keys is set

### DIFF
--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -7,7 +7,7 @@ import {
   ref, Ref, computed, onBeforeUpdate, ComponentInternalInstance, watch,
 } from '@vue/composition-api';
 import { VNode } from 'vue';
-import { get, omit } from 'lodash-es';
+import { get } from 'lodash-es';
 import { getVNodeComponentName, getVueComponentName } from '../../utils/helper';
 import Option from '../option';
 import OptionGroup from '../optionGroup';

--- a/src/select/hooks/useSelectOptions.ts
+++ b/src/select/hooks/useSelectOptions.ts
@@ -40,9 +40,8 @@ export default function useSelectOptions(
     const innerOptions: UniOption[] = props.options?.map((option) => {
       const getFormatOption = (option: TdOptionProps) => {
         const { value, label, disabled } = keys.value;
-        const restOption = omit(option, [value, label, disabled]) as Partial<TdOptionProps>;
         const res = {
-          ...restOption,
+          ...option,
           index: dynamicIndex,
           label: get(option, label),
           value: get(option, value),

--- a/src/select/select-panel.tsx
+++ b/src/select/select-panel.tsx
@@ -1,7 +1,7 @@
 import {
   computed, defineComponent, toRefs, inject, onMounted, onBeforeUnmount,
 } from '@vue/composition-api';
-import { isFunction } from 'lodash-es';
+import { isFunction, omit } from 'lodash-es';
 import { VNode } from 'vue';
 import { useTNodeJSX } from '../hooks/tnode';
 import { renderTNodeJSXDefault } from '../utils/render-tnode';
@@ -35,6 +35,7 @@ type SelectPanelProps = Pick<
   | 'creatable'
   | 'filterable'
   | 'filter'
+  | 'keys'
 >;
 
 const sizeClassMap = {
@@ -65,6 +66,7 @@ export default defineComponent({
     'scroll',
     'creatable',
     'filterable',
+    'keys',
   ],
 
   setup(props: SelectPanelProps) {
@@ -277,6 +279,12 @@ export default defineComponent({
                 );
               }
 
+              const defaultOmit = ['index', '$index', 'className', 'tagName'];
+
+              const { value, label, disabled } = this.keys || {};
+              const shouldOmitContent = [value, label, disabled].includes('content');
+              const option = omit(item, defaultOmit.concat(shouldOmitContent ? 'content' : []));
+
               const scrollProps = this.isVirtual
                 ? {
                   rowIndex: item.$index,
@@ -294,7 +302,7 @@ export default defineComponent({
                   // 透传 style
                   style={item.style}
                   // 透传其余参数
-                  {...{ props: { ...item, ...scrollProps } }}
+                  {...{ props: { ...option, ...scrollProps } }}
                   // t-option 自身逻辑所需属性
                   multiple={this.multiple}
                   scopedSlots={{ default: item.slots }}

--- a/src/select/select.tsx
+++ b/src/select/select.tsx
@@ -734,6 +734,7 @@ export default defineComponent({
                   loadingText={this.loadingText}
                   panelTopContent={this.panelTopContent}
                   panelBottomContent={this.panelBottomContent}
+                  keys={this.keys}
                 />
               ),
             },


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue/issues/3707
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
- https://github.com/Tencent/tdesign-vue/pull/3540 优化使用content做keys的问题引入的缺陷，同步 Vue3 的处理方式

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Select): 修复设置 `keys` 后， onChange 回调参数中 selectedOptions 参数缺失的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
