### PR TITLE
fix(TagInput): `suffix` is not fixed on the right side in `break-line` mode

### DIFF
--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -1,5 +1,5 @@
 import {
-  defineComponent, computed, toRefs, ref, nextTick, watch,
+  defineComponent, computed, toRefs, ref, nextTick, watch, Ref,
 } from '@vue/composition-api';
 
 import { CloseCircleFilledIcon as TdCloseCircleFilledIcon } from 'tdesign-icons-vue';
@@ -36,8 +36,10 @@ export default defineComponent({
     );
 
     const {
-      excessTagsDisplayType, readonly, disabled, clearable, placeholder,
+      excessTagsDisplayType, readonly, disabled, clearable, placeholder, suffix,
     } = toRefs(props);
+    const suffixWidthRef = ref<number>(0);
+    const suffixIconWidthRef = ref<number>(0);
     const { isHover, addHover, cancelHover } = useHover(
       {
         readonly,
@@ -139,6 +141,53 @@ export default defineComponent({
       },
     );
 
+    const updateSuffixWidth = (selector: string, cssVar: string, widthRef: Ref<number>) => {
+      const wrapperEl = tagInputRef.value?.$el as HTMLElement;
+      if (!wrapperEl) return;
+
+      const inputEl = wrapperEl.querySelector(`.${classPrefix.value}-input`) as HTMLElement;
+      if (!inputEl) return;
+
+      const targetEl = wrapperEl.querySelector(selector);
+      const width = targetEl ? targetEl.getBoundingClientRect().width : 0;
+      if (width !== widthRef.value) {
+        // eslint-disable-next-line no-param-reassign
+        widthRef.value = width;
+        if (width) {
+          inputEl.style.setProperty(cssVar, `${Math.ceil(width + 8)}px`);
+        } else {
+          inputEl.style.removeProperty(cssVar);
+        }
+      }
+    };
+
+    const handleSuffixWidthUpdate = () => {
+      nextTick(() => {
+        if (excessTagsDisplayType.value !== 'break-line') return;
+
+        if (suffix.value) {
+          updateSuffixWidth(
+            `.${classPrefix.value}-input__suffix:not(.${classPrefix.value}-input__suffix-icon)`,
+            `--${classPrefix.value}-tag-input-suffix-width`,
+            suffixWidthRef,
+          );
+        }
+
+        updateSuffixWidth(
+          `.${classPrefix.value}-input__suffix-icon`,
+          `--${classPrefix.value}-tag-input-suffix-icon-width`,
+          suffixIconWidthRef,
+        );
+      });
+    };
+
+    watch(
+      () => [excessTagsDisplayType.value, suffix.value, classPrefix.value],
+      () => {
+        handleSuffixWidthUpdate();
+      },
+    );
+
     return {
       tagValue,
       tInputValue,
@@ -166,6 +215,7 @@ export default defineComponent({
       onInputCompositionstart,
       onInputCompositionend,
       CloseCircleFilledIcon,
+      handleSuffixWidthUpdate,
     };
   },
 
@@ -191,6 +241,12 @@ export default defineComponent({
     // 左侧文本
     const label = renderTNodeJSX(this, 'label', { silent: true });
     const readonly = this.readonly || this.inputProps?.readonly;
+
+    // 更新 suffix 宽度
+    this.$nextTick(() => {
+      this.handleSuffixWidthUpdate();
+    });
+
     return (
       <TInput
         ref="tagInputRef"

--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -38,6 +38,7 @@ export default defineComponent({
     const {
       excessTagsDisplayType, readonly, disabled, clearable, placeholder, suffix,
     } = toRefs(props);
+
     const suffixWidthRef = ref<number>(0);
     const suffixIconWidthRef = ref<number>(0);
     const { isHover, addHover, cancelHover } = useHover(
@@ -73,12 +74,14 @@ export default defineComponent({
 
     const { CloseCircleFilledIcon } = useGlobalIcon({ CloseCircleFilledIcon: TdCloseCircleFilledIcon });
 
+    const isBreakLine = computed(() => excessTagsDisplayType.value === 'break-line');
+
     const classes = computed(() => {
       const isEmpty = !(Array.isArray(tagValue.value) && tagValue.value.length);
       return [
         COMPONENT_NAME.value,
         {
-          [`${COMPONENT_NAME.value}--break-line`]: excessTagsDisplayType.value === 'break-line',
+          [`${COMPONENT_NAME.value}--break-line`]: isBreakLine.value,
           [`${classPrefix.value}-is-empty`]: isEmpty,
           [`${classPrefix.value}-tag-input--with-tag`]: !isEmpty,
           [`${classPrefix.value}-tag-input--drag-sort`]: props.dragSort && !disabled.value && !readonly.value,
@@ -163,7 +166,7 @@ export default defineComponent({
 
     const handleSuffixWidthUpdate = () => {
       nextTick(() => {
-        if (excessTagsDisplayType.value !== 'break-line') return;
+        if (!isBreakLine.value) return;
 
         if (suffix.value) {
           updateSuffixWidth(
@@ -182,7 +185,7 @@ export default defineComponent({
     };
 
     watch(
-      () => [excessTagsDisplayType.value, suffix.value, classPrefix.value],
+      () => [isBreakLine.value, suffix.value, classPrefix.value],
       () => {
         handleSuffixWidthUpdate();
       },
@@ -192,6 +195,7 @@ export default defineComponent({
       tagValue,
       tInputValue,
       isHover,
+      isBreakLine,
       tagInputPlaceholder,
       showClearIcon,
       tagInputRef,

--- a/src/tag-input/tag-input.tsx
+++ b/src/tag-input/tag-input.tsx
@@ -185,7 +185,7 @@ export default defineComponent({
     };
 
     watch(
-      () => [isBreakLine.value, suffix.value, classPrefix.value],
+      () => [isBreakLine.value, suffix.value, classPrefix.value, showClearIcon.value],
       () => {
         handleSuffixWidthUpdate();
       },
@@ -245,11 +245,6 @@ export default defineComponent({
     // 左侧文本
     const label = renderTNodeJSX(this, 'label', { silent: true });
     const readonly = this.readonly || this.inputProps?.readonly;
-
-    // 更新 suffix 宽度
-    this.$nextTick(() => {
-      this.handleSuffixWidthUpdate();
-    });
 
     return (
       <TInput


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

- https://github.com/Tencent/tdesign-vue-next/pull/6585

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(TagInput): 修复 `excessTagsDisplayType="break-line"` 时，`suffix` 没有固定在右侧的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
