### PR TITLE
feat(select-input): optimize display of `ValueDisplay` in searchable mode

### DIFF
--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -29,12 +29,21 @@ const DEFAULT_KEYS = {
   value: 'value',
 };
 
+// 内部参数
+export interface SelectInputValueDisplayOptions {
+  useInputDisplay: boolean;
+  usePlaceholder: boolean;
+}
+
 function getInputValue(value: TdSelectInputProps['value'], keys: TdSelectInputProps['keys']) {
   const iKeys = keys || DEFAULT_KEYS;
   return isObject(value) ? lodashGet(value, iKeys.label) : value;
 }
 
-export default function useSingle(props: TdSelectInputProps, context: SetupContext) {
+export default function useSingle(
+  props: TdSelectInputProps & { valueDisplayOptions?: SelectInputValueDisplayOptions },
+  context: SetupContext,
+) {
   const instance = getCurrentInstance();
   const { value, keys, inputValue: propsInputValue } = toRefs(props);
   const classPrefix = usePrefixClass();
@@ -92,20 +101,56 @@ export default function useSingle(props: TdSelectInputProps, context: SetupConte
     instance.emit('mouseenter', context);
   };
 
+  const renderPrefixContent = (singleValueDisplay: any, popupVisible: boolean) => {
+    // 需要隐藏 valueDisplay 的两个情况
+    // 1 用户传入 usePlaceholder 希望使用自带占位符实现，则应在未选择值时隐藏valueDisplay，只展示占位符
+    // 2 用户传入 useInputDisplay 希望使用自带输入回显实现，激活选择器浮层时只展示input值（待讨论是否修改为激活后真的输入字符再隐藏 valueDisplay，此处实现效果与不使用 valueDisplay 只使用filterable时不同）
+
+    const label = renderTNode('label');
+
+    if (!label && !singleValueDisplay) {
+      return [];
+    }
+
+    if (singleValueDisplay) {
+      if (
+        !value.value
+        || (props.valueDisplayOptions?.useInputDisplay && popupVisible)
+        || (popupVisible && props.allowInput)
+      ) {
+        return label ? [label] : [];
+      }
+    }
+    return [label, singleValueDisplay].filter(Boolean);
+  };
+
+  const renderPlaceholder = (singleValueDisplay: any, popupVisible: boolean) => {
+    // 使用 valueDisplay 插槽时，如用户传入 usePlaceholder 使用自带占位符实现，未传则认为用户自行实现。
+    // 如果当前存在 value（对应直接使用组件和 select 组件调用时），不显示占位符。
+
+    if (singleValueDisplay) {
+      if (!value.value || (props.allowInput && popupVisible)) return props.placeholder;
+      if (!props.valueDisplayOptions?.usePlaceholder || (props.valueDisplayOptions?.usePlaceholder && value.value)) {
+        return '';
+      }
+    }
+    return props.placeholder;
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const renderSelectSingle = (h: Vue.CreateElement, popupVisible: boolean) => {
     const singleValueDisplay = renderTNode('valueDisplay');
     const pureValue = getInputValue(value.value, keys.value);
     const displayedValue = popupVisible && props.allowInput ? inputValue.value : pureValue;
-    const prefixContent = [renderTNode('label'), singleValueDisplay];
+    const prefixContent = renderPrefixContent(singleValueDisplay, popupVisible);
     const inputProps = {
       ...commonInputProps.value,
       value: singleValueDisplay && props.value ? undefined : displayedValue,
-      label: () => prefixContent,
+      label: prefixContent.length ? () => prefixContent : undefined,
       autoWidth: props.autoWidth,
       autofocus: props.autofocus,
       readonly: !props.allowInput || props.readonly,
-      placeholder: singleValueDisplay ? '' : props.placeholder,
+      placeholder: renderPlaceholder(singleValueDisplay, popupVisible),
       suffixIcon: !props.disabled && props.loading ? () => <Loading loading size="small" /> : props.suffixIcon,
       showClearIconOnEmpty: Boolean(!props.disabled && props.clearable && (inputValue.value || displayedValue)),
       inputClass: {

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -40,6 +40,11 @@ function getInputValue(value: TdSelectInputProps['value'], keys: TdSelectInputPr
   return isObject(value) ? lodashGet(value, iKeys.label) : value;
 }
 
+// 严格判断是否为空，避免数字0被判断为空
+function isEmptyValue(val: any): boolean {
+  return val === undefined || val === null;
+}
+
 export default function useSingle(
   props: TdSelectInputProps & { valueDisplayOptions?: SelectInputValueDisplayOptions },
   context: SetupContext,
@@ -114,7 +119,7 @@ export default function useSingle(
 
     if (singleValueDisplay) {
       if (
-        !value.value
+        isEmptyValue(value.value)
         || (props.valueDisplayOptions?.useInputDisplay && popupVisible)
         || (popupVisible && props.allowInput)
       ) {
@@ -129,8 +134,11 @@ export default function useSingle(
     // 如果当前存在 value（对应直接使用组件和 select 组件调用时），不显示占位符。
 
     if (singleValueDisplay) {
-      if (!value.value || (props.allowInput && popupVisible)) return props.placeholder;
-      if (!props.valueDisplayOptions?.usePlaceholder || (props.valueDisplayOptions?.usePlaceholder && value.value)) {
+      if (isEmptyValue(value.value) || (props.allowInput && popupVisible)) return props.placeholder;
+      if (
+        !props.valueDisplayOptions?.usePlaceholder
+        || (props.valueDisplayOptions?.usePlaceholder && !isEmptyValue(value.value))
+      ) {
         return '';
       }
     }

--- a/src/select-input/useSingle.tsx
+++ b/src/select-input/useSingle.tsx
@@ -145,15 +145,32 @@ export default function useSingle(
     return props.placeholder;
   };
 
+  const renderInputDisplay = (singleValueDisplay: any, displayedValue: any, popupVisible: boolean) => {
+    // 使用 valueDisplay 插槽时，如用户传入 useInputDisplay 使用自带输入回显实现，未传则认为用户自行实现。
+    if (singleValueDisplay) {
+      if (popupVisible && props.allowInput) {
+        return displayedValue;
+      }
+      if (
+        !props.valueDisplayOptions?.useInputDisplay
+        || (props.valueDisplayOptions?.useInputDisplay && !popupVisible)
+      ) {
+        return undefined;
+      }
+    }
+
+    return displayedValue;
+  };
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const renderSelectSingle = (h: Vue.CreateElement, popupVisible: boolean) => {
     const singleValueDisplay = renderTNode('valueDisplay');
-    const pureValue = getInputValue(value.value, keys.value);
-    const displayedValue = popupVisible && props.allowInput ? inputValue.value : pureValue;
+    const displayedValue = popupVisible && props.allowInput ? inputValue.value : getInputValue(value.value, keys.value);
     const prefixContent = renderPrefixContent(singleValueDisplay, popupVisible);
+
     const inputProps = {
       ...commonInputProps.value,
-      value: singleValueDisplay && props.value ? undefined : displayedValue,
+      value: renderInputDisplay(singleValueDisplay, displayedValue, popupVisible),
       label: prefixContent.length ? () => prefixContent : undefined,
       autoWidth: props.autoWidth,
       autofocus: props.autofocus,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Tencent/tdesign-vue-next/pull/3342
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

新增 SelectInputValueDisplayOptions 接口与 useInputDisplay、usePlaceholder 配置，优化单选 valueDisplay 与占位符渲染逻辑。


before 

https://github.com/user-attachments/assets/ee16a6e9-d9ed-4672-86b9-eff90ea36949


after

https://github.com/user-attachments/assets/f211f0fe-cb3b-461b-9d17-946cb1f3029f

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat(Select): 优化 `valueDisplay` 时单选搜索时会隐藏已展示的值，输入框为空值，`placeholder` 为选中的值 ⚠️
- feat(SelectInput): 优化 `valueDisplay` 时单选搜索时会隐藏已展示的值，输入框为空值，`placeholder` 为选中的值 ⚠️
- fix(Cascader): 修复 `filterable` 时使用 `valueDisplay` 单选搜索不能正确显示输入文本
- fix(TreeSelect): 修复 `filterable` 时使用 `valueDisplay` 单选搜索不能正确显示输入文本

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
