### PR TITLE
fix(space): fix missing px unit in align demo padding

### DIFF
--- a/src/space/_example-composition/align.vue
+++ b/src/space/_example-composition/align.vue
@@ -25,7 +25,7 @@
 
 <style scoped>
 .space-border {
-  padding: 12;
+  padding: 12px;
   border: 1px dashed var(--td-component-stroke);
 }
 .space-block {

--- a/src/space/_example/align.vue
+++ b/src/space/_example/align.vue
@@ -25,7 +25,7 @@
 
 <style scoped>
 .space-border {
-  padding: 12;
+  padding: 12px;
   border: 1px dashed var(--td-component-stroke);
 }
 .space-block {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

Space 组件的 `_example/align.vue` 示例代码中，`.space-border` 的 `padding` 值缺少 `px` 单位（`padding: 12` → `padding: 12px`），导致样式未正确生效。

同步修复了 `_example/align.vue` 和 `_example-composition/align.vue` 两个示例文件。

### 📝 更新日志

- fix(space): 修复 align 示例代码中 padding 缺少 px 单位的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
