### PR TITLE
fix(menu): keep submenu popup open when hovered

### DIFF
--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -150,15 +150,30 @@ export default defineComponent({
       }, 0);
     };
 
-    const targetInPopup = (el: HTMLElement) => el?.classList.contains(`${classPrefix.value}-menu__popup`);
+    const targetInPopup = (el: EventTarget | null) => {
+      if (!(el instanceof Element)) return false;
+      return Boolean(
+        popupWrapperRef.value?.contains(el)
+          || el.closest(`.${classPrefix.value}-menu__popup`)
+          || el.closest(`.${classPrefix.value}-popup.${classPrefix.value}-is-head-menu`),
+      );
+    };
+
+    const getPopupElement = () => popupWrapperRef.value?.closest?.(`.${classPrefix.value}-popup`) as HTMLElement;
+
+    /*
+     * Popup 渲染在 submenu DOM 外部，mouseleave 可能在光标仍位于 Popup 内时触发 (Monica 插件)。
+     * 若 relatedTarget 或当前 hover 状态仍在 Popup 内，则保持展开。
+     */
+    const shouldKeepPopupOpen = (relatedTarget: EventTarget | null) => targetInPopup(relatedTarget)
+      || popupWrapperRef.value?.matches?.(':hover')
+      || getPopupElement()?.matches?.(':hover');
 
     const handleMouseLeave = (e: MouseEvent) => {
       clearTimers();
 
       hideTimer.value = setTimeout(() => {
-        const inPopup = targetInPopup(e.relatedTarget as HTMLElement);
-
-        if (isCursorInPopup.value || inPopup) {
+        if (isCursorInPopup.value || shouldKeepPopupOpen(e.relatedTarget)) {
           hideTimer.value = null;
           return;
         }
@@ -178,7 +193,11 @@ export default defineComponent({
         target = target.parentNode;
       }
 
-      isCursorInPopup.value = false;
+      isCursorInPopup.value = shouldKeepPopupOpen(toElement || relatedTarget);
+
+      if (isCursorInPopup.value) {
+        return;
+      }
 
       if (!isSubmenu(target)) {
         clearTimers();

--- a/src/menu/submenu.tsx
+++ b/src/menu/submenu.tsx
@@ -152,17 +152,19 @@ export default defineComponent({
 
     const targetInPopup = (el: EventTarget | null) => {
       if (!(el instanceof Element)) return false;
+      const popupElement = getPopupElement();
+
       return Boolean(
         popupWrapperRef.value?.contains(el)
-          || el.closest(`.${classPrefix.value}-menu__popup`)
-          || el.closest(`.${classPrefix.value}-popup.${classPrefix.value}-is-head-menu`),
+          || el.closest(`.${classPrefix.value}-menu__popup`) === popupWrapperRef.value
+          || popupElement?.contains(el),
       );
     };
 
     const getPopupElement = () => popupWrapperRef.value?.closest?.(`.${classPrefix.value}-popup`) as HTMLElement;
 
     /*
-     * Popup 渲染在 submenu DOM 外部，mouseleave 可能在光标仍位于 Popup 内时触发 (Monica 插件)。
+     * Popup 渲染在 submenu DOM 外部，mouseleave 可能在光标仍位于 Popup 内时触发 (比如 Monica 插件)。
      * 若 relatedTarget 或当前 hover 状态仍在 Popup 内，则保持展开。
      */
     const shouldKeepPopupOpen = (relatedTarget: EventTarget | null) => targetInPopup(relatedTarget)


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(menu): 修复存在浏览器插件意外触发 `mouseleave` 事件，导致 submenu 不能正确选中的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
